### PR TITLE
Revert "CarpetX: remove blosc compression from OpenPMD string options"

### DIFF
--- a/CarpetX/src/io_openpmd.cxx
+++ b/CarpetX/src/io_openpmd.cxx
@@ -126,9 +126,6 @@ const std::string options = R"EOS(
     "adios2": {
       "dataset": {
         "operators": [
-)EOS"
-#ifdef ADIOS2_HAVE_BLOSC2
-R"EOS(
           {
             "type": "blosc",
             "parameters": {
@@ -136,9 +133,6 @@ R"EOS(
               "doshuffle": "BLOSC_SHUFFLE"
             }
           }
-)EOS"
-#endif
-R"EOS(
         ]
       }
     }


### PR DESCRIPTION
This reverts commit a5ef84c.