### PR TITLE
CarpetX: avoid features not supported by nvhpc's compiler

### DIFF
--- a/CarpetX/src/reduction.hxx
+++ b/CarpetX/src/reduction.hxx
@@ -121,7 +121,9 @@ template <typename T, int D> struct combine {
 };
 
 typedef reduction<CCTK_REAL, dim> reduction_CCTK_REAL;
+#ifndef __NVCOMPILER
 #pragma omp declare reduction(reduction:reduction_CCTK_REAL : omp_out += omp_in)
+#endif
 
 MPI_Datatype reduction_mpi_datatype_CCTK_REAL();
 MPI_Op reduction_mpi_op();

--- a/TestArrayGroup/src/TestDynamicData.F90
+++ b/TestArrayGroup/src/TestDynamicData.F90
@@ -6,24 +6,21 @@ subroutine TestArrayGroup_DynamicDataF(CCTK_ARGUMENTS)
   DECLARE_CCTK_PARAMETERS
   DECLARE_CCTK_ARGUMENTS
 
+  integer, dimension(3) :: dim3
+
+  ! RANK() is not supported by all compilers, so we fail to complile here instead
   ! Validate grid array dynamic data
-  if(RANK(test1) /= 3) then ! note rank 3 b/c of vector of rank=2 arrays
-      call CCTK_ERROR("incorrect dimension in test1 array dynamic data")
-  endif
+  dim3 = SHAPE(test1)
   if(SIZE(test1, 1) /= 5 .or. SIZE(test1, 2) /= 6 .or. SIZE(test1, 3) /= 4) then
       call CCTK_ERROR("incorrect size in test1 array dynamic data")
   endif
 
-  if(RANK(test2) /= 3) then ! note rank 3 b/c of vector of rank=2 arrays
-      call CCTK_ERROR("incorrect dimension in test2 array dynamic data")
-  endif
+  dim3 = SHAPE(test2)
   if(SIZE(test2, 1) /= 5 .or. SIZE(test2, 2) /= 6 .or. SIZE(test2, 3) /= 4) then
       call CCTK_ERROR("incorrect size in test2 array dynamic data")
   endif
 
-  if(RANK(test3) /= 3) then ! note rank 3 b/c of vector of rank=2 arrays
-      call CCTK_ERROR("incorrect dimension in test3 array dynamic data")
-  endif
+  dim3 = SHAPE(test3)
   if(SIZE(test3, 1) /= 5 .or. SIZE(test3, 2) /= 6 .or. SIZE(test3, 3) /= 4) then
       call CCTK_ERROR("incorrect size in test3 array dynamic data")
   endif


### PR DESCRIPTION
This avoids two features not supported by nvhpc version nvc++ 24.3 ("nvc++ 24.3-0 linuxarm64 target on aarch64 Linux -tp neoverse-v2"):

* does not support custom OpenMP reductions
* RANK() is not a F90 function but a GNU extension

The former is the more annoying fix since I added an `#ifdef`. If one consider the possible loss in speed due to using a `#pragma omp critical` instead of (possibly) are more optimal implementation via `#pragma reduction(...)` negligible then one can remove the `#ifdef`.