### PR TITLE
New thorn: NoiseX

### DIFF
--- a/ADMBaseX/configuration.ccl
+++ b/ADMBaseX/configuration.ccl
@@ -1,3 +1,3 @@
 # Configuration definition for thorn ADMBaseX
 
-REQUIRES Loop
+REQUIRES Loop NoiseX

--- a/ADMBaseX/interface.ccl
+++ b/ADMBaseX/interface.ccl
@@ -3,6 +3,7 @@
 IMPLEMENTS: ADMBaseX
 
 USES INCLUDE HEADER: loop_device.hxx
+USES INCLUDE HEADER: noisex.hxx
 
 
 

--- a/ADMBaseX/param.ccl
+++ b/ADMBaseX/param.ccl
@@ -47,7 +47,6 @@ CCTK_REAL linear_wave_wavelength "Linear wave wavelength"
   0.0:* :: ""
 } 1.0
 
-CCTK_REAL noise_amplitude "Noise amplitude"
+BOOLEAN add_noise "Add noise to initial data"
 {
-  0.0:* :: ""
-} 0.0
+} no

--- a/ADMBaseX/schedule.ccl
+++ b/ADMBaseX/schedule.ccl
@@ -106,9 +106,8 @@ if (CCTK_EQUALS(initial_dtshift, "zero")) {
 
 
 
-if (noise_amplitude != 0) {
+if (add_noise) {
   # TODO: Also add noise during evolution?
-  # TODO: Noise should be added by a separate thorn.
 
   SCHEDULE ADMBaseX_add_noise IN ADMBaseX_PostInitial
   {

--- a/ADMBaseX/src/noise.cxx
+++ b/ADMBaseX/src/noise.cxx
@@ -4,85 +4,40 @@
 #include <cctk_Arguments.h>
 #include <cctk_Parameters.h>
 
-#include <random>
+#include <noisex.hxx>
 
 namespace ADMBaseX {
 using namespace Loop;
-using namespace std;
 
 extern "C" void ADMBaseX_add_noise(CCTK_ARGUMENTS) {
-  DECLARE_CCTK_ARGUMENTS_ADMBaseX_add_noise;
-  DECLARE_CCTK_PARAMETERS;
+  DECLARE_CCTK_ARGUMENTSX_ADMBaseX_add_noise;
 
-  // Hardware random device
-  random_device device;
-  // Create and seed software random number engine from hardware random number
-  default_random_engine engine(device());
-  // Random number distribution
-  uniform_real_distribution<CCTK_REAL> distribution(-noise_amplitude,
-                                                    noise_amplitude);
-  const auto add_noise = [&](CCTK_REAL &restrict var) {
-    var += distribution(engine);
-  };
+  NoiseX::add(cctkGH, gxx);
+  NoiseX::add(cctkGH, gxx);
+  NoiseX::add(cctkGH, gxy);
+  NoiseX::add(cctkGH, gxz);
+  NoiseX::add(cctkGH, gyy);
+  NoiseX::add(cctkGH, gyz);
+  NoiseX::add(cctkGH, gzz);
 
-  const GF3D<CCTK_REAL, 0, 0, 0> gxx_(cctkGH, gxx);
-  const GF3D<CCTK_REAL, 0, 0, 0> gxy_(cctkGH, gxy);
-  const GF3D<CCTK_REAL, 0, 0, 0> gxz_(cctkGH, gxz);
-  const GF3D<CCTK_REAL, 0, 0, 0> gyy_(cctkGH, gyy);
-  const GF3D<CCTK_REAL, 0, 0, 0> gyz_(cctkGH, gyz);
-  const GF3D<CCTK_REAL, 0, 0, 0> gzz_(cctkGH, gzz);
+  NoiseX::add(cctkGH, kxx);
+  NoiseX::add(cctkGH, kxy);
+  NoiseX::add(cctkGH, kxz);
+  NoiseX::add(cctkGH, kyy);
+  NoiseX::add(cctkGH, kyz);
+  NoiseX::add(cctkGH, kzz);
 
-  const GF3D<CCTK_REAL, 0, 0, 0> kxx_(cctkGH, kxx);
-  const GF3D<CCTK_REAL, 0, 0, 0> kxy_(cctkGH, kxy);
-  const GF3D<CCTK_REAL, 0, 0, 0> kxz_(cctkGH, kxz);
-  const GF3D<CCTK_REAL, 0, 0, 0> kyy_(cctkGH, kyy);
-  const GF3D<CCTK_REAL, 0, 0, 0> kyz_(cctkGH, kyz);
-  const GF3D<CCTK_REAL, 0, 0, 0> kzz_(cctkGH, kzz);
+  NoiseX::add(cctkGH, alp);
 
-  const GF3D<CCTK_REAL, 0, 0, 0> alp_(cctkGH, alp);
+  NoiseX::add(cctkGH, dtalp);
 
-  const GF3D<CCTK_REAL, 0, 0, 0> dtalp_(cctkGH, dtalp);
+  NoiseX::add(cctkGH, betax);
+  NoiseX::add(cctkGH, betay);
+  NoiseX::add(cctkGH, betaz);
 
-  const GF3D<CCTK_REAL, 0, 0, 0> betax_(cctkGH, betax);
-  const GF3D<CCTK_REAL, 0, 0, 0> betay_(cctkGH, betay);
-  const GF3D<CCTK_REAL, 0, 0, 0> betaz_(cctkGH, betaz);
-
-  const GF3D<CCTK_REAL, 0, 0, 0> dtbetax_(cctkGH, dtbetax);
-  const GF3D<CCTK_REAL, 0, 0, 0> dtbetay_(cctkGH, dtbetay);
-  const GF3D<CCTK_REAL, 0, 0, 0> dtbetaz_(cctkGH, dtbetaz);
-
-  loop_int<0, 0, 0>(cctkGH, [&](const PointDesc &p) { add_noise(gxx_(p.I)); });
-  loop_int<0, 0, 0>(cctkGH, [&](const PointDesc &p) { add_noise(gxy_(p.I)); });
-  loop_int<0, 0, 0>(cctkGH, [&](const PointDesc &p) { add_noise(gxz_(p.I)); });
-  loop_int<0, 0, 0>(cctkGH, [&](const PointDesc &p) { add_noise(gyy_(p.I)); });
-  loop_int<0, 0, 0>(cctkGH, [&](const PointDesc &p) { add_noise(gyz_(p.I)); });
-  loop_int<0, 0, 0>(cctkGH, [&](const PointDesc &p) { add_noise(gzz_(p.I)); });
-
-  loop_int<0, 0, 0>(cctkGH, [&](const PointDesc &p) { add_noise(kxx_(p.I)); });
-  loop_int<0, 0, 0>(cctkGH, [&](const PointDesc &p) { add_noise(kxy_(p.I)); });
-  loop_int<0, 0, 0>(cctkGH, [&](const PointDesc &p) { add_noise(kxz_(p.I)); });
-  loop_int<0, 0, 0>(cctkGH, [&](const PointDesc &p) { add_noise(kyy_(p.I)); });
-  loop_int<0, 0, 0>(cctkGH, [&](const PointDesc &p) { add_noise(kyz_(p.I)); });
-  loop_int<0, 0, 0>(cctkGH, [&](const PointDesc &p) { add_noise(kzz_(p.I)); });
-
-  loop_int<0, 0, 0>(cctkGH, [&](const PointDesc &p) { add_noise(alp_(p.I)); });
-
-  loop_int<0, 0, 0>(cctkGH,
-                    [&](const PointDesc &p) { add_noise(dtalp_(p.I)); });
-
-  loop_int<0, 0, 0>(cctkGH,
-                    [&](const PointDesc &p) { add_noise(betax_(p.I)); });
-  loop_int<0, 0, 0>(cctkGH,
-                    [&](const PointDesc &p) { add_noise(betay_(p.I)); });
-  loop_int<0, 0, 0>(cctkGH,
-                    [&](const PointDesc &p) { add_noise(betaz_(p.I)); });
-
-  loop_int<0, 0, 0>(cctkGH,
-                    [&](const PointDesc &p) { add_noise(dtbetax_(p.I)); });
-  loop_int<0, 0, 0>(cctkGH,
-                    [&](const PointDesc &p) { add_noise(dtbetay_(p.I)); });
-  loop_int<0, 0, 0>(cctkGH,
-                    [&](const PointDesc &p) { add_noise(dtbetaz_(p.I)); });
+  NoiseX::add(cctkGH, dtbetax);
+  NoiseX::add(cctkGH, dtbetay);
+  NoiseX::add(cctkGH, dtbetaz);
 }
 
 } // namespace ADMBaseX

--- a/NoiseX/README
+++ b/NoiseX/README
@@ -1,0 +1,11 @@
+Cactus Code Thorn Noise
+Author(s)    : Lucas Timotheo Sanches <lsanches@lsu.edu>
+Maintainer(s): Lucas Timotheo Sanches <lsanches@lsu.edu>
+Licence      : GPL
+--------------------------------------------------------------------------
+
+1. Purpose
+
+This thorn provides a unified way to add pseudo-random noise to CarpetX
+variables. This is useful mainly for testing time evolution codes, i.e.,
+performing robust stability tests.

--- a/NoiseX/configuration.ccl
+++ b/NoiseX/configuration.ccl
@@ -1,0 +1,7 @@
+# Configuration definition for thorn NoiseX
+
+REQUIRES Loop
+
+PROVIDES NoiseX
+{
+}

--- a/NoiseX/interface.ccl
+++ b/NoiseX/interface.ccl
@@ -2,6 +2,6 @@
 
 IMPLEMENTS: NoiseX
 
-USES INCLUDE HEADER: loop_device.hxx
+USES INCLUDE HEADER: loop.hxx
 
 INCLUDE HEADER: noisex.hxx in noisex.hxx

--- a/NoiseX/interface.ccl
+++ b/NoiseX/interface.ccl
@@ -1,0 +1,7 @@
+# Interface definition for thorn NoiseX
+
+IMPLEMENTS: NoiseX
+
+USES INCLUDE HEADER: loop_device.hxx
+
+INCLUDE HEADER: noisex.hxx in noisex.hxx

--- a/NoiseX/param.ccl
+++ b/NoiseX/param.ccl
@@ -2,15 +2,15 @@
 
 KEYWORD seed_type "The type of seed to use"
 {
-  "hardware random device" :: "Uses the hardware random device to generate a seed"
+  "random" :: "Uses the hardware random device to generate a seed"
   "fixed" :: "A fixed integer value is used as sseed"
-} "hardware random device"
+} "random"
 
 KEYWORD random_engine "The random engine to use"
 {
-    "default" :: "Uses C++'s default random engine"
-    "mersenne twister" :: "32-bit Mersenne Twister by Matsumoto and Nishimura, 1998"
-    "sine wave" :: "Uses the values of a high frequency sine wave to create pseudo-randomness"
+  "default" :: "Uses C++'s default random engine"
+  "mersenne twister" :: "32-bit Mersenne Twister by Matsumoto and Nishimura, 1998"
+  "sine wave" :: "Uses the values of a high frequency sine wave to create pseudo-randomness"
 } "default"
 
 INT fixed_seed_value "The value of the fixed seed to use"

--- a/NoiseX/param.ccl
+++ b/NoiseX/param.ccl
@@ -1,0 +1,29 @@
+# Parameter definitions for thorn NoiseX
+
+KEYWORD seed_type "The type of seed to use"
+{
+  "hardware random device" :: "Uses the hardware random device to generate a seed"
+  "fixed" :: "A fixed integer value is used as sseed"
+} "hardware random device"
+
+KEYWORD random_engine "The random engine to use"
+{
+    "default" :: "Uses C++'s default random engine"
+    "mersenne twister" :: "32-bit Mersenne Twister by Matsumoto and Nishimura, 1998"
+    "sine wave" :: "Uses the values of a high frequency sine wave to create pseudo-randomness"
+} "default"
+
+INT fixed_seed_value "The value of the fixed seed to use"
+{
+  0:* :: "Positive integer"
+} 100
+
+REAL noise_amplitude "The value of the noise amplitude to use"
+{
+  0.0:* :: "Positive real"
+} 1.0e-10
+
+REAL noise_frequency "The value of the noise frenquecy to use with the sine wave engie"
+{
+  0.0:* :: "Positive real"
+} 5.0

--- a/NoiseX/schedule.ccl
+++ b/NoiseX/schedule.ccl
@@ -1,0 +1,6 @@
+# Schedule definitions for thorn NoiseX
+
+SCHEDULE NoiseX_setup_globals AT startup BEFORE Driver_Startup
+{
+  LANG: C
+} "Create NoiseX global data"

--- a/NoiseX/src/make.code.defn
+++ b/NoiseX/src/make.code.defn
@@ -1,0 +1,7 @@
+# Main make.code.defn file for thorn NoiseX
+
+# Source files in this directory
+SRCS = noisex.cxx
+
+# Subdirectories containing source files
+SUBDIRS =

--- a/NoiseX/src/noisex.cxx
+++ b/NoiseX/src/noisex.cxx
@@ -1,4 +1,4 @@
-#include <loop_device.hxx>
+#include <loop.hxx>
 
 #include <cctk.h>
 #include <cctk_Arguments.h>
@@ -8,7 +8,6 @@
 
 #include <cmath>
 #include <random>
-#include <memory>
 
 namespace NoiseX {
 
@@ -18,31 +17,25 @@ struct NoiseData {
   std::uniform_real_distribution<CCTK_REAL> distrib{};
 };
 
-std::unique_ptr<NoiseData> g_noise_data{};
+static NoiseData noise_data{};
 
 extern "C" int NoiseX_setup_globals() {
   DECLARE_CCTK_PARAMETERS;
 
   if (CCTK_EQUALS(seed_type, "hardware random device")) {
     std::random_device device{};
-    const auto random_seed{device()};
-
-    g_noise_data = std::make_unique<NoiseData>(
-        NoiseData{.default_engine = std::default_random_engine(random_seed),
-                  .mt_engine = std::mt19937(random_seed),
-                  .distrib = std::uniform_real_distribution<CCTK_REAL>(
-                      -noise_amplitude, noise_amplitude)});
-
+    const auto random_seed_value{device()};
+    noise_data.default_engine = std::default_random_engine(random_seed_value);
+    noise_data.mt_engine = std::mt19937(random_seed_value);
   } else if (CCTK_EQUALS(seed_type, "fixed")) {
-    g_noise_data = std::make_unique<NoiseData>(NoiseData{
-        .default_engine = std::default_random_engine(fixed_seed_value),
-        .mt_engine = std::mt19937(fixed_seed_value),
-        .distrib = std::uniform_real_distribution<CCTK_REAL>(-noise_amplitude,
-                                                             noise_amplitude)});
-
+    noise_data.default_engine = std::default_random_engine(fixed_seed_value);
+    noise_data.mt_engine = std::mt19937(fixed_seed_value);
   } else {
     CCTK_VERROR("Unrecognized seed type \"%s\"", seed_type);
   }
+
+  noise_data.distrib = std::uniform_real_distribution<CCTK_REAL>(
+      -noise_amplitude, noise_amplitude);
 
   return 0;
 }
@@ -51,34 +44,31 @@ void add(const cGH *restrict const cctkGH, Loop::GF3D2<CCTK_REAL> var) {
   DECLARE_CCTK_ARGUMENTS;
   DECLARE_CCTK_PARAMETERS;
 
-  const Loop::GridDescBaseDevice grid(cctkGH);
+  const Loop::GridDescBase grid(cctkGH);
 
   if (CCTK_EQUALS(random_engine, "default")) {
-    grid.loop_int<0, 0, 0>(grid.nghostzones,
-                           [=] CCTK_DEVICE CCTK_HOST(const Loop::PointDesc &p)
-                               CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                 var(p.I) += g_noise_data->distrib(
-                                     g_noise_data->default_engine);
-                               });
+    grid.loop_int<0, 0, 0>(
+        grid.nghostzones,
+        [&] CCTK_HOST(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+          var(p.I) += noise_data.distrib(noise_data.default_engine);
+        });
 
   } else if (CCTK_EQUALS(random_engine, "mersenne twister")) {
-    grid.loop_int<0, 0, 0>(grid.nghostzones,
-                           [=] CCTK_DEVICE CCTK_HOST(const Loop::PointDesc &p)
-                               CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                 var(p.I) += g_noise_data->distrib(
-                                     g_noise_data->mt_engine);
-                               });
+    grid.loop_int<0, 0, 0>(
+        grid.nghostzones,
+        [&] CCTK_HOST(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+          var(p.I) += noise_data.distrib(noise_data.mt_engine);
+        });
 
   } else if (CCTK_EQUALS(random_engine, "sine wave")) {
-    grid.loop_int<0, 0, 0>(grid.nghostzones,
-                           [=] CCTK_DEVICE CCTK_HOST(const Loop::PointDesc &p)
-                               CCTK_ATTRIBUTE_ALWAYS_INLINE {
-                                 using std::sin;
-                                 var(p.I) += noise_amplitude *
-                                             sin(noise_frequency * p.x / p.dx) *
-                                             sin(noise_frequency * p.y / p.dy) *
-                                             sin(noise_frequency * p.z / p.dz);
-                               });
+    grid.loop_int<0, 0, 0>(
+        grid.nghostzones,
+        [=] CCTK_HOST(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+          using std::sin;
+          var(p.I) += noise_amplitude * sin(noise_frequency * p.x / p.dx) *
+                      sin(noise_frequency * p.y / p.dy) *
+                      sin(noise_frequency * p.z / p.dz);
+        });
 
   } else {
     CCTK_VERROR("Unrecognized random engine \"%s\"", random_engine);

--- a/NoiseX/src/noisex.cxx
+++ b/NoiseX/src/noisex.cxx
@@ -22,7 +22,7 @@ static NoiseData noise_data{};
 extern "C" int NoiseX_setup_globals() {
   DECLARE_CCTK_PARAMETERS;
 
-  if (CCTK_EQUALS(seed_type, "hardware random device")) {
+  if (CCTK_EQUALS(seed_type, "random")) {
     std::random_device device{};
     const auto random_seed_value{device()};
     noise_data.default_engine = std::default_random_engine(random_seed_value);

--- a/NoiseX/src/noisex.cxx
+++ b/NoiseX/src/noisex.cxx
@@ -1,0 +1,80 @@
+#include <loop_device.hxx>
+
+#include <cctk.h>
+#include <cctk_Arguments.h>
+#include <cctk_Parameters.h>
+
+#include "noisex.hxx"
+
+#include <cmath>
+#include <random>
+
+namespace NoiseX {
+
+struct NoiseData {
+  std::default_random_engine default_engine{};
+  std::mt19937 mt_engine{};
+  std::uniform_real_distribution<CCTK_REAL> distrib{};
+};
+
+static NoiseData noise_data{};
+
+extern "C" int NoiseX_setup_globals() {
+  DECLARE_CCTK_PARAMETERS;
+
+  if (CCTK_EQUALS(seed_type, "hardware random device")) {
+    std::random_device device{};
+    noise_data.default_engine = std::default_random_engine(device());
+    noise_data.mt_engine = std::mt19937(device());
+  } else if (CCTK_EQUALS(seed_type, "fixed")) {
+    noise_data.default_engine = std::default_random_engine(fixed_seed_value);
+    noise_data.mt_engine = std::mt19937(fixed_seed_value);
+  } else {
+    CCTK_VERROR("Unrecognized seed type \"%s\"", seed_type);
+  }
+
+  noise_data.distrib = std::uniform_real_distribution<CCTK_REAL>(
+      -noise_amplitude, noise_amplitude);
+
+  return 0;
+}
+
+void add(const cGH *restrict const cctkGH, Loop::GF3D2<CCTK_REAL> var) {
+  DECLARE_CCTK_ARGUMENTS;
+  DECLARE_CCTK_PARAMETERS;
+
+  const Loop::GridDescBaseDevice grid(cctkGH);
+
+  if (CCTK_EQUALS(random_engine, "default")) {
+    grid.loop_int<0, 0, 0>(grid.nghostzones,
+                           [&] CCTK_DEVICE CCTK_HOST(const Loop::PointDesc &p)
+                               CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                 var(p.I) += noise_data.distrib(
+                                     noise_data.default_engine);
+                               });
+
+  } else if (CCTK_EQUALS(random_engine, "mersenne twister")) {
+    grid.loop_int<0, 0, 0>(grid.nghostzones,
+                           [&] CCTK_DEVICE CCTK_HOST(const Loop::PointDesc &p)
+                               CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                 var(p.I) +=
+                                     noise_data.distrib(noise_data.mt_engine);
+                               });
+
+  } else if (CCTK_EQUALS(random_engine, "sine wave")) {
+    grid.loop_int<0, 0, 0>(grid.nghostzones,
+                           [=] CCTK_DEVICE CCTK_HOST(const Loop::PointDesc &p)
+                               CCTK_ATTRIBUTE_ALWAYS_INLINE {
+                                 using std::sin;
+                                 var(p.I) += noise_amplitude *
+                                             sin(noise_frequency * p.x / p.dx) *
+                                             sin(noise_frequency * p.y / p.dy) *
+                                             sin(noise_frequency * p.z / p.dz);
+                               });
+
+  } else {
+    CCTK_VERROR("Unrecognized random engine \"%s\"", random_engine);
+  }
+}
+
+} // namespace NoiseX

--- a/NoiseX/src/noisex.hxx
+++ b/NoiseX/src/noisex.hxx
@@ -1,0 +1,9 @@
+#include <cctk.h>
+
+#include <loop_device.hxx>
+
+namespace NoiseX {
+
+void add(const cGH *restrict const cctkGH, Loop::GF3D2<CCTK_REAL> var);
+
+} // namespace NoiseX

--- a/NoiseX/src/noisex.hxx
+++ b/NoiseX/src/noisex.hxx
@@ -1,6 +1,6 @@
 #include <cctk.h>
 
-#include <loop_device.hxx>
+#include <loop.hxx>
 
 namespace NoiseX {
 

--- a/scripts/carpetx.th
+++ b/scripts/carpetx.th
@@ -709,6 +709,7 @@ CarpetX/FluxWaveToyX
 CarpetX/HydroBaseX
 CarpetX/Loop
 CarpetX/MovingBoxToy
+CarpetX/NoiseX
 CarpetX/ODESolvers
 CarpetX/PDESolvers
 CarpetX/PoissonX


### PR DESCRIPTION
This pull request adds a new thorn called `NoiseX` for providing a unified and localized interface for adding noise to `CarpetX` grid functions. This thorn is useful for performing robust stability tests. 

`ADMBaseX` already provides a mechanism for adding noise to ADM variables, but the current implemetation has a few issues:
1. `ADMBaseX` can only add noise to its own variables.
2. `ADMBaseX` provides no fine grained control over the type of noise being generated.
3. `ADMBaseX` noise generation is not reproducible.
4. There's a `TODO` in `ADMBaseX` which suggest delegating noise addition to a separate thorn

`NoiseX` allows users to choose between random (as it is done in `ADMBaseX`) or fixed and configurable noise seeds (for reproducibility). Furthermore it allows users to choose a noise engine for the actual generation of the pseudo-random numbers. Currently the default random engine (as used in `ADMBaseX`), Mersenne twister and sine wave generation engines are provided. This is done in hopes to improve user control over the numbers generated and allow for greater reproducibility.

This PR also modifies `ADMBaseX` for using `NoiseX` (thus providing an example usage) and the `CI` thorn list, adding `NoiseX` to the CI tests.