### PR TITLE
`MultiPatch_GetPatchSpecification` now takes an optional argument indicating whether a patch is cartesian.

### DIFF
--- a/CarpetX/interface.ccl
+++ b/CarpetX/interface.ccl
@@ -27,6 +27,7 @@ USES FUNCTION MultiPatch_GetSystemSpecification
 # Overall size of the domain
 CCTK_INT FUNCTION MultiPatch_GetPatchSpecification( \
   CCTK_INT IN patch, \
+  CCTK_INT OUT is_cartesian, \
   CCTK_INT IN size, \
   CCTK_INT OUT ARRAY ncells, \
   CCTK_REAL OUT ARRAY xmin, \

--- a/CarpetX/interface.ccl
+++ b/CarpetX/interface.ccl
@@ -25,14 +25,14 @@ CCTK_INT FUNCTION MultiPatch_GetSystemSpecification( \
 USES FUNCTION MultiPatch_GetSystemSpecification
 
 # Overall size of the domain
-CCTK_INT FUNCTION MultiPatch_GetPatchSpecification( \
+CCTK_INT FUNCTION MultiPatch_GetPatchSpecification2( \
   CCTK_INT IN patch, \
   CCTK_INT OUT is_cartesian, \
   CCTK_INT IN size, \
   CCTK_INT OUT ARRAY ncells, \
   CCTK_REAL OUT ARRAY xmin, \
   CCTK_REAL OUT ARRAY xmax)
-USES FUNCTION MultiPatch_GetPatchSpecification
+USES FUNCTION MultiPatch_GetPatchSpecification2
 
 # Patch boundaries
 CCTK_INT FUNCTION MultiPatch_GetBoundarySpecification2( \

--- a/CarpetX/src/driver.cxx
+++ b/CarpetX/src/driver.cxx
@@ -1357,8 +1357,8 @@ GHExt::PatchData::PatchData(const int patch) : patch(patch) {
   if (CCTK_IsFunctionAliased("MultiPatch_GetPatchSpecification")) {
     CCTK_INT ncells1[dim];
     CCTK_REAL xmin1[dim], xmax1[dim];
-    const int ierr =
-        MultiPatch_GetPatchSpecification(patch, dim, ncells1, xmin1, xmax1);
+    const int ierr = MultiPatch_GetPatchSpecification(patch, nullptr, dim,
+                                                      ncells1, xmin1, xmax1);
     assert(!ierr);
     for (int d = 0; d < dim; ++d)
       ncells[d] = ncells1[d];

--- a/CarpetX/src/driver.cxx
+++ b/CarpetX/src/driver.cxx
@@ -1354,11 +1354,11 @@ GHExt::PatchData::PatchData(const int patch) : patch(patch) {
   // Number of coarse grid cells
   amrex::Vector<int> ncells{ncells_x, ncells_y, ncells_z};
 
-  if (CCTK_IsFunctionAliased("MultiPatch_GetPatchSpecification")) {
+  if (CCTK_IsFunctionAliased("MultiPatch_GetPatchSpecification2")) {
     CCTK_INT ncells1[dim];
     CCTK_REAL xmin1[dim], xmax1[dim];
-    const int ierr = MultiPatch_GetPatchSpecification(patch, nullptr, dim,
-                                                      ncells1, xmin1, xmax1);
+    const int ierr = MultiPatch_GetPatchSpecification2(patch, nullptr, dim,
+                                                       ncells1, xmin1, xmax1);
     assert(!ierr);
     for (int d = 0; d < dim; ++d)
       ncells[d] = ncells1[d];


### PR DESCRIPTION
Knowing whether a patch is Cartesian is an important runtime optimization.
It is also important for IO.

`CapyrX` changed the interface for `MultiPatch_GetPatchSpecification` so that this information can be obtained [in this commit](https://github.com/lucass-carneiro/CapyrX/commit/e43635257f1e4740f8c686781dc3010ff4fce155)

This pull request adapts `CarpetX`'s interface file and all usages of `MultiPatch_GetPatchSpecification` to reflect this new interface