### PR TITLE
ODESolvers: add dummy schedule block to show scheduled routines

### DIFF
--- a/ODESolvers/interface.ccl
+++ b/ODESolvers/interface.ccl
@@ -10,3 +10,7 @@ void FUNCTION CallScheduleGroup(
   CCTK_POINTER IN cctkGH,
   CCTK_STRING IN groupname)
 REQUIRES FUNCTION CallScheduleGroup
+
+# these are *always* 0 (false) so that the groups do not execute
+# TODO: this does not handle "Implicit Euler" yet
+CCTK_INT do_substeps TYPE=SCALAR TAGS='checkpoint="no"' "Dummy condition used to generate schedule printouts"

--- a/ODESolvers/schedule.ccl
+++ b/ODESolvers/schedule.ccl
@@ -1,5 +1,15 @@
 # Schedule definitions for thorn ODESolvers
 
+STORAGE: do_substeps
+
+SCHEDULE ODESolvers_InitConstants AT WRAGH
+{
+  LANG: C
+  OPTIONS: global
+
+  WRITES: do_substeps
+} "Set up dummy loop counters for schedule printout"
+
 SCHEDULE ODESolvers_Solve AT evol
 {
   LANG: C
@@ -175,6 +185,22 @@ SCHEDULE ODESolvers_Solve AT evol
   # SCHEDULE GROUP ODESolvers_ImplicitStep AT poststep AFTER ODESolvers_PostStep
   # {
   # } "Take an implicit step everywhere on the grid"
+
+  # TODO: this does not yet handle "Implicit Euler" correctly
+  # this group never actually executes since do_subseteps == 0 always, it is
+  # only present to show up in the schedule printout
+  SCHEDULE GROUP ODESolvers_CalledBySolve AT EVOL AFTER ODESolvers_Solve WHILE (ODESolvers::do_substeps)
+  {
+  } "Groups internally scheduled by ODESolvers_Solve"
+
+  SCHEDULE GROUP ODESolvers_RHS IN ODESolvers_CalledBySolve
+  {
+  } "Evaluate the RHS for of state vector everywhere on the grid"
+
+  SCHEDULE GROUP ODESolvers_PostStep IN ODESolvers_CalledBySolve AFTER ODESolvers_RHS
+  {
+  } "Apply boundary conditions to state vector, and project if necessary"
+
   
   SCHEDULE GROUP ODESolvers_EstimateError AT poststep AFTER (ODESolvers_PostStep, ODESolvers_RHS)
   {

--- a/ODESolvers/src/solve.cxx
+++ b/ODESolvers/src/solve.cxx
@@ -666,6 +666,13 @@ void mark_invalid(const std::vector<int> &groups) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+extern "C" void ODESolvers_InitConstants(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTS_ODESolvers_InitConstants;
+  DECLARE_CCTK_PARAMETERS;
+
+  *do_substeps = 0;
+}
+
 extern "C" void ODESolvers_Solve(CCTK_ARGUMENTS) {
   DECLARE_CCTK_ARGUMENTS_ODESolvers_Solve;
   DECLARE_CCTK_PARAMETERS;


### PR DESCRIPTION
this adds a dummy scheduled group that is never executed but that shows up in the schedule printout to show what routines are scheduled inside of ODESolvers_Solve