### PR TITLE
Adapt to AMReX 26.02 Array4 API changes

### DIFF
--- a/CarpetX/src/interpolate.cxx
+++ b/CarpetX/src/interpolate.cxx
@@ -75,8 +75,8 @@ template <typename T, int order, int centering> struct interpolator {
   template <int dir>
   std::enable_if_t<(dir == -1), T>
   interpolate(const vect<int, dim> &i, const vect<CCTK_REAL, dim> &di) const {
-    const amrex::IntVect j(i[0] + vars.begin.x, i[1] + vars.begin.y,
-                           i[2] + vars.begin.z);
+    const amrex::Dim3 vlo = amrex::lbound(vars);
+    const amrex::IntVect j(i[0] + vlo.x, i[1] + vlo.y, i[2] + vlo.z);
 #ifdef CCTK_DEBUG
     assert(vars.contains(j[0], j[1], j[2]));
 #endif
@@ -244,9 +244,12 @@ template <typename T, int order, int centering> struct interpolator {
     // const auto x1 = x0 + (grid.lsh - 1 - indextype) * grid.dx;
     const auto dx = grid.dx;
 
-    assert(vars.end.x - vars.begin.x == grid.lsh[0] - indextype[0]);
-    assert(vars.end.y - vars.begin.y == grid.lsh[1] - indextype[1]);
-    assert(vars.end.z - vars.begin.z == grid.lsh[2] - indextype[2]);
+    assert(amrex::ubound(vars).x - amrex::lbound(vars).x + 1 ==
+           grid.lsh[0] - indextype[0]);
+    assert(amrex::ubound(vars).y - amrex::lbound(vars).y + 1 ==
+           grid.lsh[1] - indextype[1]);
+    assert(amrex::ubound(vars).z - amrex::lbound(vars).z + 1 ==
+           grid.lsh[2] - indextype[2]);
 
     // We assume that the input is synchronized, i.e. that all ghost
     // zones are valid, but all outer boundaries are invalid.

--- a/CarpetX/src/io_tsv.cxx
+++ b/CarpetX/src/io_tsv.cxx
@@ -152,11 +152,11 @@ void WriteTSVold(const cGH *restrict cctkGH, const std::string &filename,
       const auto &mfab = *groupdata.mfab.at(tl);
       for (amrex::MFIter mfi(mfab); mfi.isValid(); ++mfi) {
         const amrex::Array4<const CCTK_REAL> &vars = mfab.array(mfi);
-        const auto &imin = vars.begin;
-        const auto &imax = vars.end;
-        for (int k = imin.z; k < imax.z; ++k) {
-          for (int j = imin.y; j < imax.y; ++j) {
-            for (int i = imin.x; i < imax.x; ++i) {
+        const amrex::Dim3 imin = amrex::lbound(vars);
+        const amrex::Dim3 imax = amrex::ubound(vars); // inclusive
+        for (int k = imin.z; k <= imax.z; ++k) {
+          for (int j = imin.y; j <= imax.y; ++j) {
+            for (int i = imin.x; i <= imax.x; ++i) {
               const std::array<int, dim> I{i, j, k};
               std::array<CCTK_REAL, dim> x;
               for (int d = 0; d < dim; ++d)
@@ -514,9 +514,11 @@ void WriteTSVGFs(const cGH *restrict cctkGH, const std::string &filename,
                                  (groupdata.indextype[d] == 0 && f == 1) &&
                          symmetries[f][d] != symmetry_t::none;
 
-        const vect<int, dim> varmin = {vars.begin.x, vars.begin.y,
-                                       vars.begin.z};
-        const vect<int, dim> varmax = {vars.end.x, vars.end.y, vars.end.z};
+        const amrex::Dim3 vlo = amrex::lbound(vars);
+        const amrex::Dim3 vhi = amrex::ubound(vars); // inclusive
+        const vect<int, dim> varmin = {vlo.x, vlo.y, vlo.z};
+        // varmax is exclusive
+        const vect<int, dim> varmax = {vhi.x + 1, vhi.y + 1, vhi.z + 1};
 
         // Skip ghost points but keep boundary points
         const vect<int, dim> intmin = varmin + !bbox[0] * nghosts;

--- a/CarpetX/src/reduction.cxx
+++ b/CarpetX/src/reduction.cxx
@@ -229,12 +229,12 @@ reduction<CCTK_REAL, dim> reduce(int gi, int vi, int tl) {
             finemask = std::make_unique<amrex::Array4<const int> >(
                 finemask_imfab->array(mfi));
             // Ensure the mask has the correct size
-            assert(finemask->begin.x == vars.begin.x);
-            assert(finemask->begin.y == vars.begin.y);
-            assert(finemask->begin.z == vars.begin.z);
-            assert(finemask->end.x == vars.end.x);
-            assert(finemask->end.y == vars.end.y);
-            assert(finemask->end.z == vars.end.z);
+            assert(amrex::lbound(*finemask).x == amrex::lbound(vars).x);
+            assert(amrex::lbound(*finemask).y == amrex::lbound(vars).y);
+            assert(amrex::lbound(*finemask).z == amrex::lbound(vars).z);
+            assert(amrex::ubound(*finemask).x == amrex::ubound(vars).x);
+            assert(amrex::ubound(*finemask).y == amrex::ubound(vars).y);
+            assert(amrex::ubound(*finemask).z == amrex::ubound(vars).z);
           }
 
           red += reduce_array(vars, vi, tmin, tmax, indextype, imin, imax,

--- a/ODESolvers/src/solve.cxx
+++ b/ODESolvers/src/solve.cxx
@@ -11,6 +11,7 @@
 #include <div.hxx>
 
 #include <AMReX_MultiFab.H>
+#include <AMReX_Version.H>
 
 #if defined _OPENMP || defined __HIPCC__
 #include <omp.h>
@@ -322,12 +323,23 @@ void statecomp_t::lincomb(const statecomp_t &dst, const CCTK_REAL scale,
       std::array<amrex::Array4<const CCTK_REAL>, N> srcvars;
       for (std::size_t n = 0; n < N; ++n)
         srcvars[n] = srcs[n]->mfabs.at(m)->const_array(mfi);
+      // Array4's public stride members were replaced by get_stride() in
+      // AMReX 26.02
+#if AMREX_RELEASE_NUMBER >= 260200
+      for (std::size_t n = 0; n < N; ++n) {
+        assert(srcvars[n].template get_stride<1>() == dstvar.get_stride<1>());
+        assert(srcvars[n].template get_stride<2>() == dstvar.get_stride<2>());
+        assert(srcvars[n].template get_stride<3>() == dstvar.get_stride<3>());
+      }
+      const std::ptrdiff_t nstride = dstvar.get_stride<3>();
+#else
       for (std::size_t n = 0; n < N; ++n) {
         assert(srcvars[n].jstride == dstvar.jstride);
         assert(srcvars[n].kstride == dstvar.kstride);
         assert(srcvars[n].nstride == dstvar.nstride);
       }
       const std::ptrdiff_t nstride = dstvar.nstride;
+#endif
       const std::ptrdiff_t npoints = nstride * ncomps;
 
       CCTK_REAL *restrict const dstptr = dstvar.dataPtr();

--- a/scripts/actions-cpu-real32.cfg
+++ b/scripts/actions-cpu-real32.cfg
@@ -18,7 +18,7 @@ F90 = gfortran
 # Note: GCC 13.2 with -ftrivial-auto-var-init=pattern mis-compiles (?) C++ lambdas
 
 CFLAGS = -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS -fPIE -fcf-protection=full -fstack-clash-protection -fstack-protector-strong -ftrivial-auto-var-init=pattern -g -march=x86-64-v3 -pie -pipe -std=gnu11
-CXXFLAGS = -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS -fPIE -fcf-protection=full -fstack-clash-protection -fstack-protector-strong -g -march=x86-64-v3 -pie -pipe -std=gnu++17
+CXXFLAGS = -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS -fPIE -fcf-protection=full -fstack-clash-protection -fstack-protector-strong -g -march=x86-64-v3 -pie -pipe -std=gnu++20
 FPPFLAGS = -traditional
 F90FLAGS = -fPIE -fcf-protection=full -fcray-pointer -ffixed-line-length-none -finit-character=65 -finit-integer=42424242 -finit-real=nan -fstack-clash-protection -fstack-protector-strong -g -march=x86-64-v3 -pie -pipe
 LDFLAGS = -L/usr/lib/x86_64-linux-gnu -Wl,-rpath,/usr/local/lib -Wl,-z,relro,-z,now

--- a/scripts/actions-cpu-real64.cfg
+++ b/scripts/actions-cpu-real64.cfg
@@ -18,7 +18,7 @@ F90 = gfortran
 # Note: GCC 13.2 with -ftrivial-auto-var-init=pattern mis-compiles (?) C++ lambdas
 
 CFLAGS = -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS -fPIE -fcf-protection=full -fstack-clash-protection -fstack-protector-strong -ftrivial-auto-var-init=pattern -g -march=x86-64-v3 -pie -pipe -std=gnu11
-CXXFLAGS = -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS -fPIE -fcf-protection=full -fstack-clash-protection -fstack-protector-strong -g -march=x86-64-v3 -pie -pipe -std=gnu++17
+CXXFLAGS = -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS -fPIE -fcf-protection=full -fstack-clash-protection -fstack-protector-strong -g -march=x86-64-v3 -pie -pipe -std=gnu++20
 FPPFLAGS = -traditional
 F90FLAGS = -fPIE -fcf-protection=full -fcray-pointer -ffixed-line-length-none -finit-character=65 -finit-integer=42424242 -finit-real=nan -fstack-clash-protection -fstack-protector-strong -g -march=x86-64-v3 -pie -pipe
 LDFLAGS = -L/usr/lib/x86_64-linux-gnu -Wl,-rpath,/usr/local/lib -Wl,-z,relro,-z,now

--- a/scripts/actions-cuda-real32.cfg
+++ b/scripts/actions-cuda-real32.cfg
@@ -24,7 +24,7 @@ CFLAGS = -pipe -g -std=gnu11
 #   Call parameter type does not match function signature!
 #     %tmp = load double, double* %x.addr, align 8, !dbg !1483
 #     float  %1 = call i32 @__isnanf(double %tmp), !dbg !1483
-CXXFLAGS = -pipe -g0 -std=c++17 --compiler-options -std=gnu++17 --expt-relaxed-constexpr --extended-lambda --gpu-architecture sm_90 --forward-unknown-to-host-compiler --Werror ext-lambda-captures-this --relocatable-device-code=true --objdir-as-tempdir
+CXXFLAGS = -pipe -g0 -std=c++20 --compiler-options -std=gnu++20 --expt-relaxed-constexpr --extended-lambda --gpu-architecture sm_90 --forward-unknown-to-host-compiler --Werror ext-lambda-captures-this --relocatable-device-code=true --objdir-as-tempdir
 FPPFLAGS = -traditional
 F90FLAGS = -pipe -g -fcray-pointer -ffixed-line-length-none
 LIBS = nvToolsExt gfortran

--- a/scripts/actions-cuda-real64.cfg
+++ b/scripts/actions-cuda-real64.cfg
@@ -24,7 +24,7 @@ CFLAGS = -pipe -g -std=gnu11
 #   Call parameter type does not match function signature!
 #     %tmp = load double, double* %x.addr, align 8, !dbg !1483
 #     float  %1 = call i32 @__isnanf(double %tmp), !dbg !1483
-CXXFLAGS = -pipe -g0 -std=c++17 --compiler-options -std=gnu++17 --expt-relaxed-constexpr --extended-lambda --gpu-architecture sm_90 --forward-unknown-to-host-compiler --Werror ext-lambda-captures-this --relocatable-device-code=true --objdir-as-tempdir
+CXXFLAGS = -pipe -g0 -std=c++20 --compiler-options -std=gnu++20 --expt-relaxed-constexpr --extended-lambda --gpu-architecture sm_90 --forward-unknown-to-host-compiler --Werror ext-lambda-captures-this --relocatable-device-code=true --objdir-as-tempdir
 FPPFLAGS = -traditional
 F90FLAGS = -pipe -g -fcray-pointer -ffixed-line-length-none
 LIBS = nvToolsExt gfortran

--- a/scripts/actions-oneapi-real64.cfg
+++ b/scripts/actions-oneapi-real64.cfg
@@ -18,7 +18,7 @@ LD = icpx -fsycl
 # -g   # Debug information uses too much disk space on CI
 CPPFLAGS = -DSIMD_DISABLE
 CFLAGS = -fp-model=precise -march=x86-64-v3 -pipe -std=gnu11
-CXXFLAGS = -fp-model=precise -fsycl -march=x86-64-v3 -pipe -std=c++17
+CXXFLAGS = -fp-model=precise -fsycl -march=x86-64-v3 -pipe -std=c++20
 FPPFLAGS = -traditional
 F90FLAGS = -fcray-pointer -ffixed-line-length-none -march=x86-64-v3 -pipe
 

--- a/scripts/actions-rocm-real64.cfg
+++ b/scripts/actions-rocm-real64.cfg
@@ -18,7 +18,7 @@ LD = /opt/rocm/llvm/bin/clang++
 
 CPPFLAGS = -DSIMD_DISABLE
 CFLAGS = -pipe -g -std=gnu11
-CXXFLAGS = -pipe -g -std=c++17 --offload-arch=gfx90a
+CXXFLAGS = -pipe -g -std=c++20 --offload-arch=gfx90a
 FPPFLAGS = -traditional
 F90FLAGS = -pipe -g -fcray-pointer -ffixed-line-length-none
 


### PR DESCRIPTION
AMReX 26.02 refactored `Array4` into a specialization of the new `ArrayND` class (AMReX-Codes/amrex#4900). This changed the public member API that CarpetX relies on:

- the `Dim3 begin`/`end` members became `IntVectND`s, so `vars.begin.x` etc. no longer compile;
- the public `jstride`/`kstride`/`nstride` members were replaced by a `get_stride<d>()` accessor;
- the new headers use C++20 `requires` clauses, so building against AMReX ≥ 26.02 needs `-std=c++20`.

## Changes

- **CarpetX**: use the `amrex::lbound`/`amrex::ubound` free functions instead of the `begin`/`end` members in `interpolate.cxx`, `io_tsv.cxx`, and `reduction.cxx`. These functions exist in all AMReX versions, so this compiles against both old and new AMReX. Note that `ubound` is inclusive while the old `end` member was exclusive; loop bounds and asserts are adjusted accordingly.
- **ODESolvers**: use `Array4::get_stride()` when building against AMReX ≥ 26.02, guarded by `AMREX_RELEASE_NUMBER` (the same pattern as the existing guard in `CarpetX/src/fillpatch.cxx`); the old stride members are kept for older AMReX.
- **scripts**: bump the CI configs from C++17 to C++20, required for AMReX ≥ 26.02 and harmless for older versions.

No behavior change is intended; this is a pure API adaptation.

## Tests

Built and ran the CarpetX testsuite against AMReX 26.07 (g++, macOS), which exercises the new (`AMREX_RELEASE_NUMBER >= 260200`) code path. The pre-26.02 code path in `ODESolvers` is textually unchanged and continues to compile against the AMReX shipped in the current CI containers.

These changes were originally developed and CI-tested (CPU/CUDA/ROCm/oneAPI, real32/real64) in lwJi/CarpetX#103.
