### PR TITLE
Add bounded static two-level subcycling and synchronized recovery

### DIFF
--- a/BoxInBox/schedule.ccl
+++ b/BoxInBox/schedule.ccl
@@ -11,6 +11,17 @@ SCHEDULE BoxInBox_Init AT initial
   WRITES: radiixyz
 } "Initialize"
 
+SCHEDULE BoxInBox_Init AT post_recover_variables
+{
+  LANG: C
+  OPTIONS: global
+  WRITES: active
+  WRITES: num_levels
+  WRITES: positions
+  WRITES: radii
+  WRITES: radiixyz
+} "Reinitialize parameter-derived refinement regions after recovery"
+
 SCHEDULE BoxInBox_Setup AS EstimateError AT postinitial
 {
   LANG: C

--- a/CarpetX/interface.ccl
+++ b/CarpetX/interface.ccl
@@ -16,6 +16,16 @@ USES INCLUDE HEADER: loop_device.hxx
 
 INCLUDES HEADER: driver.hxx IN driver.hxx
 INCLUDES HEADER: reduction.hxx IN reduction.hxx
+INCLUDES HEADER: subcycling_dense_control_builder.hxx IN subcycling_dense_control_builder.hxx
+INCLUDES HEADER: subcycling_dense_mfab_state.hxx IN subcycling_dense_mfab_state.hxx
+INCLUDES HEADER: subcycling_dense_output.hxx IN subcycling_dense_output.hxx
+INCLUDES HEADER: subcycling_dense_stencil.hxx IN subcycling_dense_stencil.hxx
+INCLUDES HEADER: subcycling_method_contract.hxx IN subcycling_method_contract.hxx
+INCLUDES HEADER: subcycling_native_gate.hxx IN subcycling_native_gate.hxx
+INCLUDES HEADER: subcycling_scratch_state.hxx IN subcycling_scratch_state.hxx
+INCLUDES HEADER: subcycling_scratch_schedule_executor.hxx IN subcycling_scratch_schedule_executor.hxx
+INCLUDES HEADER: subcycling_scratch_state_transaction.hxx IN subcycling_scratch_state_transaction.hxx
+INCLUDES HEADER: subcycling_step_context.hxx IN subcycling_step_context.hxx
 
 
 

--- a/CarpetX/src/driver.cxx
+++ b/CarpetX/src/driver.cxx
@@ -1313,6 +1313,8 @@ void CactusAmrCore::MakeNewLevelFromCoarse(
 #pragma omp critical
     CCTK_VINFO("MakeNewLevelFromCoarse patch %d level %d", patch, level);
 
+  assert(level > 0);
+
   if (use_subcycling_wip) {
     if (patch != 0 || level != 1 || ghext->num_patches() != 1 ||
         max_num_levels != 2 || regrid_every != 0)
@@ -1328,7 +1330,8 @@ void CactusAmrCore::MakeNewLevelFromCoarse(
           "coarse level before level-1 creation");
 
     const auto &coarseleveldata = patchdata.leveldata.at(0);
-    const auto refinement_ratio = refRatio(level);
+    const auto refinement_ratio =
+        refRatio(static_v1_parent_refinement_ratio_index(level));
     if (!permits_static_v1_level_one_creation(
             StaticV1LevelOneCreationEnvelope{
                 use_subcycling_wip,
@@ -1340,8 +1343,9 @@ void CactusAmrCore::MakeNewLevelFromCoarse(
                 regrid_every,
                 coarseleveldata.patch,
                 coarseleveldata.level,
-                static_cast<int>(coarseleveldata.iteration),
-                static_cast<int>(coarseleveldata.delta_iteration),
+                {coarseleveldata.iteration.num, coarseleveldata.iteration.den},
+                {coarseleveldata.delta_iteration.num,
+                 coarseleveldata.delta_iteration.den},
                 coarseleveldata.is_subcycling_level,
                 {refinement_ratio[0], refinement_ratio[1], refinement_ratio[2]},
                 time}))

--- a/CarpetX/src/driver.cxx
+++ b/CarpetX/src/driver.cxx
@@ -8,6 +8,7 @@
 #include "loop_device.hxx"
 #include "prolongate_3d_rf2.hxx"
 #include "schedule.hxx"
+#include "subcycling_static_v1_contract.hxx"
 #include "timer.hxx"
 
 #include <cctk.h>
@@ -1273,11 +1274,30 @@ void CactusAmrCore::MakeNewLevelFromScratch(
     const amrex::DistributionMapping &dm) {
   DECLARE_CCTK_PARAMETERS;
 
+  if (use_subcycling_wip &&
+      (patch != 0 || level != 0 || time != 0.0 ||
+       ghext->num_patches() != 1 || max_num_levels != 2 ||
+       ghext->num_levels(patch) != 0 || regrid_every != 0))
+    CCTK_VERROR(
+        "static-v1 MakeNewLevelFromScratch requires initial patch 0 level 0 "
+        "creation at time 0 with no existing levels, one patch, two levels, "
+        "and CarpetX::regrid_every=0");
+
   if (verbose)
 #pragma omp critical
     CCTK_VINFO("MakeNewLevelFromScratch patch %d level %d", patch, level);
 
   SetupLevel(level, ba, dm, []() { return "MakeNewLevelFromScratch"; });
+
+  if (use_subcycling_wip) {
+    const auto &leveldata = ghext->patchdata.at(patch).leveldata.at(level);
+    if (leveldata.patch != 0 || leveldata.level != 0 ||
+        leveldata.iteration != 0 || leveldata.delta_iteration != 1 ||
+        leveldata.is_subcycling_level)
+      CCTK_VERROR(
+          "static-v1 MakeNewLevelFromScratch produced invalid level-0 "
+          "identity, clock, or subcycling metadata");
+  }
 
   if (verbose)
 #pragma omp critical
@@ -1293,13 +1313,60 @@ void CactusAmrCore::MakeNewLevelFromCoarse(
 #pragma omp critical
     CCTK_VINFO("MakeNewLevelFromCoarse patch %d level %d", patch, level);
 
-  assert(!use_subcycling_wip);
-  assert(level > 0);
+  if (use_subcycling_wip) {
+    if (patch != 0 || level != 1 || ghext->num_patches() != 1 ||
+        max_num_levels != 2 || regrid_every != 0)
+      CCTK_VERROR(
+          "static-v1 MakeNewLevelFromCoarse requires patch 0 level 1 with "
+          "one patch, two levels, and CarpetX::regrid_every=0");
+
+    const auto &patchdata = ghext->patchdata.at(patch);
+    const int existing_level_count = patchdata.leveldata.size();
+    if (existing_level_count != 1)
+      CCTK_VERROR(
+          "static-v1 MakeNewLevelFromCoarse requires exactly one existing "
+          "coarse level before level-1 creation");
+
+    const auto &coarseleveldata = patchdata.leveldata.at(0);
+    const auto refinement_ratio = refRatio(level);
+    if (!permits_static_v1_level_one_creation(
+            StaticV1LevelOneCreationEnvelope{
+                use_subcycling_wip,
+                ghext->num_patches(),
+                patch,
+                level,
+                max_num_levels,
+                existing_level_count,
+                regrid_every,
+                coarseleveldata.patch,
+                coarseleveldata.level,
+                static_cast<int>(coarseleveldata.iteration),
+                static_cast<int>(coarseleveldata.delta_iteration),
+                coarseleveldata.is_subcycling_level,
+                {refinement_ratio[0], refinement_ratio[1], refinement_ratio[2]},
+                time}))
+      CCTK_VERROR(
+          "static-v1 MakeNewLevelFromCoarse rejected a callback outside the "
+          "exact initial factor-two level-1 creation envelope");
+  }
 
   SetupLevel(level, ba, dm, []() { return "MakeNewLevelFromCoarse"; });
 
+  if (use_subcycling_wip) {
+    const auto &patchdata = ghext->patchdata.at(patch);
+    const auto &leveldata = patchdata.leveldata.at(level);
+    const auto &coarseleveldata = patchdata.leveldata.at(level - 1);
+    if (leveldata.patch != 0 || leveldata.level != 1 ||
+        leveldata.iteration != coarseleveldata.iteration ||
+        leveldata.iteration != 0 ||
+        leveldata.delta_iteration != coarseleveldata.delta_iteration / 2 ||
+        !leveldata.is_subcycling_level)
+      CCTK_VERROR(
+          "static-v1 MakeNewLevelFromCoarse produced invalid level-1 "
+          "identity, clock, or subcycling metadata before prolongation");
+  }
+
   // Prolongate
-  assert(!use_subcycling_wip);
   auto &patchdata = ghext->patchdata.at(patch);
   auto &leveldata = patchdata.leveldata.at(level);
   auto &coarseleveldata = patchdata.leveldata.at(level - 1);
@@ -1389,6 +1456,10 @@ void CactusAmrCore::RemakeLevel(const int level, const amrex::Real time,
                                 const amrex::DistributionMapping &dm) {
   DECLARE_CCTK_PARAMETERS;
 
+  if (use_subcycling_wip)
+    CCTK_VERROR(
+        "static-v1 rejects RemakeLevel: dynamic regridding is unsupported");
+
   if (verbose)
 #pragma omp critical
     CCTK_VINFO("RemakeLevel patch %d level %d", patch, level);
@@ -1400,9 +1471,6 @@ void CactusAmrCore::RemakeLevel(const int level, const amrex::Real time,
   const active_levels_t active_levels(level, level + 1, patch, patch + 1);
   const active_levels_t active_coarse_levels(level - 1, level, patch,
                                              patch + 1);
-
-  // Copy or prolongate
-  assert(!use_subcycling_wip);
 
   // Check old level
   const int num_groups = CCTK_NumGroups();
@@ -1527,6 +1595,10 @@ void CactusAmrCore::RemakeLevel(const int level, const amrex::Real time,
 
 void CactusAmrCore::ClearLevel(const int level) {
   DECLARE_CCTK_PARAMETERS;
+
+  if (use_subcycling_wip)
+    CCTK_VERROR(
+        "static-v1 rejects ClearLevel: dynamic level removal is unsupported");
 
   if (verbose)
 #pragma omp critical

--- a/CarpetX/src/driver.cxx
+++ b/CarpetX/src/driver.cxx
@@ -30,6 +30,7 @@
 #include <memory>
 #include <ostream>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -95,6 +96,48 @@ extern "C" CCTK_INT CarpetX_GetBoundarySizesAndTypes(
  */
 extern "C" CCTK_INT CarpetX_GetEpoch(void) {
   return carpetx_epoch.load(std::memory_order_relaxed);
+}
+
+std::uint64_t register_subcycling_method_contract(
+    const SubcyclingMethodContract &contract) {
+  if (ghext == nullptr)
+    throw std::logic_error(
+        "cannot register a subcycling method contract without a GHExt");
+  return ghext->subcycling_method_contracts.register_contract(contract);
+}
+
+std::uint64_t register_subcycling_group_schema(
+    const std::string_view provider_id,
+    const SubcyclingGroupSchema &group_schema) {
+  if (ghext == nullptr)
+    throw std::logic_error(
+        "cannot register a subcycling group schema without a GHExt");
+  return ghext->subcycling_method_contracts.register_group_schema(
+      provider_id, group_schema);
+}
+
+SubcyclingMethodContractSnapshot
+require_registered_subcycling_method_contract() {
+  if (ghext == nullptr)
+    throw std::logic_error(
+        "cannot read a subcycling method contract without a GHExt");
+  return ghext->subcycling_method_contracts.require_snapshot();
+}
+
+SubcyclingMethodContractSnapshot
+require_complete_registered_subcycling_method_contract() {
+  if (ghext == nullptr)
+    throw std::logic_error(
+        "cannot read a subcycling method contract without a GHExt");
+  return ghext->subcycling_method_contracts.require_complete_snapshot();
+}
+
+void validate_registered_subcycling_method_contract(
+    const SubcyclingMethodContractSnapshot &snapshot) {
+  if (ghext == nullptr)
+    throw std::logic_error(
+        "cannot validate a subcycling method contract without a GHExt");
+  ghext->subcycling_method_contracts.validate_snapshot(snapshot);
 }
 
 // Local functions

--- a/CarpetX/src/driver.hxx
+++ b/CarpetX/src/driver.hxx
@@ -2,6 +2,7 @@
 #define CARPETX_CARPETX_DRIVER_HXX
 
 #include "loop.hxx"
+#include "subcycling_method_contract.hxx"
 #include "valid.hxx"
 
 #include <rational.hxx>
@@ -111,6 +112,8 @@ public:
 struct GHExt {
 
   GHExt() = default;
+  SubcyclingMethodContractRegistry subcycling_method_contracts;
+
   GHExt(const GHExt &) = delete;
   GHExt(GHExt &&) = delete;
   GHExt &operator=(const GHExt &) = delete;

--- a/CarpetX/src/hierarchy_stepper.cxx
+++ b/CarpetX/src/hierarchy_stepper.cxx
@@ -1,0 +1,463 @@
+#include "hierarchy_stepper.hxx"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <numeric>
+#include <stdexcept>
+#include <utility>
+
+namespace CarpetX {
+namespace {
+
+bool known_method(const SubcyclingODEMethod method) noexcept {
+  switch (method) {
+  case SubcyclingODEMethod::rk4:
+  case SubcyclingODEMethod::rkf78_order7:
+  case SubcyclingODEMethod::dp87_order8:
+    return true;
+  }
+  return false;
+}
+
+bool zero_fingerprint(const TableauFingerprint &fingerprint) noexcept {
+  return std::all_of(fingerprint.begin(), fingerprint.end(),
+                     [](const std::uint8_t value) { return value == 0; });
+}
+
+DenseCapability
+canonical_capability(const SubcyclingODEMethod method,
+                     const TableauFingerprint &tableau_fingerprint) {
+  switch (method) {
+  case SubcyclingODEMethod::rk4:
+    return DenseCapability{method, tableau_fingerprint, 4, 4, 4, 4, 5, true,
+                           true};
+  case SubcyclingODEMethod::rkf78_order7:
+    return DenseCapability{method, tableau_fingerprint, 7, 7, 11, 23, 8, true,
+                           true};
+  case SubcyclingODEMethod::dp87_order8:
+    return DenseCapability{method, tableau_fingerprint, 8, 8, 13, 39, 9, true,
+                           true};
+  }
+  throw std::invalid_argument("unsupported hierarchy ODE method");
+}
+
+bool same_capability(const DenseCapability &left,
+                     const DenseCapability &right) noexcept {
+  return left.method == right.method &&
+         left.tableau_fingerprint == right.tableau_fingerprint &&
+         left.endpoint_order == right.endpoint_order &&
+         left.dense_uniform_order == right.dense_uniform_order &&
+         left.stage_count == right.stage_count &&
+         left.extra_rhs_evaluations == right.extra_rhs_evaluations &&
+         left.persistent_vector_count == right.persistent_vector_count &&
+         left.arbitrary_theta == right.arbitrary_theta &&
+         left.verified == right.verified;
+}
+
+std::int64_t checked_multiply_by_positive(const std::int64_t value,
+                                          const std::int64_t factor) {
+  if (factor <= 0)
+    throw std::logic_error("clock denominator factor must be positive");
+  if (value > std::numeric_limits<std::int64_t>::max() / factor ||
+      value < std::numeric_limits<std::int64_t>::min() / factor)
+    throw std::overflow_error("exact hierarchy clock multiplication overflow");
+  return value * factor;
+}
+
+std::int64_t checked_add_integer(const std::int64_t left,
+                                 const std::int64_t right) {
+  if ((right > 0 &&
+       left > std::numeric_limits<std::int64_t>::max() - right) ||
+      (right < 0 &&
+       left < std::numeric_limits<std::int64_t>::min() - right))
+    throw std::overflow_error("exact hierarchy clock addition overflow");
+  return left + right;
+}
+
+hierarchy_time_t checked_clock_add(const hierarchy_time_t left,
+                                   const hierarchy_time_t right) {
+  if (left.den <= 0 || right.den <= 0)
+    throw std::invalid_argument(
+        "exact hierarchy clocks require positive denominators");
+  const auto common = std::gcd(left.den, right.den);
+  const auto left_factor = right.den / common;
+  const auto right_factor = left.den / common;
+  const auto left_term = checked_multiply_by_positive(left.num, left_factor);
+  const auto right_term = checked_multiply_by_positive(right.num, right_factor);
+  const auto numerator = checked_add_integer(left_term, right_term);
+  const auto denominator =
+      checked_multiply_by_positive(left.den, left_factor);
+  return hierarchy_time_t(numerator, denominator);
+}
+
+class HierarchyStagePreparer final : public StagePreparer {
+public:
+  HierarchyStagePreparer(HierarchyEvolutionAdapter &adapter,
+                         const StepContext &expected_context,
+                         std::shared_ptr<const DenseInterval> parent_dense)
+      : adapter_(adapter), expected_context_(expected_context),
+        parent_dense_(std::move(parent_dense)) {
+    if (expected_context_.level == 0 && parent_dense_ != nullptr)
+      throw std::logic_error("root level cannot have parent dense state");
+    if (expected_context_.level > 0 && parent_dense_ == nullptr)
+      throw std::logic_error("fine level requires parent dense state");
+  }
+
+  void prepare_stage(const StepContext &context,
+                     const StagePoint &stage_point) override {
+    if (&context != &expected_context_)
+      throw std::logic_error("stage context does not belong to this level step");
+
+    const auto exact_stage_clock =
+        context.begin_clock +
+        stage_point.stage_fraction * (context.end_clock - context.begin_clock);
+    StagePoint canonical_stage_point = stage_point;
+    canonical_stage_point.stage_time =
+        context.begin_time + static_cast<double>(stage_point.stage_fraction) *
+                                 (context.end_time - context.begin_time);
+    const double time_scale =
+        std::max({1.0, std::abs(context.begin_time),
+                  std::abs(context.end_time),
+                  std::abs(canonical_stage_point.stage_time)});
+    const double tolerance =
+        16.0 * std::numeric_limits<double>::epsilon() * time_scale;
+
+    if (parent_dense_ != nullptr) {
+      const auto &id = parent_dense_->id();
+      if (id.level != context.level - 1 ||
+          id.begin_clock > context.begin_clock ||
+          id.end_clock < context.end_clock)
+        throw std::logic_error(
+            "parent dense interval does not cover the child step exactly");
+      if (exact_stage_clock < id.begin_clock ||
+          exact_stage_clock > id.end_clock ||
+          canonical_stage_point.stage_time < id.begin_time - tolerance ||
+          canonical_stage_point.stage_time > id.end_time + tolerance)
+        throw std::out_of_range(
+            "parent dense interval does not cover the requested stage time");
+    }
+
+    adapter_.prepare_stage(context, canonical_stage_point,
+                           parent_dense_.get());
+  }
+
+private:
+  HierarchyEvolutionAdapter &adapter_;
+  const StepContext &expected_context_;
+  std::shared_ptr<const DenseInterval> parent_dense_;
+};
+
+class SynchronizationScope final {
+public:
+  SynchronizationScope(HierarchyEvolutionAdapter &adapter,
+                       const int coarse_level, const int fine_level,
+                       const hierarchy_time_t time)
+      : adapter_(adapter), coarse_level_(coarse_level),
+        fine_level_(fine_level), time_(time) {
+    adapter_.begin_synchronization(coarse_level_, fine_level_, time_);
+  }
+
+  ~SynchronizationScope() {
+    adapter_.end_synchronization(coarse_level_, fine_level_, time_);
+  }
+
+  SynchronizationScope(const SynchronizationScope &) = delete;
+  SynchronizationScope &operator=(const SynchronizationScope &) = delete;
+
+private:
+  HierarchyEvolutionAdapter &adapter_;
+  int coarse_level_;
+  int fine_level_;
+  hierarchy_time_t time_;
+};
+
+} // namespace
+
+HierarchyStepper::HierarchyStepper(
+    HierarchyStepperConfig config,
+    const DenseOutputRegistry &dense_registry)
+    : level_configs_(std::move(config.levels)),
+      initial_clock_(config.initial_clock),
+      initial_physical_time_(config.initial_physical_time),
+      coarse_dt_(config.coarse_dt), epoch_(config.initial_epoch) {
+  if (level_configs_.empty())
+    throw std::invalid_argument("hierarchy must contain at least one level");
+  if (config.refinement_ratio != 2)
+    throw std::invalid_argument("only factor-two time refinement is supported");
+  if (level_configs_.size() > 62)
+    throw std::invalid_argument("hierarchy depth exceeds exact clock range");
+  if (!std::isfinite(initial_physical_time_) || !std::isfinite(coarse_dt_) ||
+      !(coarse_dt_ > 0.0))
+    throw std::invalid_argument(
+        "initial physical time and coarse dt must be finite, with dt positive");
+  if (config.initial_accepted_steps.empty()) {
+    if (config.initial_epoch != 0)
+      throw std::invalid_argument(
+          "a recovered hierarchy epoch requires accepted-step counts");
+  } else {
+    if (config.initial_accepted_steps.size() != level_configs_.size())
+      throw std::invalid_argument(
+          "accepted-step count must be supplied for every level");
+    if (config.initial_accepted_steps.front() != config.initial_epoch)
+      throw std::invalid_argument(
+          "coarse accepted-step count must equal the hierarchy epoch");
+    for (std::size_t level = 1; level < level_configs_.size(); ++level) {
+      const auto coarse_steps = config.initial_accepted_steps[level - 1];
+      if (coarse_steps > std::numeric_limits<std::uint64_t>::max() / 2 ||
+          config.initial_accepted_steps[level] != 2 * coarse_steps)
+        throw std::invalid_argument(
+            "recovered accepted-step counts must follow factor-two refinement");
+    }
+  }
+
+  expected_dense_capabilities_.reserve(level_configs_.size());
+  active_dense_.resize(level_configs_.size());
+  clocks_.reserve(level_configs_.size());
+
+  hierarchy_time_t level_dt{1};
+  for (std::size_t level = 0; level < level_configs_.size(); ++level) {
+    const auto &level_config = level_configs_[level];
+    if (!known_method(level_config.method))
+      throw std::invalid_argument("hierarchy level uses an unsupported method");
+    if (zero_fingerprint(level_config.tableau_fingerprint))
+      throw std::invalid_argument(
+          "hierarchy level tableau fingerprint must be non-zero");
+
+    try {
+      const auto provider = dense_registry.require(
+          level_config.method, level_config.tableau_fingerprint);
+      const auto expected = canonical_capability(
+          level_config.method, level_config.tableau_fingerprint);
+      if (!same_capability(provider->capability(), expected))
+        throw std::invalid_argument(
+            "dense capability does not match the fixed method contract");
+      expected_dense_capabilities_.push_back(expected);
+    } catch (const std::out_of_range &) {
+      throw std::invalid_argument(
+          "no verified dense capability matches a hierarchy level");
+    }
+
+    const auto accepted_steps = config.initial_accepted_steps.empty()
+                                    ? std::uint64_t{0}
+                                    : config.initial_accepted_steps[level];
+    clocks_.push_back(LevelClock{initial_clock_, level_dt, accepted_steps});
+    level_dt /= 2;
+  }
+}
+
+HierarchyAdvanceResult
+HierarchyStepper::advance_one_epoch(HierarchyEvolutionAdapter &adapter) {
+  if (in_progress_ || faulted_)
+    throw std::logic_error("cannot advance an active or faulted hierarchy");
+  if (!clocks_aligned() || !no_dense_in_flight())
+    throw std::logic_error("cannot advance a desynchronized hierarchy");
+  if (epoch_ == std::numeric_limits<std::uint64_t>::max())
+    throw std::overflow_error("hierarchy epoch counter exhausted");
+  preflight_epoch_capacity();
+
+  in_progress_ = true;
+  try {
+    advance_level(0, adapter);
+    if (!clocks_aligned() || !no_dense_in_flight())
+      throw std::logic_error("hierarchy did not synchronize after an epoch");
+
+    const auto synchronized_time = clocks_.front().time;
+    const auto synchronized_physical_time = physical_time(synchronized_time);
+    const auto completed_epoch = epoch_ + 1;
+    const auto stop_requested =
+        stop_requested_.exchange(false, std::memory_order_acq_rel);
+    stop_snapshot_in_flight_.store(stop_requested, std::memory_order_release);
+    try {
+      adapter.run_sync_observers(synchronized_time,
+                                 synchronized_physical_time, completed_epoch,
+                                 stop_requested);
+    } catch (...) {
+      if (stop_requested)
+        stop_requested_.store(true, std::memory_order_release);
+      stop_snapshot_in_flight_.store(false, std::memory_order_release);
+      throw;
+    }
+    stop_snapshot_in_flight_.store(false, std::memory_order_release);
+    epoch_ = completed_epoch;
+
+    in_progress_ = false;
+    return HierarchyAdvanceResult{synchronized_time,
+                                  synchronized_physical_time, epoch_,
+                                  stop_requested};
+  } catch (...) {
+    for (auto &interval : active_dense_)
+      interval.reset();
+    faulted_ = true;
+    in_progress_ = false;
+    throw;
+  }
+}
+
+void HierarchyStepper::request_stop_at_next_sync() noexcept {
+  stop_requested_.store(true, std::memory_order_release);
+}
+
+bool HierarchyStepper::stop_pending() const noexcept {
+  return stop_requested_.load(std::memory_order_acquire) ||
+         stop_snapshot_in_flight_.load(std::memory_order_acquire);
+}
+
+bool HierarchyStepper::hierarchy_synchronized() const noexcept {
+  return !in_progress_ && !faulted_ && clocks_aligned() &&
+         no_dense_in_flight();
+}
+
+std::uint64_t HierarchyStepper::epoch() const noexcept { return epoch_; }
+
+const std::vector<LevelClock> &HierarchyStepper::clocks() const noexcept {
+  return clocks_;
+}
+
+bool HierarchyStepper::clocks_aligned() const noexcept {
+  if (clocks_.empty())
+    return false;
+  const auto synchronized_time = clocks_.front().time;
+  return std::all_of(clocks_.begin(), clocks_.end(),
+                     [&](const LevelClock &clock) {
+                       return clock.time == synchronized_time;
+                     });
+}
+
+bool HierarchyStepper::no_dense_in_flight() const noexcept {
+  return std::all_of(active_dense_.begin(), active_dense_.end(),
+                     [](const auto &interval) { return interval == nullptr; });
+}
+
+void HierarchyStepper::preflight_epoch_capacity() const {
+  std::uint64_t accepted_step_increment = 1;
+  const auto coarse_dt = clocks_.front().dt;
+  for (std::size_t level = 0; level < clocks_.size(); ++level) {
+    const auto &clock = clocks_[level];
+    if (clock.accepted_steps >
+        std::numeric_limits<std::uint64_t>::max() - accepted_step_increment)
+      throw std::overflow_error(
+          "level accepted-step counter cannot cover the next epoch");
+
+    static_cast<void>(checked_clock_add(clock.time, clock.dt));
+    static_cast<void>(checked_clock_add(clock.time, coarse_dt));
+
+    if (level + 1 < clocks_.size()) {
+      if (accepted_step_increment >
+          std::numeric_limits<std::uint64_t>::max() / 2)
+        throw std::overflow_error(
+            "hierarchy depth exceeds accepted-step counter capacity");
+      accepted_step_increment *= 2;
+    }
+  }
+}
+
+double HierarchyStepper::physical_time(const hierarchy_time_t clock) const {
+  const double result =
+      initial_physical_time_ +
+      static_cast<double>(clock - initial_clock_) * coarse_dt_;
+  if (!std::isfinite(result))
+    throw std::overflow_error("hierarchy physical time is not finite");
+  return result;
+}
+
+void HierarchyStepper::validate_dense_interval(
+    const int level, const StepContext &context,
+    const DenseInterval &interval) const {
+  const auto index = static_cast<std::size_t>(level);
+  const auto &expected_capability = expected_dense_capabilities_[index];
+  const auto &id = interval.id();
+  if (id.level != level || id.begin_clock != context.begin_clock ||
+      id.end_clock != context.end_clock ||
+      id.begin_time != context.begin_time || id.end_time != context.end_time ||
+      id.method != context.method ||
+      id.tableau_fingerprint !=
+          level_configs_[index].tableau_fingerprint)
+    throw std::logic_error(
+        "published dense interval does not match the accepted level step");
+  if (!same_capability(interval.capability(), expected_capability))
+    throw std::logic_error(
+        "published dense interval capability differs from preflight");
+}
+
+void HierarchyStepper::advance_level(const int level,
+                                     HierarchyEvolutionAdapter &adapter) {
+  if (level < 0 || static_cast<std::size_t>(level) >= clocks_.size())
+    throw std::logic_error("invalid hierarchy level");
+
+  const auto index = static_cast<std::size_t>(level);
+  auto &clock = clocks_[index];
+  const auto begin = clock.time;
+  const auto end = checked_clock_add(begin, clock.dt);
+  const bool require_dense = index + 1 < clocks_.size();
+
+  if (require_dense && clocks_[index + 1].time != begin)
+    throw std::logic_error("child clock is not aligned with its parent");
+
+  std::shared_ptr<const DenseInterval> parent_dense;
+  if (level > 0) {
+    parent_dense = active_dense_[index - 1];
+    if (parent_dense == nullptr)
+      throw std::logic_error("fine level has no retained parent dense interval");
+  }
+
+  const StepContext context{level,
+                            begin,
+                            end,
+                            physical_time(begin),
+                            physical_time(end),
+                            level_configs_[index].method,
+                            require_dense,
+                            clock.accepted_steps + 1};
+  HierarchyStagePreparer stage_preparer(adapter, context,
+                                        std::move(parent_dense));
+
+  auto session = adapter.begin_level_step(context, require_dense);
+  auto *const transaction =
+      session == nullptr ? nullptr : session->transaction();
+  if (transaction == nullptr)
+    throw std::logic_error(
+        "level-step session must own a scratch-state transaction");
+
+  LevelAdvanceResult result;
+  {
+    ScopedStepContext scope(context, stage_preparer, transaction);
+    result = session->advance();
+  }
+
+  if (require_dense) {
+    if (result.dense_interval == nullptr)
+      throw std::logic_error("parent level did not publish dense state");
+    validate_dense_interval(level, context, *result.dense_interval);
+  } else if (result.dense_interval != nullptr) {
+    throw std::logic_error("leaf level unexpectedly published dense state");
+  }
+  session->commit();
+
+  clock.time = end;
+  if (clock.accepted_steps == std::numeric_limits<std::uint64_t>::max())
+    throw std::overflow_error("level accepted-step counter exhausted");
+  ++clock.accepted_steps;
+  session.reset();
+
+  if (!require_dense)
+    return;
+
+  active_dense_[index] = std::move(result.dense_interval);
+  try {
+    advance_level(level + 1, adapter);
+    advance_level(level + 1, adapter);
+    if (clocks_[index + 1].time != end)
+      throw std::logic_error("child clock did not catch up with its parent");
+
+    const SynchronizationScope synchronization_scope(adapter, level, level + 1,
+                                                     end);
+    adapter.synchronize_levels(level, level + 1, end);
+  } catch (...) {
+    active_dense_[index].reset();
+    throw;
+  }
+  active_dense_[index].reset();
+}
+
+} // namespace CarpetX

--- a/CarpetX/src/hierarchy_stepper.hxx
+++ b/CarpetX/src/hierarchy_stepper.hxx
@@ -1,0 +1,114 @@
+#ifndef CARPETX_HIERARCHY_STEPPER_HXX
+#define CARPETX_HIERARCHY_STEPPER_HXX
+
+#include "subcycling_dense_output.hxx"
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace CarpetX {
+
+using hierarchy_time_t = step_clock_t;
+
+struct LevelClock {
+  hierarchy_time_t time{0};
+  hierarchy_time_t dt{1};
+  std::uint64_t accepted_steps{0};
+};
+
+struct LevelAdvanceConfig {
+  SubcyclingODEMethod method;
+  TableauFingerprint tableau_fingerprint;
+};
+
+struct HierarchyStepperConfig {
+  std::vector<LevelAdvanceConfig> levels;
+  hierarchy_time_t initial_clock{0};
+  double initial_physical_time{0.0};
+  double coarse_dt{1.0};
+  int refinement_ratio{2};
+  std::uint64_t initial_epoch{0};
+  std::vector<std::uint64_t> initial_accepted_steps;
+};
+
+struct LevelAdvanceResult {
+  std::shared_ptr<const DenseInterval> dense_interval;
+};
+
+struct HierarchyAdvanceResult {
+  hierarchy_time_t synchronized_time{0};
+  double synchronized_physical_time{0.0};
+  std::uint64_t epoch{0};
+  bool stop_requested{false};
+};
+
+class LevelStepSession {
+public:
+  virtual ~LevelStepSession() = default;
+  virtual ScratchStateTransaction *transaction() noexcept = 0;
+  virtual LevelAdvanceResult advance() = 0;
+  virtual void commit() = 0;
+};
+
+class HierarchyEvolutionAdapter {
+public:
+  virtual ~HierarchyEvolutionAdapter() = default;
+
+  virtual std::unique_ptr<LevelStepSession>
+  begin_level_step(const StepContext &context, bool require_dense) = 0;
+  virtual void prepare_stage(const StepContext &context,
+                             const StagePoint &stage_point,
+                             const DenseInterval *parent_dense) = 0;
+
+  virtual void begin_synchronization(int coarse_level, int fine_level,
+                                     hierarchy_time_t time) = 0;
+  virtual void synchronize_levels(int coarse_level, int fine_level,
+                                  hierarchy_time_t time) = 0;
+  virtual void end_synchronization(int coarse_level, int fine_level,
+                                   hierarchy_time_t time) noexcept = 0;
+
+  virtual void run_sync_observers(hierarchy_time_t time, double physical_time,
+                                  std::uint64_t completed_epoch,
+                                  bool stop_requested) = 0;
+};
+
+class HierarchyStepper {
+public:
+  HierarchyStepper(HierarchyStepperConfig config,
+                   const DenseOutputRegistry &dense_registry);
+
+  HierarchyAdvanceResult advance_one_epoch(HierarchyEvolutionAdapter &adapter);
+  void request_stop_at_next_sync() noexcept;
+  bool stop_pending() const noexcept;
+  bool hierarchy_synchronized() const noexcept;
+  std::uint64_t epoch() const noexcept;
+  const std::vector<LevelClock> &clocks() const noexcept;
+
+private:
+  void advance_level(int level, HierarchyEvolutionAdapter &adapter);
+  bool clocks_aligned() const noexcept;
+  bool no_dense_in_flight() const noexcept;
+  void preflight_epoch_capacity() const;
+  double physical_time(hierarchy_time_t clock) const;
+  void validate_dense_interval(int level, const StepContext &context,
+                               const DenseInterval &interval) const;
+
+  std::vector<LevelAdvanceConfig> level_configs_;
+  std::vector<LevelClock> clocks_;
+  std::vector<DenseCapability> expected_dense_capabilities_;
+  std::vector<std::shared_ptr<const DenseInterval>> active_dense_;
+  hierarchy_time_t initial_clock_{0};
+  double initial_physical_time_{0.0};
+  double coarse_dt_{1.0};
+  bool in_progress_{false};
+  bool faulted_{false};
+  std::atomic_bool stop_requested_{false};
+  std::atomic_bool stop_snapshot_in_flight_{false};
+  std::uint64_t epoch_{0};
+};
+
+} // namespace CarpetX
+
+#endif // CARPETX_HIERARCHY_STEPPER_HXX

--- a/CarpetX/src/make.code.defn
+++ b/CarpetX/src/make.code.defn
@@ -31,6 +31,8 @@ SRCS =							\
 	boundaries_impl_pos_pos_pos.cxx			\
 	driver.cxx					\
 	fillpatch.cxx					\
+	hierarchy_stepper.cxx				\
+	transaction_level_step_session.cxx		\
 	interpolate.cxx					\
 	io.cxx						\
 	io_adios2.cxx					\
@@ -54,6 +56,19 @@ SRCS =							\
 	prolongate_3d_rf2_impl_poly_eno3lfb.cxx		\
 	reduction.cxx					\
 	schedule.cxx					\
+	subcycling_dense_control_builder.cxx		\
+	subcycling_dense_output.cxx			\
+	subcycling_dense_mfab_state.cxx			\
+	subcycling_dense_stencil.cxx			\
+	subcycling_method_contract.cxx			\
+	subcycling_native_gate.cxx			\
+	subcycling_scratch_state.cxx			\
+	subcycling_scratch_adapter.cxx			\
+	subcycling_scratch_local_gh.cxx			\
+	subcycling_schedule_certification.cxx		\
+	subcycling_scratch_schedule_executor.cxx	\
+	subcycling_scratch_state_transaction.cxx	\
+	subcycling_step_context.cxx			\
 	task_manager.cxx				\
 	timer.cxx					\
 	valid.cxx

--- a/CarpetX/src/make.code.defn
+++ b/CarpetX/src/make.code.defn
@@ -62,12 +62,16 @@ SRCS =							\
 	subcycling_dense_stencil.cxx			\
 	subcycling_method_contract.cxx			\
 	subcycling_native_gate.cxx			\
+	subcycling_runtime_clock.cxx			\
 	subcycling_scratch_state.cxx			\
 	subcycling_scratch_adapter.cxx			\
 	subcycling_scratch_local_gh.cxx			\
 	subcycling_schedule_certification.cxx		\
 	subcycling_scratch_schedule_executor.cxx	\
 	subcycling_scratch_state_transaction.cxx	\
+	subcycling_stage_spatial_preparer.cxx		\
+	subcycling_stage_spatial_preparer_native.cxx	\
+	subcycling_static_v1_top_adapter.cxx		\
 	subcycling_step_context.cxx			\
 	task_manager.cxx				\
 	timer.cxx					\

--- a/CarpetX/src/schedule.cxx
+++ b/CarpetX/src/schedule.cxx
@@ -1260,6 +1260,11 @@ int Initialise(tFleshConfig *config) {
 
       active_levels = std::optional<active_levels_t>();
 
+      if (should_stop_static_v1_initial_regrid_loop(
+              use_subcycling_wip, ghext->num_patches(), max_num_levels,
+              ghext->num_levels()))
+        break;
+
       // Regrid
       bool did_modify_any_level;
       {

--- a/CarpetX/src/schedule.cxx
+++ b/CarpetX/src/schedule.cxx
@@ -4,6 +4,7 @@
 #include "loop.hxx"
 #include "schedule.hxx"
 #include "subcycling_schedule_state.hxx"
+#include "subcycling_static_v1_top_adapter.hxx"
 #include "task_manager.hxx"
 #include "timer.hxx"
 #include "valid.hxx"
@@ -39,6 +40,7 @@ static inline int omp_in_parallel() { return 0; }
 #include <map>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -897,6 +899,10 @@ void update_cctkGHs(cGH *restrict const cctkGH) {
   }
 }
 
+void ScheduleInternal::propagate_root_runtime_metadata(cGH &root) noexcept {
+  update_cctkGHs(&root);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 extern "C" void CarpetX_GetLoopBoxAll(const void *restrict const cctkGH_,
@@ -1430,6 +1436,11 @@ bool EvolutionIsDone(cGH *restrict const cctkGH) {
   return we_are_done;
 }
 
+bool ScheduleInternal::evolution_is_done_at_sync(
+    cGH *restrict const cctkGH) {
+  return EvolutionIsDone(cctkGH);
+}
+
 void InvalidateTimelevels(cGH *restrict const cctkGH) {
   DECLARE_CCTK_PARAMETERS;
 
@@ -1616,9 +1627,32 @@ void CycleTimelevels(cGH *restrict const cctkGH) {
                        ScheduleInternal::TimelevelDomain::legacy_all);
 }
 
+void ScheduleInternal::cycle_active_level_grid_function_timelevels(
+    cGH *restrict const cctkGH) {
+  static Timer timer("CycleActiveLevelGridFunctionTimelevels");
+  Interval interval(timer);
+  if (!active_levels)
+    throw std::logic_error(
+        "active-level GF timelevel rotation requires an active level scope");
+  CycleTimelevelGroups(
+      cctkGH, ScheduleInternal::TimelevelDomain::level_grid_functions);
+}
+
+void ScheduleInternal::cycle_synchronized_global_timelevels(
+    cGH *restrict const cctkGH) {
+  static Timer timer("CycleSynchronizedGlobalTimelevels");
+  Interval interval(timer);
+  CycleTimelevelGroups(cctkGH,
+                       ScheduleInternal::TimelevelDomain::synchronized_globals);
+}
+
 // Schedule evolution
 int Evolve(tFleshConfig *config) {
   DECLARE_CCTK_PARAMETERS;
+
+  if (select_static_v1_evolve_path(use_subcycling_wip) ==
+      StaticV1EvolvePath::static_v1)
+    return EvolveStaticV1(config);
 
   static Timer timer("Evolve");
   Interval interval(timer);
@@ -2874,6 +2908,29 @@ void Restrict(const cGH *cctkGH, int level) {
     }
   }
   Restrict(cctkGH, level, groups);
+}
+
+void ScheduleInternal::restrict_and_sync_static_v1_evolved_groups(
+    cGH *const cctkGH,
+    const std::vector<int> &restricted_evolved_groups) {
+  if (cctkGH == nullptr || !in_global_mode(cctkGH))
+    throw std::invalid_argument(
+        "static-v1 restriction requires the root GH in global mode");
+  // Child evolution may have launched asynchronous device work. The static-v1
+  // synchronization point owns the wait before touching either level.
+  synchronize();
+  Restrict(cctkGH, 0, restricted_evolved_groups);
+
+  ScopedActiveLevels<active_levels_t> coarse_scope(
+      active_levels, active_levels_t(0, 1, 0, 1));
+  if (!restricted_evolved_groups.empty()) {
+    const int status = SyncGroupsByDirI(
+        cctkGH, static_cast<int>(restricted_evolved_groups.size()),
+        restricted_evolved_groups.data(), nullptr);
+    if (status != static_cast<int>(restricted_evolved_groups.size()))
+      throw std::runtime_error(
+          "static-v1 coarse evolved-group synchronization failed");
+  }
 }
 
 // storage handling

--- a/CarpetX/src/schedule.cxx
+++ b/CarpetX/src/schedule.cxx
@@ -3,6 +3,7 @@
 #include "io.hxx"
 #include "loop.hxx"
 #include "schedule.hxx"
+#include "subcycling_schedule_state.hxx"
 #include "task_manager.hxx"
 #include "timer.hxx"
 #include "valid.hxx"
@@ -491,9 +492,7 @@ void setup_cctkGH(cGH *restrict cctkGH) {
 void update_cctkGH(cGH *const cctkGH, const cGH *const sourceGH) {
   if (cctkGH == sourceGH)
     return;
-  cctkGH->cctk_iteration = sourceGH->cctk_iteration;
-  cctkGH->cctk_time = sourceGH->cctk_time;
-  cctkGH->cctk_delta_time = sourceGH->cctk_delta_time;
+  ScheduleInternal::copy_level_time_metadata(*cctkGH, *sourceGH);
   // for (int d = 0; d < dim; ++d)
   //   cctkGH->cctk_origin_space[d] = sourceGH->cctk_origin_space[d];
   // for (int d = 0; d < dim; ++d)
@@ -1492,9 +1491,120 @@ void InvalidateTimelevels(cGH *restrict const cctkGH) {
   } // for gi
 }
 
-void CycleTimelevels(cGH *restrict const cctkGH) {
+namespace {
+
+void CycleGFTimelevelGroup(const int gi, const bool presync_only,
+                           std::vector<int> &presync_groups) {
+  const auto &patchdata0 = ghext->patchdata.at(0);
+  const auto &leveldata0 = patchdata0.leveldata.at(0);
+  const auto &groupdata0 = *leveldata0.groupdata.at(gi);
+  const int ntls0 = groupdata0.mfab.size();
+  const nan_handling_t nan_handling = groupdata0.do_checkpoint
+                                          ? nan_handling_t::forbid_nans
+                                          : nan_handling_t::allow_nans;
+
+  assert(active_levels);
+  active_levels->loop_serially([&](auto &restrict leveldata) {
+    auto &restrict groupdata = *leveldata.groupdata.at(gi);
+    const int ntls = groupdata.mfab.size();
+    assert(ntls == ntls0);
+    // Rotate time levels and invalidate current time level
+    if (ntls > 1) {
+      rotate(groupdata.mfab.begin(), groupdata.mfab.end() - 1,
+             groupdata.mfab.end());
+      rotate(groupdata.valid.begin(), groupdata.valid.end() - 1,
+             groupdata.valid.end());
+      for (int vi = 0; vi < groupdata.numvars; ++vi)
+        groupdata.valid.at(0).at(vi).set_all(valid_t(), []() {
+          return "CycletimeLevels (invalidate current time level)";
+        });
+    }
+    // All time levels (except the current) must be valid everywhere for
+    // checkpointed groups
+    if (groupdata.do_checkpoint) {
+      for (int tl = (ntls == 1 ? 0 : 1); tl < ntls; ++tl) {
+        // it is only possible to sync time-level zero
+        if (tl == 0 && presync_only) {
+          presync_groups.push_back(gi);
+        } else {
+          for (int vi = 0; vi < groupdata.numvars; ++vi) {
+            error_if_invalid(groupdata, vi, tl, make_valid_all(), []() {
+              return "CycleTimelevels for the state vector";
+            });
+          }
+        }
+      }
+    }
+  });
+  for (int vi = 0; vi < groupdata0.numvars; ++vi) {
+    if (ntls0 > 1)
+      poison_invalid_gf(*active_levels, gi, vi, 0);
+    for (int tl = 0; tl < ntls0; ++tl)
+      check_valid_gf(*active_levels, gi, vi, tl, nan_handling,
+                     []() { return "CycleTimelevels"; });
+  }
+}
+
+void CycleGlobalTimelevelGroup(const int gi) {
+  auto &restrict globaldata = ghext->globaldata;
+  auto &restrict arraygroupdata = *globaldata.arraygroupdata.at(gi);
+  const nan_handling_t nan_handling = arraygroupdata.do_checkpoint
+                                          ? nan_handling_t::forbid_nans
+                                          : nan_handling_t::allow_nans;
+  const int ntls = arraygroupdata.data.size();
+  // Rotate time levels and invalidate current time level
+  if (ntls > 1) {
+    rotate(arraygroupdata.data.begin(), arraygroupdata.data.end() - 1,
+           arraygroupdata.data.end());
+    rotate(arraygroupdata.valid.begin(), arraygroupdata.valid.end() - 1,
+           arraygroupdata.valid.end());
+    for (int vi = 0; vi < arraygroupdata.numvars; ++vi) {
+      arraygroupdata.valid.at(0).at(vi).set_int(false, []() {
+        return "CycletimeLevels (invalidate current time level)";
+      });
+      poison_invalid_ga(gi, vi, 0);
+    }
+  }
+  for (int tl = 0; tl < ntls; ++tl)
+    for (int vi = 0; vi < arraygroupdata.numvars; ++vi)
+      check_valid_ga(gi, vi, tl, nan_handling,
+                     []() { return "CycleTimelevels"; });
+}
+
+// This split is schedule-internal. The legacy domain deliberately dispatches
+// each group immediately in its original group-index order.
+void CycleTimelevelGroups(cGH *restrict const cctkGH,
+                          const ScheduleInternal::TimelevelDomain domain) {
   DECLARE_CCTK_PARAMETERS;
 
+  const bool presync_only = CCTK_EQUALS(presync_mode, "presync-only");
+  std::vector<int> presync_groups;
+  ScheduleInternal::for_each_timelevel_group(
+      CCTK_NumGroups(), domain,
+      [](const int gi) {
+        cGroup group;
+        const int ierr = CCTK_GroupData(gi, &group);
+        assert(!ierr);
+        return group.grouptype == CCTK_GF
+                   ? ScheduleInternal::TimelevelGroupKind::level_grid_function
+                   : ScheduleInternal::TimelevelGroupKind::synchronized_global;
+      },
+      [&](const int gi, const ScheduleInternal::TimelevelGroupKind kind) {
+        if (kind ==
+            ScheduleInternal::TimelevelGroupKind::level_grid_function)
+          CycleGFTimelevelGroup(gi, presync_only, presync_groups);
+        else
+          CycleGlobalTimelevelGroup(gi);
+      });
+
+  if (!presync_groups.empty())
+    SyncGroupsByDirI(cctkGH, presync_groups.size(), presync_groups.data(),
+                     nullptr);
+}
+
+} // namespace
+
+void CycleTimelevels(cGH *restrict const cctkGH) {
   static Timer timer("CycleTimelevels");
   Interval interval(timer);
 
@@ -1502,96 +1612,8 @@ void CycleTimelevels(cGH *restrict const cctkGH) {
   cctkGH->cctk_time += cctkGH->cctk_delta_time;
   update_cctkGHs(cctkGH);
 
-  // TODO: Parallelize over groups
-  const int num_groups = CCTK_NumGroups();
-  const bool presync_only = CCTK_EQUALS(presync_mode, "presync-only");
-  std::vector<int> presync_groups;
-  for (int gi = 0; gi < num_groups; ++gi) {
-    cGroup group;
-    int ierr = CCTK_GroupData(gi, &group);
-    assert(!ierr);
-
-    if (group.grouptype == CCTK_GF) {
-      const auto &patchdata0 = ghext->patchdata.at(0);
-      const auto &leveldata0 = patchdata0.leveldata.at(0);
-      const auto &groupdata0 = *leveldata0.groupdata.at(gi);
-      const int ntls0 = groupdata0.mfab.size();
-      const nan_handling_t nan_handling = groupdata0.do_checkpoint
-                                              ? nan_handling_t::forbid_nans
-                                              : nan_handling_t::allow_nans;
-
-      assert(active_levels);
-      active_levels->loop_serially([&](auto &restrict leveldata) {
-        auto &restrict groupdata = *leveldata.groupdata.at(gi);
-        const int ntls = groupdata.mfab.size();
-        assert(ntls == ntls0);
-        // Rotate time levels and invalidate current time level
-        if (ntls > 1) {
-          rotate(groupdata.mfab.begin(), groupdata.mfab.end() - 1,
-                 groupdata.mfab.end());
-          rotate(groupdata.valid.begin(), groupdata.valid.end() - 1,
-                 groupdata.valid.end());
-          for (int vi = 0; vi < groupdata.numvars; ++vi)
-            groupdata.valid.at(0).at(vi).set_all(valid_t(), []() {
-              return "CycletimeLevels (invalidate current time level)";
-            });
-        }
-        // All time levels (except the current) must be valid everywhere for
-        // checkpointed groups
-        if (groupdata.do_checkpoint) {
-          for (int tl = (ntls == 1 ? 0 : 1); tl < ntls; ++tl) {
-            // it is only possible to sync time-level zero
-            if (tl == 0 && presync_only) {
-              presync_groups.push_back(gi);
-            } else {
-              for (int vi = 0; vi < groupdata.numvars; ++vi) {
-                error_if_invalid(groupdata, vi, tl, make_valid_all(), []() {
-                  return "CycleTimelevels for the state vector";
-                });
-              }
-            }
-          }
-        }
-      });
-      for (int vi = 0; vi < groupdata0.numvars; ++vi) {
-        if (ntls0 > 1)
-          poison_invalid_gf(*active_levels, gi, vi, 0);
-        for (int tl = 0; tl < ntls0; ++tl)
-          check_valid_gf(*active_levels, gi, vi, tl, nan_handling,
-                         []() { return "CycleTimelevels"; });
-      }
-    } else { // CCTK_ARRAY or CCTK_SCALAR
-
-      auto &restrict globaldata = ghext->globaldata;
-      auto &restrict arraygroupdata = *globaldata.arraygroupdata.at(gi);
-      const nan_handling_t nan_handling = arraygroupdata.do_checkpoint
-                                              ? nan_handling_t::forbid_nans
-                                              : nan_handling_t::allow_nans;
-      const int ntls = arraygroupdata.data.size();
-      // Rotate time levels and invalidate current time level
-      if (ntls > 1) {
-        rotate(arraygroupdata.data.begin(), arraygroupdata.data.end() - 1,
-               arraygroupdata.data.end());
-        rotate(arraygroupdata.valid.begin(), arraygroupdata.valid.end() - 1,
-               arraygroupdata.valid.end());
-        for (int vi = 0; vi < arraygroupdata.numvars; ++vi) {
-          arraygroupdata.valid.at(0).at(vi).set_int(false, []() {
-            return "CycletimeLevels (invalidate current time level)";
-          });
-          poison_invalid_ga(gi, vi, 0);
-        }
-      }
-      for (int tl = 0; tl < ntls; ++tl)
-        for (int vi = 0; vi < arraygroupdata.numvars; ++vi)
-          check_valid_ga(gi, vi, tl, nan_handling,
-                         []() { return "CycleTimelevels"; });
-    }
-
-  } // for gi
-  if (!presync_groups.empty()) {
-    SyncGroupsByDirI(cctkGH, presync_groups.size(), presync_groups.data(),
-                     nullptr);
-  }
+  CycleTimelevelGroups(cctkGH,
+                       ScheduleInternal::TimelevelDomain::legacy_all);
 }
 
 // Schedule evolution

--- a/CarpetX/src/schedule.hxx
+++ b/CarpetX/src/schedule.hxx
@@ -92,6 +92,19 @@ public:
 // TODO: Move this into ghext
 extern std::optional<active_levels_t> active_levels;
 
+namespace ScheduleInternal {
+
+// Narrow subcycling hooks around schedule-owned state. They deliberately do
+// not expose the underlying GH inventory or generic timelevel dispatcher.
+void propagate_root_runtime_metadata(cGH &root) noexcept;
+bool evolution_is_done_at_sync(cGH *cctkGH);
+void cycle_active_level_grid_function_timelevels(cGH *cctkGH);
+void cycle_synchronized_global_timelevels(cGH *cctkGH);
+void restrict_and_sync_static_v1_evolved_groups(
+    cGH *cctkGH, const std::vector<int> &restricted_evolved_groups);
+
+} // namespace ScheduleInternal
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // Like an MFIter, but does not support iteration, instead it can be copied

--- a/CarpetX/src/subcycling_dense_control_builder.cxx
+++ b/CarpetX/src/subcycling_dense_control_builder.cxx
@@ -1,0 +1,176 @@
+#include "subcycling_dense_control_builder.hxx"
+
+#include <AMReX_MultiFab.H>
+
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <unordered_set>
+#include <utility>
+
+namespace CarpetX {
+namespace {
+
+struct ValidatedControlMetadata {
+  const DenseStencil *stencil;
+  std::size_t begin_value_sample;
+  std::size_t end_value_sample;
+  std::vector<std::vector<double>> effective_weights;
+};
+
+bool same_constraint(const DenseSampleConstraint &left,
+                     const DenseSampleConstraint &right) noexcept {
+  return left.theta == right.theta && left.kind == right.kind;
+}
+
+ValidatedControlMetadata validate_and_build_metadata(
+    const SubcyclingODEMethod method, const double parent_dt,
+    const std::vector<DenseMFabRawSampleView> &samples) {
+  const auto &stencil = reference_dense_stencil(method);
+  const auto &constraints = stencil.specification().constraints;
+
+  if (!std::isfinite(parent_dt) || !(parent_dt > 0.0))
+    throw std::invalid_argument(
+        "dense MultiFab control parent dt must be finite and positive");
+  if (samples.size() != constraints.size())
+    throw std::invalid_argument(
+        "dense MultiFab control sample count does not match stencil");
+
+  std::unordered_set<const OwnedMultiFabDenseState *> unique_states;
+  unique_states.reserve(samples.size());
+  for (std::size_t index = 0; index < samples.size(); ++index) {
+    if (!same_constraint(samples[index].constraint, constraints[index]))
+      throw std::invalid_argument(
+          "dense MultiFab sample metadata does not match stencil");
+    if (samples[index].state == nullptr)
+      throw std::invalid_argument("dense MultiFab sample state must not be null");
+    if (!unique_states.insert(samples[index].state).second)
+      throw std::invalid_argument("dense MultiFab sample states must be unique");
+  }
+
+  const auto &reference = *samples.front().state;
+  for (const auto &sample : samples) {
+    if (!reference.compatible(*sample.state) ||
+        !sample.state->compatible(reference))
+      throw std::invalid_argument(
+          "dense MultiFab samples must be mutually compatible");
+  }
+
+  std::size_t begin_value_sample = samples.size();
+  std::size_t end_value_sample = samples.size();
+  for (std::size_t index = 0; index < constraints.size(); ++index) {
+    if (constraints[index].kind != DenseSampleKind::value)
+      continue;
+    if (constraints[index].theta == 0.0)
+      begin_value_sample = index;
+    if (constraints[index].theta == 1.0)
+      end_value_sample = index;
+  }
+  if (begin_value_sample == samples.size() ||
+      end_value_sample == samples.size())
+    throw std::logic_error("reference dense stencil lacks endpoint values");
+
+  std::vector<std::vector<double>> effective_weights(
+      stencil.control_count(), std::vector<double>(stencil.sample_count()));
+  for (std::size_t control = 0; control < stencil.control_count(); ++control) {
+    for (std::size_t sample = 0; sample < stencil.sample_count(); ++sample) {
+      double effective = stencil.weight(control, sample);
+      if (constraints[sample].kind == DenseSampleKind::scaled_derivative)
+        effective *= parent_dt;
+      if (!std::isfinite(effective))
+        throw std::invalid_argument(
+            "dense MultiFab effective coefficient is not finite");
+
+      const double representable_lowest = static_cast<double>(
+          std::numeric_limits<amrex::Real>::lowest());
+      const double representable_max =
+          static_cast<double>(std::numeric_limits<amrex::Real>::max());
+      if (effective < representable_lowest || effective > representable_max)
+        throw std::invalid_argument(
+            "dense MultiFab coefficient is outside amrex Real range");
+      const amrex::Real representable = static_cast<amrex::Real>(effective);
+      if (!std::isfinite(representable))
+        throw std::invalid_argument(
+            "dense MultiFab coefficient is not representable by amrex Real");
+      effective_weights[control][sample] =
+          static_cast<double>(representable);
+    }
+  }
+
+  return ValidatedControlMetadata{&stencil, begin_value_sample,
+                                  end_value_sample,
+                                  std::move(effective_weights)};
+}
+
+std::unique_ptr<OwnedMultiFabDenseState>
+copy_control(const OwnedMultiFabDenseState &source) {
+  auto result = OwnedMultiFabDenseState::empty_like(source);
+  result->copy_from(source);
+  return result;
+}
+
+std::unique_ptr<OwnedMultiFabDenseState> combination_control(
+    const std::vector<double> &weights,
+    const std::vector<DenseMFabRawSampleView> &samples) {
+  std::vector<double> nonzero_weights;
+  std::vector<const OwnedMultiFabDenseState *> nonzero_sources;
+  nonzero_weights.reserve(weights.size());
+  nonzero_sources.reserve(weights.size());
+  for (std::size_t index = 0; index < weights.size(); ++index) {
+    if (weights[index] == 0.0)
+      continue;
+    nonzero_weights.push_back(weights[index]);
+    nonzero_sources.push_back(samples[index].state);
+  }
+  if (nonzero_sources.empty())
+    throw std::logic_error("reference dense control has no nonzero weights");
+  return OwnedMultiFabDenseState::linear_combination_of(nonzero_weights,
+                                                         nonzero_sources);
+}
+
+} // namespace
+
+DenseMFabControlSet::DenseMFabControlSet(
+    const SubcyclingODEMethod method, const double parent_dt,
+    std::vector<std::unique_ptr<OwnedMultiFabDenseState>> controls)
+    : method_(method), parent_dt_(parent_dt), controls_(std::move(controls)) {}
+
+SubcyclingODEMethod DenseMFabControlSet::method() const noexcept {
+  return method_;
+}
+
+double DenseMFabControlSet::parent_dt() const noexcept { return parent_dt_; }
+
+std::size_t DenseMFabControlSet::control_count() const noexcept {
+  return controls_.size();
+}
+
+const OwnedMultiFabDenseState &
+DenseMFabControlSet::control(const std::size_t index) const {
+  return *controls_.at(index);
+}
+
+std::vector<std::unique_ptr<OwnedMultiFabDenseState>>
+DenseMFabControlSet::release_controls() && {
+  return std::move(controls_);
+}
+
+DenseMFabControlSet build_reference_dense_controls(
+    const SubcyclingODEMethod method, const double parent_dt,
+    const std::vector<DenseMFabRawSampleView> &samples) {
+  const auto metadata =
+      validate_and_build_metadata(method, parent_dt, samples);
+
+  std::vector<std::unique_ptr<OwnedMultiFabDenseState>> controls;
+  controls.reserve(metadata.stencil->control_count());
+  controls.push_back(copy_control(*samples[metadata.begin_value_sample].state));
+  for (std::size_t control = 1;
+       control + 1 < metadata.stencil->control_count(); ++control) {
+    controls.push_back(
+        combination_control(metadata.effective_weights[control], samples));
+  }
+  controls.push_back(copy_control(*samples[metadata.end_value_sample].state));
+  return DenseMFabControlSet(method, parent_dt, std::move(controls));
+}
+
+} // namespace CarpetX

--- a/CarpetX/src/subcycling_dense_control_builder.hxx
+++ b/CarpetX/src/subcycling_dense_control_builder.hxx
@@ -1,0 +1,53 @@
+#ifndef CARPETX_SUBCYCLING_DENSE_CONTROL_BUILDER_HXX
+#define CARPETX_SUBCYCLING_DENSE_CONTROL_BUILDER_HXX
+
+#include "subcycling_dense_mfab_state.hxx"
+#include "subcycling_dense_stencil.hxx"
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+namespace CarpetX {
+
+struct DenseMFabRawSampleView {
+  DenseSampleConstraint constraint;
+  const OwnedMultiFabDenseState *state;
+};
+
+class DenseMFabControlSet {
+public:
+  SubcyclingODEMethod method() const noexcept;
+  double parent_dt() const noexcept;
+  std::size_t control_count() const noexcept;
+  const OwnedMultiFabDenseState &control(std::size_t index) const;
+
+  std::vector<std::unique_ptr<OwnedMultiFabDenseState>>
+  release_controls() &&;
+
+  DenseMFabControlSet(const DenseMFabControlSet &) = delete;
+  DenseMFabControlSet &operator=(const DenseMFabControlSet &) = delete;
+  DenseMFabControlSet(DenseMFabControlSet &&) noexcept = default;
+  DenseMFabControlSet &operator=(DenseMFabControlSet &&) noexcept = default;
+
+private:
+  friend DenseMFabControlSet build_reference_dense_controls(
+      SubcyclingODEMethod, double,
+      const std::vector<DenseMFabRawSampleView> &);
+
+  DenseMFabControlSet(
+      SubcyclingODEMethod method, double parent_dt,
+      std::vector<std::unique_ptr<OwnedMultiFabDenseState>> controls);
+
+  SubcyclingODEMethod method_;
+  double parent_dt_;
+  std::vector<std::unique_ptr<OwnedMultiFabDenseState>> controls_;
+};
+
+DenseMFabControlSet build_reference_dense_controls(
+    SubcyclingODEMethod method, double parent_dt,
+    const std::vector<DenseMFabRawSampleView> &samples);
+
+} // namespace CarpetX
+
+#endif // CARPETX_SUBCYCLING_DENSE_CONTROL_BUILDER_HXX

--- a/CarpetX/src/subcycling_dense_mfab_state.cxx
+++ b/CarpetX/src/subcycling_dense_mfab_state.cxx
@@ -1,0 +1,236 @@
+#include "subcycling_dense_mfab_state.hxx"
+
+#include <cmath>
+#include <stdexcept>
+#include <tuple>
+#include <utility>
+
+namespace CarpetX {
+namespace {
+
+bool non_negative(const DenseMFabKey &key) noexcept {
+  return key.hierarchy_epoch >= 0 && key.patch >= 0 && key.level >= 0 &&
+         key.group_index >= 0;
+}
+
+auto ordered_key(const DenseMFabKey &key) noexcept {
+  return std::tie(key.hierarchy_epoch, key.patch, key.level, key.group_index);
+}
+
+bool same_key(const DenseMFabKey &left, const DenseMFabKey &right) noexcept {
+  return ordered_key(left) == ordered_key(right);
+}
+
+bool same_layout(const amrex::MultiFab &left,
+                 const amrex::MultiFab &right) noexcept {
+  return left.boxArray() == right.boxArray() &&
+         left.DistributionMap() == right.DistributionMap() &&
+         left.nComp() == right.nComp() &&
+         left.nGrowVect() == right.nGrowVect();
+}
+
+void validate_views(const std::vector<DenseMFabView> &views) {
+  if (views.empty())
+    throw std::invalid_argument("dense MultiFab state requires at least one view");
+
+  const std::int64_t hierarchy_epoch = views.front().key.hierarchy_epoch;
+  for (std::size_t index = 0; index < views.size(); ++index) {
+    const auto &view = views[index];
+    if (view.multifab == nullptr)
+      throw std::invalid_argument("dense MultiFab view must not be null");
+    if (!non_negative(view.key))
+      throw std::invalid_argument("dense MultiFab keys must be non-negative");
+    if (view.key.hierarchy_epoch != hierarchy_epoch)
+      throw std::invalid_argument("dense MultiFab views must share one epoch");
+    if (index != 0 &&
+        !(ordered_key(views[index - 1].key) < ordered_key(view.key)))
+      throw std::invalid_argument(
+          "dense MultiFab keys must be strictly increasing");
+  }
+}
+
+void validate_concrete_combination(
+    const std::vector<double> &weights,
+    const std::vector<const OwnedMultiFabDenseState *> &sources) {
+  if (sources.empty())
+    throw std::invalid_argument(
+        "dense MultiFab combination requires at least one source");
+  if (weights.size() != sources.size())
+    throw std::invalid_argument(
+        "dense MultiFab weight and source counts differ");
+  for (const double weight : weights) {
+    if (!std::isfinite(weight))
+      throw std::invalid_argument(
+          "dense MultiFab combination weights must be finite");
+  }
+  if (sources.front() == nullptr)
+    throw std::invalid_argument("dense MultiFab source must not be null");
+  for (const auto *source : sources) {
+    if (source == nullptr)
+      throw std::invalid_argument("dense MultiFab source must not be null");
+    if (!sources.front()->compatible(*source))
+      throw std::invalid_argument(
+          "dense MultiFab combination sources are incompatible");
+  }
+}
+
+} // namespace
+
+OwnedMultiFabDenseState::OwnedMultiFabDenseState(std::vector<Entry> entries)
+    : entries_(std::move(entries)) {}
+
+std::unique_ptr<OwnedMultiFabDenseState>
+OwnedMultiFabDenseState::copy_of(const std::vector<DenseMFabView> &views) {
+  validate_views(views);
+
+  std::vector<Entry> entries;
+  entries.reserve(views.size());
+  for (const auto &view : views) {
+    auto owned = std::make_unique<amrex::MultiFab>(
+        view.multifab->boxArray(), view.multifab->DistributionMap(),
+        view.multifab->nComp(), view.multifab->nGrowVect());
+    amrex::MultiFab::Copy(*owned, *view.multifab, 0, 0,
+                          view.multifab->nComp(), 0);
+    entries.push_back(Entry{view.key, std::move(owned)});
+  }
+  return std::unique_ptr<OwnedMultiFabDenseState>(
+      new OwnedMultiFabDenseState(std::move(entries)));
+}
+
+std::unique_ptr<OwnedMultiFabDenseState>
+OwnedMultiFabDenseState::allocate_like(
+    const std::vector<DenseMFabView> &views) {
+  validate_views(views);
+
+  std::vector<Entry> entries;
+  entries.reserve(views.size());
+  for (const auto &view : views) {
+    auto owned = std::make_unique<amrex::MultiFab>(
+        view.multifab->boxArray(), view.multifab->DistributionMap(),
+        view.multifab->nComp(), view.multifab->nGrowVect());
+    entries.push_back(Entry{view.key, std::move(owned)});
+  }
+  return std::unique_ptr<OwnedMultiFabDenseState>(
+      new OwnedMultiFabDenseState(std::move(entries)));
+}
+
+std::unique_ptr<OwnedMultiFabDenseState>
+OwnedMultiFabDenseState::empty_like(const OwnedMultiFabDenseState &source) {
+  std::vector<Entry> entries;
+  entries.reserve(source.entries_.size());
+  for (const auto &source_entry : source.entries_) {
+    const auto &source_mfab = *source_entry.multifab;
+    auto owned = std::make_unique<amrex::MultiFab>(
+        source_mfab.boxArray(), source_mfab.DistributionMap(),
+        source_mfab.nComp(), source_mfab.nGrowVect());
+    entries.push_back(Entry{source_entry.key, std::move(owned)});
+  }
+  return std::unique_ptr<OwnedMultiFabDenseState>(
+      new OwnedMultiFabDenseState(std::move(entries)));
+}
+
+std::unique_ptr<OwnedMultiFabDenseState>
+OwnedMultiFabDenseState::linear_combination_of(
+    const std::vector<double> &weights,
+    const std::vector<const OwnedMultiFabDenseState *> &sources) {
+  validate_concrete_combination(weights, sources);
+
+  auto result = empty_like(*sources.front());
+  std::vector<const DenseStateVector *> base_sources;
+  base_sources.reserve(sources.size());
+  for (const auto *source : sources)
+    base_sources.push_back(source);
+  result->linear_combination(weights, base_sources);
+  return result;
+}
+
+std::size_t OwnedMultiFabDenseState::entry_count() const noexcept {
+  return entries_.size();
+}
+
+const DenseMFabKey &
+OwnedMultiFabDenseState::key(const std::size_t index) const {
+  return entries_.at(index).key;
+}
+
+const amrex::MultiFab &
+OwnedMultiFabDenseState::multifab(const std::size_t index) const {
+  return *entries_.at(index).multifab;
+}
+
+bool OwnedMultiFabDenseState::compatible(
+    const DenseStateVector &other) const noexcept {
+  const auto *typed = dynamic_cast<const OwnedMultiFabDenseState *>(&other);
+  if (typed == nullptr || entries_.size() != typed->entries_.size())
+    return false;
+  for (std::size_t index = 0; index < entries_.size(); ++index) {
+    if (!same_key(entries_[index].key, typed->entries_[index].key) ||
+        !same_layout(*entries_[index].multifab,
+                     *typed->entries_[index].multifab))
+      return false;
+  }
+  return true;
+}
+
+void OwnedMultiFabDenseState::copy_from(const DenseStateVector &other) {
+  const auto *typed = dynamic_cast<const OwnedMultiFabDenseState *>(&other);
+  if (typed == nullptr)
+    throw std::invalid_argument("dense MultiFab copy source has wrong type");
+  if (typed == this)
+    throw std::invalid_argument("dense MultiFab copy rejects aliasing");
+  if (!compatible(*typed))
+    throw std::invalid_argument("dense MultiFab copy source is incompatible");
+
+  for (std::size_t index = 0; index < entries_.size(); ++index) {
+    auto &destination = *entries_[index].multifab;
+    const auto &source = *typed->entries_[index].multifab;
+    amrex::MultiFab::Copy(destination, source, 0, 0,
+                          destination.nComp(), 0);
+  }
+}
+
+void OwnedMultiFabDenseState::linear_combination(
+    const std::vector<double> &weights,
+    const std::vector<const DenseStateVector *> &sources) {
+  if (sources.empty())
+    throw std::invalid_argument(
+        "dense MultiFab combination requires at least one source");
+  if (weights.size() != sources.size())
+    throw std::invalid_argument(
+        "dense MultiFab weight and source counts differ");
+  for (const double weight : weights) {
+    if (!std::isfinite(weight))
+      throw std::invalid_argument(
+          "dense MultiFab combination weights must be finite");
+  }
+
+  std::vector<const OwnedMultiFabDenseState *> typed_sources;
+  typed_sources.reserve(sources.size());
+  for (const auto *source : sources) {
+    if (source == nullptr)
+      throw std::invalid_argument("dense MultiFab source must not be null");
+    if (source == this)
+      throw std::invalid_argument(
+          "dense MultiFab combination rejects destination aliasing");
+    const auto *typed =
+        dynamic_cast<const OwnedMultiFabDenseState *>(source);
+    if (typed == nullptr)
+      throw std::invalid_argument("dense MultiFab source has wrong type");
+    if (!compatible(*typed))
+      throw std::invalid_argument("dense MultiFab source is incompatible");
+    typed_sources.push_back(typed);
+  }
+
+  for (std::size_t entry = 0; entry < entries_.size(); ++entry) {
+    auto &destination = *entries_[entry].multifab;
+    destination.setVal(0.0, 0, destination.nComp(), 0);
+    for (std::size_t source = 0; source < typed_sources.size(); ++source) {
+      amrex::MultiFab::Saxpy(
+          destination, weights[source],
+          *typed_sources[source]->entries_[entry].multifab, 0, 0,
+          destination.nComp(), 0);
+    }
+  }
+}
+
+} // namespace CarpetX

--- a/CarpetX/src/subcycling_dense_mfab_state.hxx
+++ b/CarpetX/src/subcycling_dense_mfab_state.hxx
@@ -1,0 +1,72 @@
+#ifndef CARPETX_SUBCYCLING_DENSE_MFAB_STATE_HXX
+#define CARPETX_SUBCYCLING_DENSE_MFAB_STATE_HXX
+
+#include "subcycling_dense_output.hxx"
+
+#include <AMReX_MultiFab.H>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace CarpetX {
+
+struct DenseMFabKey {
+  std::int64_t hierarchy_epoch;
+  int patch;
+  int level;
+  int group_index;
+};
+
+struct DenseMFabView {
+  DenseMFabKey key;
+  const amrex::MultiFab *multifab;
+};
+
+class OwnedMultiFabDenseState final : public DenseStateVector {
+public:
+  ~OwnedMultiFabDenseState() override = default;
+
+  OwnedMultiFabDenseState(const OwnedMultiFabDenseState &) = delete;
+  OwnedMultiFabDenseState &operator=(const OwnedMultiFabDenseState &) = delete;
+  OwnedMultiFabDenseState(OwnedMultiFabDenseState &&) = delete;
+  OwnedMultiFabDenseState &operator=(OwnedMultiFabDenseState &&) = delete;
+
+  static std::unique_ptr<OwnedMultiFabDenseState>
+  copy_of(const std::vector<DenseMFabView> &views);
+
+  static std::unique_ptr<OwnedMultiFabDenseState>
+  allocate_like(const std::vector<DenseMFabView> &views);
+
+  static std::unique_ptr<OwnedMultiFabDenseState>
+  empty_like(const OwnedMultiFabDenseState &source);
+
+  static std::unique_ptr<OwnedMultiFabDenseState> linear_combination_of(
+      const std::vector<double> &weights,
+      const std::vector<const OwnedMultiFabDenseState *> &sources);
+
+  std::size_t entry_count() const noexcept;
+  const DenseMFabKey &key(std::size_t index) const;
+  const amrex::MultiFab &multifab(std::size_t index) const;
+
+  bool compatible(const DenseStateVector &other) const noexcept override;
+  void copy_from(const DenseStateVector &other) override;
+  void linear_combination(
+      const std::vector<double> &weights,
+      const std::vector<const DenseStateVector *> &sources) override;
+
+private:
+  struct Entry {
+    DenseMFabKey key;
+    std::unique_ptr<amrex::MultiFab> multifab;
+  };
+
+  explicit OwnedMultiFabDenseState(std::vector<Entry> entries);
+
+  std::vector<Entry> entries_;
+};
+
+} // namespace CarpetX
+
+#endif // CARPETX_SUBCYCLING_DENSE_MFAB_STATE_HXX

--- a/CarpetX/src/subcycling_dense_output.cxx
+++ b/CarpetX/src/subcycling_dense_output.cxx
@@ -1,0 +1,253 @@
+#include "subcycling_dense_output.hxx"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <utility>
+
+namespace CarpetX {
+namespace {
+
+bool known_method(const SubcyclingODEMethod method) noexcept {
+  switch (method) {
+  case SubcyclingODEMethod::rk4:
+  case SubcyclingODEMethod::rkf78_order7:
+  case SubcyclingODEMethod::dp87_order8:
+    return true;
+  }
+  return false;
+}
+
+bool zero_fingerprint(const TableauFingerprint &fingerprint) noexcept {
+  return std::all_of(fingerprint.begin(), fingerprint.end(),
+                     [](const std::uint8_t value) { return value == 0; });
+}
+
+void validate_capability(const DenseCapability &capability) {
+  if (!known_method(capability.method))
+    throw std::invalid_argument("dense provider has an unknown ODE method");
+  if (zero_fingerprint(capability.tableau_fingerprint))
+    throw std::invalid_argument("dense provider fingerprint must be non-zero");
+  if (capability.endpoint_order <= 0 || capability.dense_uniform_order <= 0)
+    throw std::invalid_argument("dense provider orders must be positive");
+  if (capability.dense_uniform_order < capability.endpoint_order)
+    throw std::invalid_argument(
+        "dense uniform order must not be below endpoint order");
+  if (capability.stage_count <= 0 || capability.extra_rhs_evaluations < 0)
+    throw std::invalid_argument("dense provider cost must be non-negative");
+  if (capability.persistent_vector_count <= 0 ||
+      static_cast<long long>(capability.persistent_vector_count) !=
+          static_cast<long long>(capability.dense_uniform_order) + 1LL)
+    throw std::invalid_argument(
+        "dense provider must own one Bernstein control per polynomial degree");
+  if (!capability.arbitrary_theta)
+    throw std::invalid_argument(
+        "dense provider must support arbitrary interior theta");
+  if (!capability.verified)
+    throw std::invalid_argument("dense provider is not verified");
+}
+
+void validate_interval_id(const DenseCapability &capability,
+                          const DenseIntervalId &id) {
+  if (id.level < 0)
+    throw std::invalid_argument("dense interval level must be non-negative");
+  if (!(id.begin_clock < id.end_clock))
+    throw std::invalid_argument("dense interval clocks must increase exactly");
+  if (!std::isfinite(id.begin_time) || !std::isfinite(id.end_time) ||
+      !(id.begin_time < id.end_time))
+    throw std::invalid_argument(
+        "dense interval physical times must be finite and increase");
+  if (id.method != capability.method)
+    throw std::invalid_argument(
+        "dense interval method does not match provider capability");
+  if (id.tableau_fingerprint != capability.tableau_fingerprint)
+    throw std::invalid_argument(
+        "dense interval fingerprint does not match provider capability");
+}
+
+double binomial(const int n, const int k) {
+  if (k < 0 || k > n)
+    return 0.0;
+  const int smaller = std::min(k, n - k);
+  double result = 1.0;
+  for (int i = 1; i <= smaller; ++i)
+    result *= static_cast<double>(n - smaller + i) / static_cast<double>(i);
+  return result;
+}
+
+} // namespace
+
+DenseInterval::DenseInterval(
+    DenseCapability capability, DenseIntervalId id,
+    std::vector<std::unique_ptr<DenseStateVector>> controls)
+    : capability_(std::move(capability)), id_(std::move(id)),
+      controls_(std::move(controls)) {}
+
+const DenseIntervalId &DenseInterval::id() const noexcept { return id_; }
+
+const DenseCapability &DenseInterval::capability() const noexcept {
+  return capability_;
+}
+
+std::size_t DenseInterval::control_count() const noexcept {
+  return controls_.size();
+}
+
+void DenseInterval::evaluate(const double theta,
+                             DenseStateVector &destination) const {
+  if (!std::isfinite(theta))
+    throw std::invalid_argument("dense evaluation theta must be finite");
+  if (theta < 0.0 || theta > 1.0)
+    throw std::out_of_range("dense evaluation theta must be in [0, 1]");
+  if (controls_.empty())
+    throw std::logic_error("dense interval has no controls");
+  if (!destination.compatible(*controls_.front()) ||
+      !controls_.front()->compatible(destination))
+    throw std::invalid_argument(
+        "dense evaluation destination is incompatible with controls");
+
+  if (theta == 0.0) {
+    destination.copy_from(*controls_.front());
+    return;
+  }
+  if (theta == 1.0) {
+    destination.copy_from(*controls_.back());
+    return;
+  }
+
+  const int degree = static_cast<int>(controls_.size()) - 1;
+  std::vector<double> weights;
+  std::vector<const DenseStateVector *> sources;
+  weights.reserve(controls_.size());
+  sources.reserve(controls_.size());
+  for (int k = 0; k <= degree; ++k) {
+    weights.push_back(binomial(degree, k) * std::pow(theta, k) *
+                      std::pow(1.0 - theta, degree - k));
+    sources.push_back(controls_[static_cast<std::size_t>(k)].get());
+  }
+  destination.linear_combination(weights, sources);
+}
+
+void DenseInterval::evaluate(const step_clock_t theta,
+                             DenseStateVector &destination) const {
+  if (theta.den <= 0)
+    throw std::invalid_argument(
+        "exact dense evaluation theta must have a positive denominator");
+  if (theta < 0 || theta > 1)
+    throw std::out_of_range(
+        "exact dense evaluation theta must be in [0, 1]");
+  evaluate(static_cast<double>(theta), destination);
+}
+
+DenseIntervalBuilder::DenseIntervalBuilder(DenseCapability capability,
+                                           DenseIntervalId id)
+    : capability_(std::move(capability)), id_(std::move(id)) {
+  validate_capability(capability_);
+  validate_interval_id(capability_, id_);
+  controls_.reserve(
+      static_cast<std::size_t>(capability_.persistent_vector_count));
+}
+
+DenseIntervalBuilder::DenseIntervalBuilder(
+    DenseIntervalBuilder &&other) noexcept
+    : capability_(std::move(other.capability_)), id_(std::move(other.id_)),
+      controls_(std::move(other.controls_)), state_(other.state_) {
+  other.state_ = State::moved_from;
+}
+
+DenseIntervalBuilder &
+DenseIntervalBuilder::operator=(DenseIntervalBuilder &&other) {
+  require_active();
+  other.require_active();
+  if (this == &other)
+    return *this;
+  if (!controls_.empty())
+    throw std::logic_error(
+        "dense interval move-assignment target must be empty");
+
+  capability_ = std::move(other.capability_);
+  id_ = std::move(other.id_);
+  controls_ = std::move(other.controls_);
+  state_ = State::active;
+  other.state_ = State::moved_from;
+  return *this;
+}
+
+void DenseIntervalBuilder::require_active() const {
+  if (state_ == State::sealed)
+    throw std::logic_error("dense interval builder is already sealed");
+  if (state_ == State::moved_from)
+    throw std::logic_error("dense interval builder was moved from");
+}
+
+void DenseIntervalBuilder::add_control(
+    std::unique_ptr<DenseStateVector> control) {
+  require_active();
+  if (control == nullptr)
+    throw std::invalid_argument("dense interval control must be owned");
+  if (controls_.size() >=
+      static_cast<std::size_t>(capability_.persistent_vector_count))
+    throw std::length_error("dense interval has excess controls");
+  if (!controls_.empty() &&
+      (!controls_.front()->compatible(*control) ||
+       !control->compatible(*controls_.front())))
+    throw std::invalid_argument("dense interval controls are incompatible");
+  controls_.push_back(std::move(control));
+}
+
+std::shared_ptr<const DenseInterval> DenseIntervalBuilder::seal() {
+  require_active();
+  if (controls_.size() !=
+      static_cast<std::size_t>(capability_.persistent_vector_count))
+    throw std::logic_error("dense interval is missing controls");
+
+  auto result = std::shared_ptr<const DenseInterval>(new DenseInterval(
+      capability_, id_, std::move(controls_)));
+  state_ = State::sealed;
+  return result;
+}
+
+DenseOutputProvider::DenseOutputProvider(DenseCapability capability)
+    : capability_(std::move(capability)) {
+  validate_capability(capability_);
+}
+
+const DenseCapability &DenseOutputProvider::capability() const noexcept {
+  return capability_;
+}
+
+std::unique_ptr<DenseIntervalBuilder> DenseOutputProvider::begin_interval(
+    const DenseIntervalId &id) const {
+  return std::make_unique<DenseIntervalBuilder>(capability_, id);
+}
+
+void DenseOutputRegistry::register_provider(
+    std::shared_ptr<const DenseOutputProvider> provider) {
+  if (provider == nullptr)
+    throw std::invalid_argument("cannot register a null dense provider");
+  const auto capability = provider->capability();
+  validate_capability(capability);
+  const auto duplicate =
+      std::find_if(entries_.begin(), entries_.end(), [&](const Entry &entry) {
+        return entry.capability.method == capability.method;
+      });
+  if (duplicate != entries_.end())
+    throw std::logic_error("a dense provider already owns this ODE method");
+  entries_.push_back(Entry{capability, std::move(provider)});
+}
+
+std::shared_ptr<const DenseOutputProvider> DenseOutputRegistry::require(
+    const SubcyclingODEMethod method,
+    const TableauFingerprint &tableau_fingerprint) const {
+  const auto entry =
+      std::find_if(entries_.begin(), entries_.end(), [&](const Entry &candidate) {
+        return candidate.capability.method == method &&
+               candidate.capability.tableau_fingerprint == tableau_fingerprint;
+      });
+  if (entry == entries_.end())
+    throw std::out_of_range(
+        "no verified dense provider matches method and fingerprint");
+  return entry->provider;
+}
+
+} // namespace CarpetX

--- a/CarpetX/src/subcycling_dense_output.hxx
+++ b/CarpetX/src/subcycling_dense_output.hxx
@@ -1,0 +1,117 @@
+#ifndef CARPETX_SUBCYCLING_DENSE_OUTPUT_HXX
+#define CARPETX_SUBCYCLING_DENSE_OUTPUT_HXX
+
+#include "subcycling_step_context.hxx"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace CarpetX {
+
+using TableauFingerprint = std::array<std::uint8_t, 32>;
+
+struct DenseCapability {
+  SubcyclingODEMethod method;
+  TableauFingerprint tableau_fingerprint;
+  int endpoint_order;
+  int dense_uniform_order;
+  int stage_count;
+  int extra_rhs_evaluations;
+  int persistent_vector_count;
+  bool arbitrary_theta;
+  bool verified;
+};
+
+struct DenseIntervalId {
+  int level;
+  step_clock_t begin_clock;
+  step_clock_t end_clock;
+  double begin_time;
+  double end_time;
+  SubcyclingODEMethod method;
+  TableauFingerprint tableau_fingerprint;
+};
+
+class DenseStateVector {
+public:
+  virtual ~DenseStateVector() = default;
+  virtual bool compatible(const DenseStateVector &other) const noexcept = 0;
+  virtual void copy_from(const DenseStateVector &other) = 0;
+  virtual void linear_combination(
+      const std::vector<double> &weights,
+      const std::vector<const DenseStateVector *> &sources) = 0;
+};
+
+class DenseInterval {
+public:
+  const DenseIntervalId &id() const noexcept;
+  const DenseCapability &capability() const noexcept;
+  std::size_t control_count() const noexcept;
+  void evaluate(double theta, DenseStateVector &destination) const;
+  void evaluate(step_clock_t theta, DenseStateVector &destination) const;
+
+private:
+  friend class DenseIntervalBuilder;
+  DenseInterval(DenseCapability capability, DenseIntervalId id,
+                std::vector<std::unique_ptr<DenseStateVector>> controls);
+
+  DenseCapability capability_;
+  DenseIntervalId id_;
+  std::vector<std::unique_ptr<DenseStateVector>> controls_;
+};
+
+class DenseIntervalBuilder {
+public:
+  DenseIntervalBuilder(DenseCapability capability, DenseIntervalId id);
+  ~DenseIntervalBuilder() = default;
+
+  DenseIntervalBuilder(const DenseIntervalBuilder &) = delete;
+  DenseIntervalBuilder &operator=(const DenseIntervalBuilder &) = delete;
+  DenseIntervalBuilder(DenseIntervalBuilder &&other) noexcept;
+  DenseIntervalBuilder &operator=(DenseIntervalBuilder &&other);
+
+  void add_control(std::unique_ptr<DenseStateVector> control);
+  std::shared_ptr<const DenseInterval> seal();
+
+private:
+  enum class State { active, sealed, moved_from };
+  void require_active() const;
+
+  DenseCapability capability_{};
+  DenseIntervalId id_{};
+  std::vector<std::unique_ptr<DenseStateVector>> controls_;
+  State state_{State::active};
+};
+
+class DenseOutputProvider final {
+public:
+  explicit DenseOutputProvider(DenseCapability capability);
+  const DenseCapability &capability() const noexcept;
+  std::unique_ptr<DenseIntervalBuilder>
+  begin_interval(const DenseIntervalId &id) const;
+
+private:
+  const DenseCapability capability_;
+};
+
+class DenseOutputRegistry {
+public:
+  void register_provider(std::shared_ptr<const DenseOutputProvider> provider);
+  std::shared_ptr<const DenseOutputProvider>
+  require(SubcyclingODEMethod method,
+          const TableauFingerprint &tableau_fingerprint) const;
+
+private:
+  struct Entry {
+    DenseCapability capability;
+    std::shared_ptr<const DenseOutputProvider> provider;
+  };
+  std::vector<Entry> entries_;
+};
+
+} // namespace CarpetX
+
+#endif // CARPETX_SUBCYCLING_DENSE_OUTPUT_HXX

--- a/CarpetX/src/subcycling_dense_stencil.cxx
+++ b/CarpetX/src/subcycling_dense_stencil.cxx
@@ -1,0 +1,342 @@
+#include "subcycling_dense_stencil.hxx"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace CarpetX {
+namespace {
+
+using long_matrix = std::vector<std::vector<long double>>;
+
+bool known_method(const SubcyclingODEMethod method) noexcept {
+  switch (method) {
+  case SubcyclingODEMethod::rk4:
+  case SubcyclingODEMethod::rkf78_order7:
+  case SubcyclingODEMethod::dp87_order8:
+    return true;
+  }
+  return false;
+}
+
+void validate_specification(const DenseStencilSpecification &specification) {
+  if (!known_method(specification.method))
+    throw std::invalid_argument("dense stencil has an unsupported ODE method");
+  if (specification.endpoint_order <= 0 ||
+      specification.dense_uniform_order <= 0 ||
+      specification.dense_uniform_order < specification.endpoint_order)
+    throw std::invalid_argument("dense stencil orders are invalid");
+  if (specification.stage_count <= 0 ||
+      specification.extra_rhs_evaluations < 0)
+    throw std::invalid_argument("dense stencil stage cost is invalid");
+
+  const auto expected_count =
+      static_cast<std::size_t>(specification.dense_uniform_order) + 1U;
+  if (specification.constraints.size() != expected_count)
+    throw std::invalid_argument(
+        "dense stencil needs exactly dense_uniform_order + 1 samples");
+
+  bool has_begin_value = false;
+  bool has_end_value = false;
+  double previous_theta = 0.0;
+  DenseSampleKind previous_kind = DenseSampleKind::value;
+  bool have_previous = false;
+  for (const auto &constraint : specification.constraints) {
+    if (!std::isfinite(constraint.theta) || constraint.theta < 0.0 ||
+        constraint.theta > 1.0)
+      throw std::invalid_argument(
+          "dense stencil sample theta must be finite and in [0, 1]");
+    if (constraint.kind != DenseSampleKind::value &&
+        constraint.kind != DenseSampleKind::scaled_derivative)
+      throw std::invalid_argument("dense stencil has an unknown sample kind");
+
+    if (!have_previous) {
+      if (constraint.kind != DenseSampleKind::value)
+        throw std::invalid_argument(
+            "dense stencil derivative cannot precede its value");
+    } else if (constraint.theta < previous_theta) {
+      throw std::invalid_argument("dense stencil sample nodes must be sorted");
+    } else if (constraint.theta == previous_theta) {
+      if (previous_kind != DenseSampleKind::value ||
+          constraint.kind != DenseSampleKind::scaled_derivative)
+        throw std::invalid_argument(
+            "dense stencil sample constraints are duplicated or misordered");
+    } else if (constraint.kind != DenseSampleKind::value) {
+      throw std::invalid_argument(
+          "dense stencil derivative cannot precede its value");
+    }
+
+    if (constraint.theta == 0.0 &&
+        constraint.kind == DenseSampleKind::value)
+      has_begin_value = true;
+    if (constraint.theta == 1.0 &&
+        constraint.kind == DenseSampleKind::value)
+      has_end_value = true;
+    previous_theta = constraint.theta;
+    previous_kind = constraint.kind;
+    have_previous = true;
+  }
+  if (!has_begin_value || !has_end_value)
+    throw std::invalid_argument(
+        "dense stencil requires endpoint value constraints at 0 and 1");
+}
+
+long double binomial(const int n, const int k) {
+  if (k < 0 || k > n)
+    return 0.0L;
+  const int smaller = std::min(k, n - k);
+  long double result = 1.0L;
+  for (int j = 1; j <= smaller; ++j)
+    result *= static_cast<long double>(n - smaller + j) /
+              static_cast<long double>(j);
+  return result;
+}
+
+long_matrix inverse_confluent_matrix(
+    const DenseStencilSpecification &specification) {
+  const int degree = specification.dense_uniform_order;
+  const std::size_t count = specification.constraints.size();
+  long_matrix augmented(count, std::vector<long double>(2 * count, 0.0L));
+  long double matrix_scale = 0.0L;
+
+  for (std::size_t row = 0; row < count; ++row) {
+    const auto &constraint = specification.constraints[row];
+    const long double theta = static_cast<long double>(constraint.theta);
+    if (constraint.kind == DenseSampleKind::value) {
+      long double theta_power = 1.0L;
+      for (int column = 0; column <= degree; ++column) {
+        augmented[row][static_cast<std::size_t>(column)] = theta_power;
+        matrix_scale = std::max(matrix_scale, std::abs(theta_power));
+        theta_power *= theta;
+      }
+    } else {
+      // k=0 is exactly zero.  Do not form theta^(-1) at theta=0.
+      augmented[row][0] = 0.0L;
+      long double theta_power = 1.0L;
+      for (int column = 1; column <= degree; ++column) {
+        const long double entry =
+            static_cast<long double>(column) * theta_power;
+        augmented[row][static_cast<std::size_t>(column)] = entry;
+        matrix_scale = std::max(matrix_scale, std::abs(entry));
+        theta_power *= theta;
+      }
+    }
+    augmented[row][count + row] = 1.0L;
+  }
+
+  const long double singularity_threshold =
+      std::numeric_limits<long double>::epsilon() *
+      std::max(1.0L, matrix_scale) * static_cast<long double>(count) * 128.0L;
+
+  for (std::size_t column = 0; column < count; ++column) {
+    std::size_t pivot_row = column;
+    long double pivot_magnitude = std::abs(augmented[column][column]);
+    for (std::size_t row = column + 1; row < count; ++row) {
+      const long double candidate = std::abs(augmented[row][column]);
+      if (candidate > pivot_magnitude) {
+        pivot_magnitude = candidate;
+        pivot_row = row;
+      }
+    }
+    if (pivot_magnitude <= singularity_threshold)
+      throw std::invalid_argument(
+          "dense stencil constraints form a singular interpolation matrix");
+    if (pivot_row != column)
+      std::swap(augmented[pivot_row], augmented[column]);
+
+    const long double pivot = augmented[column][column];
+    for (long double &entry : augmented[column])
+      entry /= pivot;
+
+    for (std::size_t row = 0; row < count; ++row) {
+      if (row == column)
+        continue;
+      const long double factor = augmented[row][column];
+      if (factor == 0.0L)
+        continue;
+      for (std::size_t entry = 0; entry < 2 * count; ++entry)
+        augmented[row][entry] -= factor * augmented[column][entry];
+    }
+  }
+
+  long_matrix inverse(count, std::vector<long double>(count, 0.0L));
+  for (std::size_t row = 0; row < count; ++row)
+    for (std::size_t column = 0; column < count; ++column)
+      inverse[row][column] = augmented[row][count + column];
+  return inverse;
+}
+
+DenseStencilSpecification rk4_specification() {
+  return DenseStencilSpecification{
+      SubcyclingODEMethod::rk4,
+      4,
+      4,
+      4,
+      4,
+      {{0.0, DenseSampleKind::value},
+       {0.0, DenseSampleKind::scaled_derivative},
+       {0.5, DenseSampleKind::value},
+       {1.0, DenseSampleKind::value},
+       {1.0, DenseSampleKind::scaled_derivative}}};
+}
+
+DenseStencilSpecification rkf78_specification() {
+  return DenseStencilSpecification{
+      SubcyclingODEMethod::rkf78_order7,
+      7,
+      7,
+      11,
+      23,
+      {{0.0, DenseSampleKind::value},
+       {0.0, DenseSampleKind::scaled_derivative},
+       {1.0 / 3.0, DenseSampleKind::value},
+       {1.0 / 3.0, DenseSampleKind::scaled_derivative},
+       {2.0 / 3.0, DenseSampleKind::value},
+       {2.0 / 3.0, DenseSampleKind::scaled_derivative},
+       {1.0, DenseSampleKind::value},
+       {1.0, DenseSampleKind::scaled_derivative}}};
+}
+
+DenseStencilSpecification dp87_specification() {
+  return DenseStencilSpecification{
+      SubcyclingODEMethod::dp87_order8,
+      8,
+      8,
+      13,
+      39,
+      {{0.0, DenseSampleKind::value},
+       {0.0, DenseSampleKind::scaled_derivative},
+       {0.25, DenseSampleKind::value},
+       {0.25, DenseSampleKind::scaled_derivative},
+       {0.5, DenseSampleKind::value},
+       {0.5, DenseSampleKind::scaled_derivative},
+       {0.75, DenseSampleKind::value},
+       {1.0, DenseSampleKind::value},
+       {1.0, DenseSampleKind::scaled_derivative}}};
+}
+
+} // namespace
+
+DenseStencil::DenseStencil(DenseStencilSpecification specification)
+    : specification_(std::move(specification)),
+      weights_(build_weights(specification_)) {}
+
+const DenseStencilSpecification &DenseStencil::specification() const noexcept {
+  return specification_;
+}
+
+std::size_t DenseStencil::control_count() const noexcept {
+  return specification_.constraints.size();
+}
+
+std::size_t DenseStencil::sample_count() const noexcept {
+  return specification_.constraints.size();
+}
+
+const std::vector<double> &DenseStencil::weights() const noexcept {
+  return weights_;
+}
+
+double DenseStencil::weight(const std::size_t control,
+                            const std::size_t sample) const {
+  const std::size_t count = sample_count();
+  if (control >= count || sample >= count)
+    throw std::out_of_range("dense stencil weight index is out of range");
+  return weights_[control * count + sample];
+}
+
+std::vector<double>
+DenseStencil::make_controls(const std::vector<double> &samples) const {
+  const std::size_t count = sample_count();
+  if (samples.size() != count)
+    throw std::invalid_argument("dense stencil sample count does not match");
+  std::vector<double> controls(count, 0.0);
+  for (std::size_t control = 0; control < count; ++control)
+    for (std::size_t sample = 0; sample < count; ++sample)
+      controls[control] += weight(control, sample) * samples[sample];
+  return controls;
+}
+
+std::vector<double> DenseStencil::build_weights(
+    const DenseStencilSpecification &specification) {
+  validate_specification(specification);
+  const int degree = specification.dense_uniform_order;
+  const std::size_t count = specification.constraints.size();
+  const auto inverse = inverse_confluent_matrix(specification);
+  long_matrix long_weights(count, std::vector<long double>(count, 0.0L));
+
+  for (int control = 0; control <= degree; ++control) {
+    for (std::size_t sample = 0; sample < count; ++sample) {
+      long double result = 0.0L;
+      for (int power = 0; power <= control; ++power) {
+        const long double coefficient =
+            binomial(control, power) / binomial(degree, power);
+        result += coefficient *
+                  inverse[static_cast<std::size_t>(power)][sample];
+      }
+      long_weights[static_cast<std::size_t>(control)][sample] = result;
+    }
+  }
+
+  std::size_t begin_value = count;
+  std::size_t end_value = count;
+  for (std::size_t sample = 0; sample < count; ++sample) {
+    const auto &constraint = specification.constraints[sample];
+    if (constraint.theta == 0.0 &&
+        constraint.kind == DenseSampleKind::value)
+      begin_value = sample;
+    if (constraint.theta == 1.0 &&
+        constraint.kind == DenseSampleKind::value)
+      end_value = sample;
+  }
+
+  const long double endpoint_tolerance = 2.0e-12L;
+  for (std::size_t sample = 0; sample < count; ++sample) {
+    const long double expected_begin = sample == begin_value ? 1.0L : 0.0L;
+    const long double expected_end = sample == end_value ? 1.0L : 0.0L;
+    if (std::abs(long_weights.front()[sample] - expected_begin) >
+            endpoint_tolerance ||
+        std::abs(long_weights.back()[sample] - expected_end) >
+            endpoint_tolerance)
+      throw std::runtime_error(
+          "dense stencil endpoint rows failed identity verification");
+  }
+
+  std::vector<double> result(count * count, 0.0);
+  for (std::size_t control = 0; control < count; ++control) {
+    for (std::size_t sample = 0; sample < count; ++sample) {
+      const long double entry = long_weights[control][sample];
+      if (!std::isfinite(entry))
+        throw std::runtime_error("dense stencil produced a non-finite weight");
+      const double converted = static_cast<double>(entry);
+      if (!std::isfinite(converted))
+        throw std::runtime_error("dense stencil weight does not fit in double");
+      result[control * count + sample] = converted;
+    }
+  }
+  for (std::size_t sample = 0; sample < count; ++sample) {
+    result[sample] = sample == begin_value ? 1.0 : 0.0;
+    result[(count - 1) * count + sample] = sample == end_value ? 1.0 : 0.0;
+  }
+  return result;
+}
+
+const DenseStencil &reference_dense_stencil(const SubcyclingODEMethod method) {
+  static const DenseStencil rk4(rk4_specification());
+  static const DenseStencil rkf78(rkf78_specification());
+  static const DenseStencil dp87(dp87_specification());
+  switch (method) {
+  case SubcyclingODEMethod::rk4:
+    return rk4;
+  case SubcyclingODEMethod::rkf78_order7:
+    return rkf78;
+  case SubcyclingODEMethod::dp87_order8:
+    return dp87;
+  }
+  throw std::invalid_argument("no reference dense stencil for ODE method");
+}
+
+} // namespace CarpetX

--- a/CarpetX/src/subcycling_dense_stencil.hxx
+++ b/CarpetX/src/subcycling_dense_stencil.hxx
@@ -1,0 +1,51 @@
+#ifndef CARPETX_SUBCYCLING_DENSE_STENCIL_HXX
+#define CARPETX_SUBCYCLING_DENSE_STENCIL_HXX
+
+#include "subcycling_step_context.hxx"
+
+#include <cstddef>
+#include <vector>
+
+namespace CarpetX {
+
+enum class DenseSampleKind { value, scaled_derivative };
+
+struct DenseSampleConstraint {
+  double theta;
+  DenseSampleKind kind;
+};
+
+struct DenseStencilSpecification {
+  SubcyclingODEMethod method;
+  int endpoint_order;
+  int dense_uniform_order;
+  int stage_count;
+  int extra_rhs_evaluations;
+  std::vector<DenseSampleConstraint> constraints;
+};
+
+class DenseStencil {
+public:
+  explicit DenseStencil(DenseStencilSpecification specification);
+
+  const DenseStencilSpecification &specification() const noexcept;
+  std::size_t control_count() const noexcept;
+  std::size_t sample_count() const noexcept;
+  const std::vector<double> &weights() const noexcept;
+  double weight(std::size_t control, std::size_t sample) const;
+  std::vector<double>
+  make_controls(const std::vector<double> &samples) const;
+
+private:
+  static std::vector<double>
+  build_weights(const DenseStencilSpecification &specification);
+
+  const DenseStencilSpecification specification_;
+  const std::vector<double> weights_;
+};
+
+const DenseStencil &reference_dense_stencil(SubcyclingODEMethod method);
+
+} // namespace CarpetX
+
+#endif // CARPETX_SUBCYCLING_DENSE_STENCIL_HXX

--- a/CarpetX/src/subcycling_method_contract.cxx
+++ b/CarpetX/src/subcycling_method_contract.cxx
@@ -1,0 +1,155 @@
+#include "subcycling_method_contract.hxx"
+
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace CarpetX {
+namespace {
+
+bool known_method(const SubcyclingODEMethod method) noexcept {
+  switch (method) {
+  case SubcyclingODEMethod::rk4:
+  case SubcyclingODEMethod::rkf78_order7:
+  case SubcyclingODEMethod::dp87_order8:
+    return true;
+  }
+  return false;
+}
+
+bool zero_fingerprint(const TableauFingerprint &fingerprint) noexcept {
+  return std::all_of(fingerprint.begin(), fingerprint.end(),
+                     [](const std::uint8_t value) { return value == 0; });
+}
+
+bool same_dense(const DenseCapability &left,
+                const DenseCapability &right) noexcept {
+  return left.method == right.method &&
+         left.tableau_fingerprint == right.tableau_fingerprint &&
+         left.endpoint_order == right.endpoint_order &&
+         left.dense_uniform_order == right.dense_uniform_order &&
+         left.stage_count == right.stage_count &&
+         left.extra_rhs_evaluations == right.extra_rhs_evaluations &&
+         left.persistent_vector_count == right.persistent_vector_count &&
+         left.arbitrary_theta == right.arbitrary_theta &&
+         left.verified == right.verified;
+}
+
+bool same_contract(const SubcyclingMethodContract &left,
+                   const SubcyclingMethodContract &right) noexcept {
+  return left.provider_id == right.provider_id &&
+         left.parameter_value == right.parameter_value &&
+         same_dense(left.dense, right.dense);
+}
+
+bool same_schema(const SubcyclingGroupSchema &left,
+                 const SubcyclingGroupSchema &right) noexcept {
+  if (left.ordered_group_pairs.size() !=
+          right.ordered_group_pairs.size() ||
+      left.dependent_groups != right.dependent_groups)
+    return false;
+  for (std::size_t index = 0; index < left.ordered_group_pairs.size();
+       ++index) {
+    const auto &left_pair = left.ordered_group_pairs[index];
+    const auto &right_pair = right.ordered_group_pairs[index];
+    if (left_pair.evolved_group != right_pair.evolved_group ||
+        left_pair.rhs_group != right_pair.rhs_group)
+      return false;
+  }
+  return true;
+}
+
+void validate_contract(const SubcyclingMethodContract &contract) {
+  const auto &dense = contract.dense;
+  if (contract.provider_id.empty() || contract.parameter_value.empty())
+    throw std::invalid_argument(
+        "subcycling method contract identity must not be empty");
+  if (!known_method(dense.method) ||
+      zero_fingerprint(dense.tableau_fingerprint) ||
+      dense.endpoint_order <= 0 ||
+      dense.dense_uniform_order < dense.endpoint_order ||
+      dense.stage_count <= 0 || dense.extra_rhs_evaluations < 0 ||
+      dense.persistent_vector_count <= 0 || !dense.arbitrary_theta ||
+      !dense.verified)
+    throw std::invalid_argument(
+        "subcycling method contract has an invalid dense capability");
+}
+
+} // namespace
+
+bool SubcyclingMethodContractRegistry::empty() const noexcept {
+  return !snapshot_.has_value();
+}
+
+std::uint64_t SubcyclingMethodContractRegistry::register_contract(
+    const SubcyclingMethodContract &contract) {
+  validate_contract(contract);
+  if (snapshot_) {
+    if (snapshot_->contract.provider_id != contract.provider_id)
+      throw std::logic_error(
+          "another provider already owns the subcycling method contract");
+    if (!same_contract(snapshot_->contract, contract))
+      throw std::logic_error(
+          "the subcycling method contract is frozen for this GHExt");
+    return snapshot_->registration_epoch;
+  }
+  snapshot_.emplace(SubcyclingMethodContractSnapshot{
+      contract, std::nullopt, std::uint64_t{1}});
+  return snapshot_->registration_epoch;
+}
+
+std::uint64_t SubcyclingMethodContractRegistry::register_group_schema(
+    const std::string_view provider_id,
+    const SubcyclingGroupSchema &group_schema) {
+  if (!snapshot_)
+    throw std::logic_error(
+        "cannot register a group schema before a method contract");
+  if (provider_id != snapshot_->contract.provider_id)
+    throw std::logic_error(
+        "group schema provider does not own the method contract");
+  if (snapshot_->group_schema) {
+    if (!same_schema(*snapshot_->group_schema, group_schema))
+      throw std::logic_error(
+          "the subcycling group schema is frozen for this GHExt");
+    return snapshot_->registration_epoch;
+  }
+  if (snapshot_->registration_epoch ==
+      std::numeric_limits<std::uint64_t>::max())
+    throw std::overflow_error(
+        "subcycling method-contract registration epoch exhausted");
+  snapshot_->group_schema = group_schema;
+  ++snapshot_->registration_epoch;
+  return snapshot_->registration_epoch;
+}
+
+SubcyclingMethodContractSnapshot
+SubcyclingMethodContractRegistry::require_snapshot() const {
+  if (!snapshot_)
+    throw std::out_of_range("no subcycling method contract is registered");
+  return *snapshot_;
+}
+
+SubcyclingMethodContractSnapshot
+SubcyclingMethodContractRegistry::require_complete_snapshot() const {
+  const auto snapshot = require_snapshot();
+  if (!snapshot.group_schema)
+    throw std::out_of_range(
+        "the subcycling method contract has no immutable group schema");
+  return snapshot;
+}
+
+void SubcyclingMethodContractRegistry::validate_snapshot(
+    const SubcyclingMethodContractSnapshot &snapshot) const {
+  if (!snapshot_ ||
+      snapshot.registration_epoch != snapshot_->registration_epoch ||
+      !same_contract(snapshot.contract, snapshot_->contract) ||
+      snapshot.group_schema.has_value() !=
+          snapshot_->group_schema.has_value() ||
+      (snapshot.group_schema &&
+       !same_schema(*snapshot.group_schema, *snapshot_->group_schema)))
+    throw std::logic_error(
+        "subcycling method-contract snapshot is stale or modified");
+}
+
+} // namespace CarpetX

--- a/CarpetX/src/subcycling_method_contract.hxx
+++ b/CarpetX/src/subcycling_method_contract.hxx
@@ -1,0 +1,70 @@
+#ifndef CARPETX_SUBCYCLING_METHOD_CONTRACT_HXX
+#define CARPETX_SUBCYCLING_METHOD_CONTRACT_HXX
+
+#include "subcycling_dense_output.hxx"
+#include "subcycling_scratch_state_transaction.hxx"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace CarpetX {
+
+struct SubcyclingMethodContract {
+  std::string provider_id;
+  std::string parameter_value;
+  DenseCapability dense;
+};
+
+struct SubcyclingGroupSchema {
+  std::vector<ScratchGroupPair> ordered_group_pairs;
+  std::vector<int> dependent_groups;
+};
+
+struct SubcyclingMethodContractSnapshot {
+  SubcyclingMethodContract contract;
+  std::optional<SubcyclingGroupSchema> group_schema;
+  std::uint64_t registration_epoch{0};
+};
+
+class SubcyclingMethodContractRegistry final {
+public:
+  bool empty() const noexcept;
+
+  std::uint64_t
+  register_contract(const SubcyclingMethodContract &contract);
+  std::uint64_t
+  register_group_schema(std::string_view provider_id,
+                        const SubcyclingGroupSchema &group_schema);
+
+  SubcyclingMethodContractSnapshot require_snapshot() const;
+  SubcyclingMethodContractSnapshot require_complete_snapshot() const;
+  void
+  validate_snapshot(const SubcyclingMethodContractSnapshot &snapshot) const;
+
+private:
+  std::optional<SubcyclingMethodContractSnapshot> snapshot_;
+};
+
+// These functions bind the pure registry above to the active CarpetX GHExt.
+// Registration happens after GHExt construction at CCTK_PARAMCHECK. Returned
+// snapshots are immutable copies suitable for a future HierarchyStepper
+// session; validate them immediately before touching primary state.
+std::uint64_t
+register_subcycling_method_contract(const SubcyclingMethodContract &contract);
+std::uint64_t
+register_subcycling_group_schema(std::string_view provider_id,
+                                 const SubcyclingGroupSchema &group_schema);
+
+SubcyclingMethodContractSnapshot
+require_registered_subcycling_method_contract();
+SubcyclingMethodContractSnapshot
+require_complete_registered_subcycling_method_contract();
+void validate_registered_subcycling_method_contract(
+    const SubcyclingMethodContractSnapshot &snapshot);
+
+} // namespace CarpetX
+
+#endif // CARPETX_SUBCYCLING_METHOD_CONTRACT_HXX

--- a/CarpetX/src/subcycling_native_gate.cxx
+++ b/CarpetX/src/subcycling_native_gate.cxx
@@ -659,6 +659,22 @@ void write_native_gate_inventory(cGH *const cctkGH,
   write_expectation(path, *observed.expectation);
 }
 
+std::unique_ptr<CertifiedLocalScheduleRegistry>
+load_certified_local_schedule_registry() {
+  auto expected = load_expectation(expectation_path());
+  auto observed_provenance = expected.provenance;
+  observed_provenance.executable_sha256 = current_executable_sha256();
+  auto certification =
+      certify_local_subcycling_schedules(expected, observed_provenance);
+  if (!certification) {
+    if (!certification.failure)
+      throw std::runtime_error(
+          "local schedule certification failed without detail");
+    certification_failure(*certification.failure);
+  }
+  return std::move(certification.registry);
+}
+
 NativeGateSession begin_native_gate(cGH *const cctkGH,
                                     const int cctk_itlast) {
   if (cctkGH == nullptr || cctk_itlast != 3 || CCTK_nProcs(cctkGH) != 1)
@@ -679,17 +695,7 @@ NativeGateSession begin_native_gate(cGH *const cctkGH,
   if (patch_cctkGH == nullptr)
     throw std::invalid_argument("native gate patch GH is absent");
 
-  auto expected = load_expectation(expectation_path());
-  auto observed_provenance = expected.provenance;
-  observed_provenance.executable_sha256 = current_executable_sha256();
-  auto certification =
-      certify_local_subcycling_schedules(expected, observed_provenance);
-  if (!certification) {
-    if (!certification.failure)
-      throw std::runtime_error(
-          "native gate certification failed without detail");
-    certification_failure(*certification.failure);
-  }
+  auto registry = load_certified_local_schedule_registry();
 
   const auto contract =
       native_gate_method_contract(patch_cctkGH->cctk_iteration);
@@ -725,11 +731,9 @@ NativeGateSession begin_native_gate(cGH *const cctkGH,
       {}};
   auto frame = copy_canonical_tl0_collective(*ghext, 0, 0);
   auto transaction = ScratchStateTransactionFactory::create_native(
-      *ghext, *certification.registry, std::move(frame),
-      std::move(metadata));
+      *ghext, *registry, std::move(frame), std::move(metadata));
   return NativeGateSession(std::make_unique<NativeGateSession::Storage>(
-      contract, context, std::move(certification.registry),
-      std::move(transaction)));
+      contract, context, std::move(registry), std::move(transaction)));
 }
 
 NativeGateReceipt end_native_gate(NativeGateSession &&session) {

--- a/CarpetX/src/subcycling_native_gate.cxx
+++ b/CarpetX/src/subcycling_native_gate.cxx
@@ -1,0 +1,768 @@
+#include "subcycling_native_gate.hxx"
+
+#include <cmath>
+#include <stdexcept>
+
+#ifndef CARPETX_SUBCYCLING_NATIVE_GATE_CONTRACT_UNIT
+#include "driver.hxx"
+#include "schedule.hxx"
+#include "subcycling_dense_output.hxx"
+#include "subcycling_schedule_certification.hxx"
+#include "subcycling_schedule_certification_native_gate.hxx"
+#include "subcycling_scratch_adapter.hxx"
+#include "subcycling_scratch_state_transaction_factory.hxx"
+
+#include <cctk.h>
+#include <cctk_Groups.h>
+
+#include <yaml-cpp/yaml.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <iterator>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+#endif
+
+namespace CarpetX {
+
+NativeGateMethodContract
+native_gate_method_contract(const int evolution_iteration) {
+  switch (evolution_iteration) {
+  case 1:
+    return {SubcyclingODEMethod::rk4, "RK4", 4, 5};
+  case 2:
+    return {SubcyclingODEMethod::rkf78_order7, "RKF78", 23, 8};
+  case 3:
+    return {SubcyclingODEMethod::dp87_order8, "DP87", 39, 9};
+  default:
+    throw std::invalid_argument(
+        "native gate requires evolution iteration 1, 2, or 3");
+  }
+}
+
+namespace native_gate_detail {
+
+StepContext make_patch_step_context(const PatchContextInput &input,
+                                    const SubcyclingODEMethod method) {
+  if (input.active_min_level != 0 || input.active_max_level != 1 ||
+      input.active_min_patch != 0 || input.active_max_patch != 1)
+    throw std::invalid_argument(
+        "native gate active hierarchy is not patch zero, level zero");
+  if (input.iteration < 0 || input.time_refinement_factor != 1 ||
+      input.level_iteration != step_clock_t(input.iteration) ||
+      !(step_clock_t(0) < input.delta_iteration) ||
+      !std::isfinite(input.time) || !std::isfinite(input.delta_time) ||
+      !(input.delta_time > 0.0))
+    throw std::invalid_argument(
+        "native gate patch clock envelope is unsupported");
+  return {0, input.level_iteration - input.delta_iteration,
+          input.level_iteration, input.time - input.delta_time, input.time,
+          method, true,
+          static_cast<std::uint64_t>(input.iteration)};
+}
+
+} // namespace native_gate_detail
+
+#ifndef CARPETX_SUBCYCLING_NATIVE_GATE_CONTRACT_UNIT
+namespace {
+
+constexpr std::uint32_t expectation_schema = 1;
+
+YAML::Node encode_strings(const std::vector<std::string> &values) {
+  YAML::Node node(YAML::NodeType::Sequence);
+  for (const auto &value : values)
+    node.push_back(value);
+  return node;
+}
+
+std::vector<std::string> decode_strings(const YAML::Node &node) {
+  if (!node || !node.IsSequence())
+    throw std::invalid_argument("native gate string list is malformed");
+  std::vector<std::string> result;
+  result.reserve(node.size());
+  for (const auto &value : node)
+    result.push_back(value.as<std::string>());
+  return result;
+}
+
+YAML::Node encode_flags(const CanonicalExecutionFlags &flags) {
+  YAML::Node node;
+#define CARPETX_NATIVE_GATE_FLAG(name) node[#name] = flags.name
+  CARPETX_NATIVE_GATE_FLAG(meta);
+  CARPETX_NATIVE_GATE_FLAG(meta_early);
+  CARPETX_NATIVE_GATE_FLAG(meta_late);
+  CARPETX_NATIVE_GATE_FLAG(global);
+  CARPETX_NATIVE_GATE_FLAG(global_early);
+  CARPETX_NATIVE_GATE_FLAG(global_late);
+  CARPETX_NATIVE_GATE_FLAG(level);
+  CARPETX_NATIVE_GATE_FLAG(singlemap);
+  CARPETX_NATIVE_GATE_FLAG(local);
+  CARPETX_NATIVE_GATE_FLAG(loop_meta);
+  CARPETX_NATIVE_GATE_FLAG(loop_global);
+  CARPETX_NATIVE_GATE_FLAG(loop_level);
+  CARPETX_NATIVE_GATE_FLAG(loop_singlemap);
+  CARPETX_NATIVE_GATE_FLAG(loop_local);
+#undef CARPETX_NATIVE_GATE_FLAG
+  return node;
+}
+
+CanonicalExecutionFlags decode_flags(const YAML::Node &node) {
+  if (!node || !node.IsMap())
+    throw std::invalid_argument("native gate execution flags are malformed");
+  CanonicalExecutionFlags flags;
+#define CARPETX_NATIVE_GATE_FLAG(name) flags.name = node[#name].as<int>()
+  CARPETX_NATIVE_GATE_FLAG(meta);
+  CARPETX_NATIVE_GATE_FLAG(meta_early);
+  CARPETX_NATIVE_GATE_FLAG(meta_late);
+  CARPETX_NATIVE_GATE_FLAG(global);
+  CARPETX_NATIVE_GATE_FLAG(global_early);
+  CARPETX_NATIVE_GATE_FLAG(global_late);
+  CARPETX_NATIVE_GATE_FLAG(level);
+  CARPETX_NATIVE_GATE_FLAG(singlemap);
+  CARPETX_NATIVE_GATE_FLAG(local);
+  CARPETX_NATIVE_GATE_FLAG(loop_meta);
+  CARPETX_NATIVE_GATE_FLAG(loop_global);
+  CARPETX_NATIVE_GATE_FLAG(loop_level);
+  CARPETX_NATIVE_GATE_FLAG(loop_singlemap);
+  CARPETX_NATIVE_GATE_FLAG(loop_local);
+#undef CARPETX_NATIVE_GATE_FLAG
+  return flags;
+}
+
+YAML::Node encode_tag(const CanonicalTag &tag) {
+  YAML::Node node;
+  node["key"] = tag.key;
+  node["type_code"] = tag.type_code;
+  node["element_count"] = tag.element_count;
+  YAML::Node bytes(YAML::NodeType::Sequence);
+  for (const auto byte : tag.value_bytes)
+    bytes.push_back(static_cast<unsigned int>(byte));
+  node["value_bytes"] = std::move(bytes);
+  return node;
+}
+
+CanonicalTag decode_tag(const YAML::Node &node) {
+  CanonicalTag tag;
+  tag.key = node["key"].as<std::string>();
+  tag.type_code = node["type_code"].as<int>();
+  tag.element_count = node["element_count"].as<std::uint64_t>();
+  const auto bytes = node["value_bytes"];
+  if (!bytes || !bytes.IsSequence())
+    throw std::invalid_argument("native gate tag bytes are malformed");
+  tag.value_bytes.reserve(bytes.size());
+  for (const auto &entry : bytes) {
+    const auto value = entry.as<unsigned int>();
+    if (value > 255U)
+      throw std::invalid_argument("native gate tag byte is out of range");
+    tag.value_bytes.push_back(static_cast<std::uint8_t>(value));
+  }
+  return tag;
+}
+
+YAML::Node encode_access(const CanonicalAccess &access) {
+  YAML::Node node;
+  node["variable_name"] = access.variable_name;
+  node["timelevel"] = access.timelevel;
+  node["read_mask"] = access.read_mask;
+  node["write_mask"] = access.write_mask;
+  node["invalidate_mask"] = access.invalidate_mask;
+  return node;
+}
+
+CanonicalAccess decode_access(const YAML::Node &node) {
+  return {node["variable_name"].as<std::string>(),
+          node["timelevel"].as<int>(), node["read_mask"].as<int>(),
+          node["write_mask"].as<int>(),
+          node["invalidate_mask"].as<int>()};
+}
+
+YAML::Node encode_group_timelevel(const CanonicalGroupTimelevel &entry) {
+  YAML::Node node;
+  node["group"] = entry.group;
+  node["timelevel"] = entry.timelevel;
+  return node;
+}
+
+CanonicalGroupTimelevel decode_group_timelevel(const YAML::Node &node) {
+  return {node["group"].as<std::string>(), node["timelevel"].as<int>()};
+}
+
+YAML::Node encode_item(const CanonicalScheduleItem &item) {
+  YAML::Node node;
+  node["description"] = item.description;
+  node["implementation"] = item.implementation;
+  node["where"] = item.where;
+  node["thorn"] = item.thorn;
+  node["routine"] = item.routine;
+  node["language"] = item.language;
+  node["function_type"] = item.function_type;
+  node["execution_flags"] = encode_flags(item.execution_flags);
+  node["effective_mode"] = static_cast<int>(item.effective_mode);
+  YAML::Node tags(YAML::NodeType::Sequence);
+  for (const auto &tag : item.tags)
+    tags.push_back(encode_tag(tag));
+  node["tags"] = std::move(tags);
+  node["reads_clauses"] = encode_strings(item.reads_clauses);
+  node["writes_clauses"] = encode_strings(item.writes_clauses);
+  node["invalidates_clauses"] = encode_strings(item.invalidates_clauses);
+  YAML::Node accesses(YAML::NodeType::Sequence);
+  for (const auto &access : item.accesses)
+    accesses.push_back(encode_access(access));
+  node["accesses"] = std::move(accesses);
+  YAML::Node storage(YAML::NodeType::Sequence);
+  for (const auto &entry : item.storage_groups)
+    storage.push_back(encode_group_timelevel(entry));
+  node["storage_groups"] = std::move(storage);
+  node["communication_groups"] = encode_strings(item.communication_groups);
+  node["sync_groups"] = encode_strings(item.sync_groups);
+  node["trigger_groups"] = encode_strings(item.trigger_groups);
+  node["ifs"] = encode_strings(item.ifs);
+  node["whiles"] = encode_strings(item.whiles);
+  return node;
+}
+
+CanonicalScheduleItem decode_item(const YAML::Node &node) {
+  CanonicalScheduleItem item;
+  item.description = node["description"].as<std::string>();
+  item.implementation = node["implementation"].as<std::string>();
+  item.where = node["where"].as<std::string>();
+  item.thorn = node["thorn"].as<std::string>();
+  item.routine = node["routine"].as<std::string>();
+  item.language = node["language"].as<int>();
+  item.function_type = node["function_type"].as<int>();
+  item.execution_flags = decode_flags(node["execution_flags"]);
+  item.effective_mode = static_cast<CanonicalScheduleMode>(
+      node["effective_mode"].as<int>());
+  for (const auto &tag : node["tags"])
+    item.tags.push_back(decode_tag(tag));
+  item.reads_clauses = decode_strings(node["reads_clauses"]);
+  item.writes_clauses = decode_strings(node["writes_clauses"]);
+  item.invalidates_clauses = decode_strings(node["invalidates_clauses"]);
+  for (const auto &access : node["accesses"])
+    item.accesses.push_back(decode_access(access));
+  for (const auto &entry : node["storage_groups"])
+    item.storage_groups.push_back(decode_group_timelevel(entry));
+  item.communication_groups = decode_strings(node["communication_groups"]);
+  item.sync_groups = decode_strings(node["sync_groups"]);
+  item.trigger_groups = decode_strings(node["trigger_groups"]);
+  item.ifs = decode_strings(node["ifs"]);
+  item.whiles = decode_strings(node["whiles"]);
+  return item;
+}
+
+YAML::Node encode_scope(const CanonicalScheduleScope &scope) {
+  YAML::Node node;
+  node["item_ordinal"] = scope.item_ordinal;
+  node["parent_local_ordinal"] = scope.parent_local_ordinal;
+  node["item"] = encode_item(scope.item);
+  return node;
+}
+
+CanonicalScheduleScope decode_scope(const YAML::Node &node) {
+  return {node["item_ordinal"].as<std::uint64_t>(),
+          node["parent_local_ordinal"].as<std::uint64_t>(),
+          decode_item(node["item"])};
+}
+
+YAML::Node encode_record(const CanonicalScheduleRecord &record) {
+  YAML::Node node;
+  node["traversal_ordinal"] = record.traversal_ordinal;
+  node["item_ordinal"] = record.item_ordinal;
+  node["parent_local_ordinal"] = record.parent_local_ordinal;
+  node["item"] = encode_item(record.item);
+  YAML::Node ancestry(YAML::NodeType::Sequence);
+  for (const auto &scope : record.ancestry)
+    ancestry.push_back(encode_scope(scope));
+  node["ancestry"] = std::move(ancestry);
+  return node;
+}
+
+CanonicalScheduleRecord decode_record(const YAML::Node &node) {
+  CanonicalScheduleRecord record;
+  record.traversal_ordinal = node["traversal_ordinal"].as<std::uint64_t>();
+  record.item_ordinal = node["item_ordinal"].as<std::uint64_t>();
+  record.parent_local_ordinal =
+      node["parent_local_ordinal"].as<std::uint64_t>();
+  record.item = decode_item(node["item"]);
+  for (const auto &scope : node["ancestry"])
+    record.ancestry.push_back(decode_scope(scope));
+  return record;
+}
+
+YAML::Node encode_target(const CanonicalTargetSchedule &target) {
+  YAML::Node node;
+  node["target"] = static_cast<int>(target.target);
+  node["body_root"] = target.body_root;
+  node["entry_state"] = static_cast<int>(target.entry_state);
+  node["exit_state"] = static_cast<int>(target.exit_state);
+  node["entry_exit_included"] = target.entry_exit_included;
+  YAML::Node records(YAML::NodeType::Sequence);
+  for (const auto &record : target.records)
+    records.push_back(encode_record(record));
+  node["records"] = std::move(records);
+  return node;
+}
+
+CanonicalTargetSchedule decode_target(const YAML::Node &node) {
+  CanonicalTargetSchedule target;
+  target.target =
+      static_cast<SubcyclingScheduleTarget>(node["target"].as<int>());
+  target.body_root = node["body_root"].as<std::string>();
+  target.entry_state =
+      static_cast<SpecialScheduleGroupState>(node["entry_state"].as<int>());
+  target.exit_state =
+      static_cast<SpecialScheduleGroupState>(node["exit_state"].as<int>());
+  target.entry_exit_included = node["entry_exit_included"].as<bool>();
+  for (const auto &record : node["records"])
+    target.records.push_back(decode_record(record));
+  return target;
+}
+
+YAML::Node encode_manifest(const CanonicalScheduleBundle &manifest) {
+  YAML::Node targets(YAML::NodeType::Sequence);
+  for (const auto &target : manifest.targets)
+    targets.push_back(encode_target(target));
+  return targets;
+}
+
+CanonicalScheduleBundle decode_manifest(const YAML::Node &node) {
+  if (!node || !node.IsSequence() || node.size() != 2)
+    throw std::invalid_argument("native gate manifest must have two targets");
+  CanonicalScheduleBundle manifest;
+  for (std::size_t i = 0; i < manifest.targets.size(); ++i)
+    manifest.targets[i] = decode_target(node[i]);
+  return manifest;
+}
+
+YAML::Node encode_provenance(const ScheduleBuildProvenance &provenance) {
+  YAML::Node node;
+  node["schema_version"] = provenance.schema_version;
+  node["inventory_abi_version"] = provenance.inventory_abi_version;
+  node["cactus_flesh_parent"] = provenance.cactus_flesh_parent;
+  node["cactus_inventory_patch_sha256"] =
+      provenance.cactus_inventory_patch_sha256;
+  node["carpetx_parent"] = provenance.carpetx_parent;
+  YAML::Node patches(YAML::NodeType::Sequence);
+  for (const auto &patch : provenance.ordered_carpetx_patches) {
+    YAML::Node entry;
+    entry["phase"] = patch.phase;
+    entry["sha256"] = patch.sha256;
+    patches.push_back(std::move(entry));
+  }
+  node["ordered_carpetx_patches"] = std::move(patches);
+  node["compiler_id"] = provenance.compiler_id;
+  node["compiler_version"] = provenance.compiler_version;
+  node["target_triple"] = provenance.target_triple;
+  node["cxx_abi"] = provenance.cxx_abi;
+  node["byte_order"] = provenance.byte_order;
+  YAML::Node sizes(YAML::NodeType::Sequence);
+  for (const auto &entry : provenance.cctk_type_sizes) {
+    YAML::Node size;
+    size["type"] = entry.first;
+    size["size"] = entry.second;
+    sizes.push_back(std::move(size));
+  }
+  node["cctk_type_sizes"] = std::move(sizes);
+  node["executable_sha256"] = provenance.executable_sha256;
+  return node;
+}
+
+ScheduleBuildProvenance decode_provenance(const YAML::Node &node) {
+  if (!node || !node.IsMap())
+    throw std::invalid_argument("native gate provenance is missing");
+  ScheduleBuildProvenance provenance;
+  provenance.schema_version = node["schema_version"].as<std::uint32_t>();
+  provenance.inventory_abi_version =
+      node["inventory_abi_version"].as<std::uint32_t>();
+  provenance.cactus_flesh_parent =
+      node["cactus_flesh_parent"].as<std::string>();
+  provenance.cactus_inventory_patch_sha256 =
+      node["cactus_inventory_patch_sha256"].as<std::string>();
+  provenance.carpetx_parent = node["carpetx_parent"].as<std::string>();
+  for (const auto &entry : node["ordered_carpetx_patches"])
+    provenance.ordered_carpetx_patches.push_back(
+        {entry["phase"].as<std::string>(),
+         entry["sha256"].as<std::string>()});
+  provenance.compiler_id = node["compiler_id"].as<std::string>();
+  provenance.compiler_version = node["compiler_version"].as<std::string>();
+  provenance.target_triple = node["target_triple"].as<std::string>();
+  provenance.cxx_abi = node["cxx_abi"].as<std::string>();
+  provenance.byte_order = node["byte_order"].as<std::string>();
+  for (const auto &entry : node["cctk_type_sizes"])
+    provenance.cctk_type_sizes.emplace_back(entry["type"].as<int>(),
+                                            entry["size"].as<int>());
+  provenance.executable_sha256 =
+      node["executable_sha256"].as<std::string>();
+  return provenance;
+}
+
+std::string expectation_path() {
+  const char *const path = std::getenv("CARPETX_NATIVE_GATE_EXPECTATION");
+  if (path == nullptr || *path == '\0')
+    throw std::runtime_error(
+        "CARPETX_NATIVE_GATE_EXPECTATION is not configured");
+  return path;
+}
+
+YAML::Node load_document(const std::string &path) {
+  const auto root = YAML::LoadFile(path);
+  if (!root || !root.IsMap())
+    throw std::invalid_argument("native gate expectation is malformed");
+  if (root["schema"].as<std::uint32_t>() != expectation_schema)
+    throw std::invalid_argument("native gate expectation schema differs");
+  return root;
+}
+
+ScheduleCertificationExpectation load_expectation(const std::string &path) {
+  const auto root = load_document(path);
+  return {decode_manifest(root["manifest"]),
+          decode_provenance(root["provenance"])};
+}
+
+void write_expectation(const std::string &path,
+                       const ScheduleCertificationExpectation &expectation) {
+  YAML::Node root;
+  root["schema"] = expectation_schema;
+  root["provenance"] = encode_provenance(expectation.provenance);
+  root["manifest"] = encode_manifest(expectation.manifest);
+  YAML::Emitter emitter;
+  emitter << root;
+  if (!emitter.good())
+    throw std::runtime_error("native gate expectation serialization failed");
+  std::ofstream output(path, std::ios::binary | std::ios::trunc);
+  if (!output)
+    throw std::runtime_error("native gate expectation cannot be written");
+  output.write(emitter.c_str(), static_cast<std::streamsize>(emitter.size()));
+  output.put('\n');
+  if (!output)
+    throw std::runtime_error("native gate expectation write failed");
+}
+
+constexpr std::uint32_t rotate_right(const std::uint32_t value,
+                                     const int count) noexcept {
+  return (value >> count) | (value << (32 - count));
+}
+
+void append_u64(std::vector<std::uint8_t> &bytes,
+                const std::uint64_t value) {
+  for (int shift = 56; shift >= 0; shift -= 8)
+    bytes.push_back(static_cast<std::uint8_t>(value >> shift));
+}
+
+std::array<std::uint8_t, 32>
+sha256(const std::vector<std::uint8_t> &message) {
+  static constexpr std::array<std::uint32_t, 64> constants{{
+      0x428a2f98U, 0x71374491U, 0xb5c0fbcfU, 0xe9b5dba5U,
+      0x3956c25bU, 0x59f111f1U, 0x923f82a4U, 0xab1c5ed5U,
+      0xd807aa98U, 0x12835b01U, 0x243185beU, 0x550c7dc3U,
+      0x72be5d74U, 0x80deb1feU, 0x9bdc06a7U, 0xc19bf174U,
+      0xe49b69c1U, 0xefbe4786U, 0x0fc19dc6U, 0x240ca1ccU,
+      0x2de92c6fU, 0x4a7484aaU, 0x5cb0a9dcU, 0x76f988daU,
+      0x983e5152U, 0xa831c66dU, 0xb00327c8U, 0xbf597fc7U,
+      0xc6e00bf3U, 0xd5a79147U, 0x06ca6351U, 0x14292967U,
+      0x27b70a85U, 0x2e1b2138U, 0x4d2c6dfcU, 0x53380d13U,
+      0x650a7354U, 0x766a0abbU, 0x81c2c92eU, 0x92722c85U,
+      0xa2bfe8a1U, 0xa81a664bU, 0xc24b8b70U, 0xc76c51a3U,
+      0xd192e819U, 0xd6990624U, 0xf40e3585U, 0x106aa070U,
+      0x19a4c116U, 0x1e376c08U, 0x2748774cU, 0x34b0bcb5U,
+      0x391c0cb3U, 0x4ed8aa4aU, 0x5b9cca4fU, 0x682e6ff3U,
+      0x748f82eeU, 0x78a5636fU, 0x84c87814U, 0x8cc70208U,
+      0x90befffaU, 0xa4506cebU, 0xbef9a3f7U, 0xc67178f2U}};
+  std::array<std::uint32_t, 8> hash{{
+      0x6a09e667U, 0xbb67ae85U, 0x3c6ef372U, 0xa54ff53aU,
+      0x510e527fU, 0x9b05688cU, 0x1f83d9abU, 0x5be0cd19U}};
+  std::vector<std::uint8_t> padded(message);
+  const auto bits = static_cast<std::uint64_t>(message.size()) * 8U;
+  padded.push_back(0x80U);
+  while (padded.size() % 64U != 56U)
+    padded.push_back(0U);
+  append_u64(padded, bits);
+  for (std::size_t block = 0; block < padded.size(); block += 64U) {
+    std::array<std::uint32_t, 64> words{};
+    for (std::size_t i = 0; i < 16U; ++i) {
+      const auto offset = block + 4U * i;
+      words[i] = (static_cast<std::uint32_t>(padded[offset]) << 24) |
+                 (static_cast<std::uint32_t>(padded[offset + 1]) << 16) |
+                 (static_cast<std::uint32_t>(padded[offset + 2]) << 8) |
+                 static_cast<std::uint32_t>(padded[offset + 3]);
+    }
+    for (std::size_t i = 16; i < words.size(); ++i) {
+      const auto s0 = rotate_right(words[i - 15], 7) ^
+                      rotate_right(words[i - 15], 18) ^
+                      (words[i - 15] >> 3);
+      const auto s1 = rotate_right(words[i - 2], 17) ^
+                      rotate_right(words[i - 2], 19) ^
+                      (words[i - 2] >> 10);
+      words[i] = words[i - 16] + s0 + words[i - 7] + s1;
+    }
+    auto a = hash[0];
+    auto b = hash[1];
+    auto c = hash[2];
+    auto d = hash[3];
+    auto e = hash[4];
+    auto f = hash[5];
+    auto g = hash[6];
+    auto h = hash[7];
+    for (std::size_t i = 0; i < words.size(); ++i) {
+      const auto s1 = rotate_right(e, 6) ^ rotate_right(e, 11) ^
+                      rotate_right(e, 25);
+      const auto choice = (e & f) ^ ((~e) & g);
+      const auto t1 = h + s1 + choice + constants[i] + words[i];
+      const auto s0 = rotate_right(a, 2) ^ rotate_right(a, 13) ^
+                      rotate_right(a, 22);
+      const auto majority = (a & b) ^ (a & c) ^ (b & c);
+      const auto t2 = s0 + majority;
+      h = g;
+      g = f;
+      f = e;
+      e = d + t1;
+      d = c;
+      c = b;
+      b = a;
+      a = t1 + t2;
+    }
+    hash[0] += a;
+    hash[1] += b;
+    hash[2] += c;
+    hash[3] += d;
+    hash[4] += e;
+    hash[5] += f;
+    hash[6] += g;
+    hash[7] += h;
+  }
+  std::array<std::uint8_t, 32> result{};
+  for (std::size_t i = 0; i < hash.size(); ++i)
+    for (std::size_t byte = 0; byte < 4; ++byte)
+      result[4 * i + byte] = static_cast<std::uint8_t>(
+          hash[i] >> static_cast<int>(24 - 8 * byte));
+  return result;
+}
+
+std::string current_executable_sha256() {
+  std::ifstream input("/proc/self/exe", std::ios::binary);
+  if (!input)
+    throw std::runtime_error("native gate cannot read /proc/self/exe");
+  std::vector<std::uint8_t> bytes;
+  std::array<char, 1 << 20> buffer{};
+  while (input.read(buffer.data(), static_cast<std::streamsize>(buffer.size())) ||
+         input.gcount() > 0) {
+    const auto count = static_cast<std::size_t>(input.gcount());
+    bytes.insert(bytes.end(), buffer.begin(), buffer.begin() + count);
+  }
+  if (!input.eof())
+    throw std::runtime_error("native gate executable read failed");
+  const auto digest = sha256(bytes);
+  std::ostringstream output;
+  output << std::hex << std::setfill('0');
+  for (const auto byte : digest)
+    output << std::setw(2) << static_cast<unsigned int>(byte);
+  return output.str();
+}
+
+[[noreturn]] void certification_failure(
+    const ScheduleCertificationFailure &failure) {
+  throw std::runtime_error("native gate schedule certification failed at " +
+                           failure.field + ": " + failure.detail);
+}
+
+class NativeGateStagePreparer final : public StagePreparer {
+public:
+  explicit NativeGateStagePreparer(const StepContext &context)
+      : context_(context) {}
+
+  void prepare_stage(const StepContext &context,
+                     const StagePoint &stage_point) override {
+    const auto scale = std::max(
+        {1.0, std::abs(context_.begin_time), std::abs(context_.end_time)});
+    const auto tolerance =
+        32.0 * std::numeric_limits<double>::epsilon() * scale;
+    if (context.level != context_.level ||
+        context.begin_clock != context_.begin_clock ||
+        context.end_clock != context_.end_clock ||
+        context.method != context_.method ||
+        !std::isfinite(stage_point.stage_time) ||
+        stage_point.stage_fraction < step_clock_t(0) ||
+        stage_point.stage_fraction > step_clock_t(1) ||
+        stage_point.stage_time < context_.begin_time - tolerance ||
+        stage_point.stage_time > context_.end_time + tolerance)
+      throw std::invalid_argument(
+          "native gate received an invalid one-level stage request");
+  }
+
+private:
+  StepContext context_;
+};
+
+int required_group(const char *const name) {
+  const int group = CCTK_GroupIndex(name);
+  if (group < 0)
+    throw std::runtime_error(std::string("native gate group is missing: ") +
+                             name);
+  return group;
+}
+
+} // namespace
+
+struct NativeGateSession::Storage {
+  NativeGateMethodContract contract;
+  StepContext context;
+  std::unique_ptr<CertifiedLocalScheduleRegistry> registry;
+  std::unique_ptr<ScratchStateTransaction> transaction;
+  NativeGateStagePreparer preparer;
+  std::unique_ptr<ScopedStepContext> scope;
+
+  Storage(NativeGateMethodContract contract_, StepContext context_,
+          std::unique_ptr<CertifiedLocalScheduleRegistry> registry_,
+          std::unique_ptr<ScratchStateTransaction> transaction_)
+      : contract(contract_), context(std::move(context_)),
+        registry(std::move(registry_)), transaction(std::move(transaction_)),
+        preparer(context) {
+    scope = std::make_unique<ScopedStepContext>(context, preparer,
+                                                transaction.get());
+  }
+};
+
+NativeGateSession::NativeGateSession() noexcept = default;
+NativeGateSession::~NativeGateSession() = default;
+NativeGateSession::NativeGateSession(NativeGateSession &&) noexcept = default;
+NativeGateSession &
+NativeGateSession::operator=(NativeGateSession &&) noexcept = default;
+NativeGateSession::NativeGateSession(std::unique_ptr<Storage> storage) noexcept
+    : storage_(std::move(storage)) {}
+bool NativeGateSession::active() const noexcept { return storage_ != nullptr; }
+
+void write_native_gate_inventory(cGH *const cctkGH,
+                                 const int cctk_itlast) {
+  if (cctkGH == nullptr || cctk_itlast != 0)
+    throw std::invalid_argument(
+        "native gate inventory requires cctk_itlast=0");
+  const auto path = expectation_path();
+  auto root = load_document(path);
+  auto provenance = decode_provenance(root["provenance"]);
+  provenance.executable_sha256 = current_executable_sha256();
+  auto observed =
+      observe_local_subcycling_schedules_for_native_gate(provenance);
+  if (!observed) {
+    if (!observed.failure)
+      throw std::runtime_error("native gate inventory failed without detail");
+    certification_failure(*observed.failure);
+  }
+  write_expectation(path, *observed.expectation);
+}
+
+NativeGateSession begin_native_gate(cGH *const cctkGH,
+                                    const int cctk_itlast) {
+  if (cctkGH == nullptr || cctk_itlast != 3 || CCTK_nProcs(cctkGH) != 1)
+    throw std::invalid_argument(
+        "native gate requires one rank and cctk_itlast=3");
+  if (!ghext || ghext->patchdata.size() != 1 ||
+      ghext->patchdata.front().leveldata.size() != 1)
+    throw std::invalid_argument(
+        "native gate hierarchy is not exactly one patch and one level");
+  if (!active_levels || active_levels->min_level != 0 ||
+      active_levels->max_level != 1 || active_levels->min_patch != 0 ||
+      active_levels->max_patch != 1)
+    throw std::invalid_argument(
+        "native gate active hierarchy is not patch zero, level zero");
+
+  const auto &level = ghext->patchdata.front().leveldata.front();
+  const auto *const patch_cctkGH = level.get_patch_cctkGH();
+  if (patch_cctkGH == nullptr)
+    throw std::invalid_argument("native gate patch GH is absent");
+
+  auto expected = load_expectation(expectation_path());
+  auto observed_provenance = expected.provenance;
+  observed_provenance.executable_sha256 = current_executable_sha256();
+  auto certification =
+      certify_local_subcycling_schedules(expected, observed_provenance);
+  if (!certification) {
+    if (!certification.failure)
+      throw std::runtime_error(
+          "native gate certification failed without detail");
+    certification_failure(*certification.failure);
+  }
+
+  const auto contract =
+      native_gate_method_contract(patch_cctkGH->cctk_iteration);
+  const StepContext context = native_gate_detail::make_patch_step_context(
+      {active_levels->min_level,
+       active_levels->max_level,
+       active_levels->min_patch,
+       active_levels->max_patch,
+       patch_cctkGH->cctk_iteration,
+       patch_cctkGH->cctk_timefac,
+       step_clock_t(level.iteration.num, level.iteration.den),
+       step_clock_t(level.delta_iteration.num, level.delta_iteration.den),
+       patch_cctkGH->cctk_time,
+       patch_cctkGH->cctk_delta_time},
+      contract.method);
+
+  const int state_group = required_group("TestODESolvers2::state");
+  const int rhs_group = required_group("TestODESolvers2::rhs");
+  const int dependent_group =
+      required_group("TestODESolvers2::gate_dependent");
+  ScratchStateTransactionFactoryMetadata metadata{
+      0,
+      0,
+      0,
+      0,
+      step_clock_t(1),
+      1.0,
+      1,
+      false,
+      {{state_group, rhs_group}},
+      {rhs_group, dependent_group},
+      {},
+      {}};
+  auto frame = copy_canonical_tl0_collective(*ghext, 0, 0);
+  auto transaction = ScratchStateTransactionFactory::create_native(
+      *ghext, *certification.registry, std::move(frame),
+      std::move(metadata));
+  return NativeGateSession(std::make_unique<NativeGateSession::Storage>(
+      contract, context, std::move(certification.registry),
+      std::move(transaction)));
+}
+
+NativeGateReceipt end_native_gate(NativeGateSession &&session) {
+  if (!session.storage_ || !session.storage_->transaction ||
+      !session.storage_->scope)
+    throw std::invalid_argument("native gate session is not active");
+  auto &storage = *session.storage_;
+  const auto rhs_count = storage.transaction->rhs_evaluation_count();
+  auto interval = storage.transaction->take_committed_dense();
+  if (!interval)
+    throw std::runtime_error(
+        "native gate ODESolvers did not publish a dense interval");
+  const auto &id = interval->id();
+  const auto &capability = interval->capability();
+  if (id.level != storage.context.level ||
+      id.begin_clock != storage.context.begin_clock ||
+      id.end_clock != storage.context.end_clock ||
+      id.begin_time != storage.context.begin_time ||
+      id.end_time != storage.context.end_time ||
+      id.method != storage.context.method ||
+      capability.method != storage.context.method ||
+      capability.extra_rhs_evaluations !=
+          static_cast<int>(storage.contract.extra_rhs_evaluations) ||
+      rhs_count != storage.contract.extra_rhs_evaluations ||
+      interval->control_count() != storage.contract.control_count)
+    throw std::runtime_error(
+        "native gate dense interval metadata or count differs");
+  const NativeGateReceipt receipt{storage.context.method, rhs_count,
+                                  interval->control_count()};
+  storage.scope.reset();
+  session.storage_.reset();
+  return receipt;
+}
+#endif
+
+} // namespace CarpetX

--- a/CarpetX/src/subcycling_native_gate.hxx
+++ b/CarpetX/src/subcycling_native_gate.hxx
@@ -10,6 +10,8 @@
 
 namespace CarpetX {
 
+class CertifiedLocalScheduleRegistry;
+
 struct NativeGateMethodContract {
   SubcyclingODEMethod method;
   const char *ode_parameter_value;
@@ -73,6 +75,12 @@ struct NativeGateReceipt {
 // Inventory mode is deliberately non-promoting. The path and build provenance
 // are supplied through CARPETX_NATIVE_GATE_EXPECTATION.
 void write_native_gate_inventory(cGH *cctkGH, int cctk_itlast);
+
+// Load the same immutable expectation used by the native gate, bind its
+// provenance to the current executable, and fail closed unless both the
+// provenance and local schedules certify exactly.
+[[nodiscard]] std::unique_ptr<CertifiedLocalScheduleRegistry>
+load_certified_local_schedule_registry();
 
 // Native mode consumes the frozen inventory, creates the certified transaction
 // and installs the StepContext for the immediately following ODESolvers call.

--- a/CarpetX/src/subcycling_native_gate.hxx
+++ b/CarpetX/src/subcycling_native_gate.hxx
@@ -1,0 +1,85 @@
+#ifndef CARPETX_SUBCYCLING_NATIVE_GATE_HXX
+#define CARPETX_SUBCYCLING_NATIVE_GATE_HXX
+
+#include "subcycling_step_context.hxx"
+
+#include <cctk.h>
+
+#include <cstddef>
+#include <memory>
+
+namespace CarpetX {
+
+struct NativeGateMethodContract {
+  SubcyclingODEMethod method;
+  const char *ode_parameter_value;
+  std::size_t extra_rhs_evaluations;
+  std::size_t control_count;
+};
+
+namespace native_gate_detail {
+
+// Kept independent of driver types so the authoritative patch clock envelope
+// can be regression-tested without constructing a Cactus hierarchy.
+struct PatchContextInput {
+  int active_min_level;
+  int active_max_level;
+  int active_min_patch;
+  int active_max_patch;
+  int iteration;
+  int time_refinement_factor;
+  step_clock_t level_iteration;
+  step_clock_t delta_iteration;
+  double time;
+  double delta_time;
+};
+
+[[nodiscard]] StepContext
+make_patch_step_context(const PatchContextInput &input,
+                        SubcyclingODEMethod method);
+
+} // namespace native_gate_detail
+
+[[nodiscard]] NativeGateMethodContract
+native_gate_method_contract(int evolution_iteration);
+
+struct NativeGateReceipt;
+
+class NativeGateSession final {
+public:
+  NativeGateSession() noexcept;
+  ~NativeGateSession();
+  NativeGateSession(const NativeGateSession &) = delete;
+  NativeGateSession &operator=(const NativeGateSession &) = delete;
+  NativeGateSession(NativeGateSession &&) noexcept;
+  NativeGateSession &operator=(NativeGateSession &&) noexcept;
+  bool active() const noexcept;
+
+private:
+  struct Storage;
+  explicit NativeGateSession(std::unique_ptr<Storage> storage) noexcept;
+  std::unique_ptr<Storage> storage_;
+  friend NativeGateSession begin_native_gate(cGH *, int);
+  friend struct NativeGateReceipt;
+  friend NativeGateReceipt end_native_gate(NativeGateSession &&);
+};
+
+struct NativeGateReceipt {
+  SubcyclingODEMethod method;
+  std::size_t extra_rhs_evaluations;
+  std::size_t control_count;
+};
+
+// Inventory mode is deliberately non-promoting. The path and build provenance
+// are supplied through CARPETX_NATIVE_GATE_EXPECTATION.
+void write_native_gate_inventory(cGH *cctkGH, int cctk_itlast);
+
+// Native mode consumes the frozen inventory, creates the certified transaction
+// and installs the StepContext for the immediately following ODESolvers call.
+[[nodiscard]] NativeGateSession begin_native_gate(cGH *cctkGH,
+                                                  int cctk_itlast);
+[[nodiscard]] NativeGateReceipt end_native_gate(NativeGateSession &&session);
+
+} // namespace CarpetX
+
+#endif

--- a/CarpetX/src/subcycling_runtime_clock.cxx
+++ b/CarpetX/src/subcycling_runtime_clock.cxx
@@ -132,6 +132,46 @@ full_sync_root_runtime_clock(const std::uint64_t completed_epoch,
                               synchronized_time, base_delta_time, 1};
 }
 
+StaticV1StepperSeed static_v1_recovery_seed(
+    const StaticV1RecoverySeedEnvelope &envelope) {
+  if (envelope.level_count != 2 || envelope.refinement_ratio != 2)
+    throw std::invalid_argument(
+        "static-v1 recovery requires two factor-two levels");
+  if (!envelope.strict_recovery)
+    throw std::invalid_argument(
+        "static-v1 recovery requires Cactus strict recovery mode");
+  if (envelope.dynamic_regrid)
+    throw std::invalid_argument(
+        "static-v1 recovery does not support dynamic regridding");
+  if (envelope.root_iteration < 0)
+    throw std::invalid_argument(
+        "static-v1 recovered root iteration must be non-negative");
+  if (envelope.root_timefac != 1)
+    throw std::invalid_argument(
+        "static-v1 recovery requires synchronized root time metadata");
+  if (!std::isfinite(envelope.root_time))
+    throw std::invalid_argument(
+        "static-v1 recovered root time must be finite");
+  require_finite_positive_dt(envelope.base_delta_time);
+
+  for (const auto clock : envelope.rebuilt_level_clocks)
+    if (!equal_clock(clock, step_clock_t(0)))
+      throw std::invalid_argument(
+          "static-v1 recovery requires freshly rebuilt zero level clocks");
+  if (!clock_difference_is(envelope.level_delta_clocks[0], step_clock_t(0),
+                           1) ||
+      !clock_difference_is(envelope.level_delta_clocks[1], step_clock_t(0),
+                           2))
+    throw std::invalid_argument(
+        "static-v1 recovered level deltas must be one and one-half");
+
+  const auto epoch = static_cast<std::uint64_t>(envelope.root_iteration);
+  return StaticV1StepperSeed{step_clock_t(envelope.root_iteration),
+                             envelope.root_time,
+                             epoch,
+                             {epoch, 2 * epoch}};
+}
+
 void validate_static_v1_clock_envelope(
     const StaticV1ClockEnvelope &envelope) {
   if (envelope.level_count != 2 || envelope.refinement_ratio != 2)

--- a/CarpetX/src/subcycling_runtime_clock.cxx
+++ b/CarpetX/src/subcycling_runtime_clock.cxx
@@ -1,0 +1,173 @@
+#include "subcycling_runtime_clock.hxx"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+namespace CarpetX {
+namespace {
+
+void require_finite_positive_dt(const double delta_time) {
+  if (!std::isfinite(delta_time) || !(delta_time > 0.0))
+    throw std::invalid_argument("base delta time must be finite and positive");
+}
+
+void require_valid_clock(const step_clock_t clock) {
+  if ((clock.den != 1 && clock.den != 2) || clock.num < 0 ||
+      clock.num > std::numeric_limits<int>::max())
+    throw std::invalid_argument(
+        "static-v1 exact clock must be a bounded integer or half-integer");
+}
+
+bool equal_clock(const step_clock_t lhs, const step_clock_t rhs) {
+  require_valid_clock(lhs);
+  require_valid_clock(rhs);
+  return lhs == rhs;
+}
+
+bool clock_equals_integer(const step_clock_t clock,
+                          const std::uint64_t value) {
+  require_valid_clock(clock);
+  return clock.den == 1 && clock.num == static_cast<std::int64_t>(value);
+}
+
+bool clock_difference_is(const step_clock_t end,
+                         const step_clock_t begin, const int denominator) {
+  require_valid_clock(begin);
+  require_valid_clock(end);
+  if (denominator != 1 && denominator != 2)
+    throw std::logic_error("unsupported static-v1 time refinement factor");
+  return end - begin == step_clock_t(1, denominator);
+}
+
+void require_physical_step(const StepContext &context,
+                           const double expected_delta_time) {
+  if (!std::isfinite(context.begin_time) ||
+      !std::isfinite(context.end_time))
+    throw std::invalid_argument("step endpoint times must be finite");
+
+  const long double begin = context.begin_time;
+  const long double end = context.end_time;
+  const long double expected = expected_delta_time;
+  const long double actual = end - begin;
+  const long double scale =
+      std::max({1.0L, std::fabs(begin), std::fabs(end), std::fabs(expected)});
+  const long double tolerance =
+      32.0L * std::numeric_limits<double>::epsilon() * scale;
+  if (!(actual > 0.0L) || std::fabs(actual - expected) > tolerance)
+    throw std::invalid_argument(
+        "physical step does not match base delta time and timefac");
+}
+
+void require_int_iteration(const std::uint64_t iteration) {
+  if (iteration >
+      static_cast<std::uint64_t>(std::numeric_limits<int>::max()))
+    throw std::overflow_error("runtime iteration exceeds CCTK_INT range");
+}
+
+} // namespace
+
+double static_v1_base_delta_time(const double legacy_finest_delta_time,
+                                 const int level_count) {
+  if (level_count != 2)
+    throw std::invalid_argument("static-v1 requires exactly two levels");
+  if (!std::isfinite(legacy_finest_delta_time) ||
+      !(legacy_finest_delta_time > 0.0))
+    throw std::invalid_argument(
+        "legacy finest delta time must be finite and positive");
+  if (legacy_finest_delta_time >
+      std::numeric_limits<double>::max() / 2.0)
+    throw std::overflow_error("base delta time is not representable");
+  const double base_delta_time = 2.0 * legacy_finest_delta_time;
+  if (!std::isfinite(base_delta_time))
+    throw std::overflow_error("base delta time is not finite");
+  return base_delta_time;
+}
+
+RuntimeClockMetadata candidate_runtime_clock(const StepContext &context,
+                                             const double base_delta_time) {
+  require_finite_positive_dt(base_delta_time);
+  if (context.level != 0 && context.level != 1)
+    throw std::invalid_argument("static-v1 supports only levels zero and one");
+
+  const int timefac = context.level == 0 ? 1 : 2;
+  if (context.endpoint_accepted_step == 0)
+    throw std::invalid_argument("accepted endpoint step must be positive");
+  require_int_iteration(context.endpoint_accepted_step);
+  require_valid_clock(context.begin_clock);
+  require_valid_clock(context.end_clock);
+  const step_clock_t expected_begin(
+      static_cast<std::int64_t>(context.endpoint_accepted_step - 1), timefac);
+  const step_clock_t expected_end(
+      static_cast<std::int64_t>(context.endpoint_accepted_step), timefac);
+  if (context.begin_clock != expected_begin || context.end_clock != expected_end)
+    throw std::invalid_argument(
+        "step exact clocks do not match the accepted-step count");
+  if (!clock_difference_is(context.end_clock, context.begin_clock, timefac))
+    throw std::invalid_argument(
+        "step exact-clock delta does not match level timefac");
+
+  const double physical_delta_time = base_delta_time / timefac;
+  if (!std::isfinite(physical_delta_time) ||
+      !(physical_delta_time > 0.0))
+    throw std::overflow_error(
+        "level physical delta time is not representable");
+  require_physical_step(context, physical_delta_time);
+
+  return RuntimeClockMetadata{
+      static_cast<int>(context.endpoint_accepted_step), context.end_time,
+      base_delta_time, timefac};
+}
+
+RuntimeClockMetadata
+full_sync_root_runtime_clock(const std::uint64_t completed_epoch,
+                             const double synchronized_time,
+                             const double base_delta_time) {
+  require_finite_positive_dt(base_delta_time);
+  if (!std::isfinite(synchronized_time))
+    throw std::invalid_argument("synchronized physical time must be finite");
+  require_int_iteration(completed_epoch);
+  return RuntimeClockMetadata{static_cast<int>(completed_epoch),
+                              synchronized_time, base_delta_time, 1};
+}
+
+void validate_static_v1_clock_envelope(
+    const StaticV1ClockEnvelope &envelope) {
+  if (envelope.level_count != 2 || envelope.refinement_ratio != 2)
+    throw std::invalid_argument(
+        "static-v1 requires two levels with factor-two refinement");
+  if (envelope.recovering)
+    throw std::invalid_argument("static-v1 does not support recovery");
+  if (envelope.dynamic_regrid)
+    throw std::invalid_argument("static-v1 does not support dynamic regridding");
+
+  require_int_iteration(envelope.completed_epoch);
+  for (const auto accepted_step : envelope.accepted_steps)
+    require_int_iteration(accepted_step);
+  if (envelope.accepted_steps[0] != envelope.completed_epoch)
+    throw std::invalid_argument(
+        "coarse accepted-step count must equal the completed epoch");
+  if (envelope.accepted_steps[0] >
+          std::numeric_limits<std::uint64_t>::max() / 2 ||
+      envelope.accepted_steps[1] != 2 * envelope.accepted_steps[0])
+    throw std::invalid_argument(
+        "fine accepted-step count must be twice the coarse count");
+
+  if (!clock_equals_integer(envelope.synchronized_clock,
+                            envelope.completed_epoch))
+    throw std::invalid_argument(
+        "synchronized exact clock must equal the completed epoch");
+  if (!equal_clock(envelope.level_clocks[0], envelope.synchronized_clock) ||
+      !equal_clock(envelope.level_clocks[1], envelope.synchronized_clock))
+    throw std::invalid_argument(
+        "both level clocks must equal the synchronized clock");
+  if (!clock_difference_is(envelope.level_delta_clocks[0], step_clock_t(0),
+                           1) ||
+      !clock_difference_is(envelope.level_delta_clocks[1], step_clock_t(0),
+                           2))
+    throw std::invalid_argument(
+        "static-v1 level deltas must be exactly one and one-half");
+}
+
+} // namespace CarpetX

--- a/CarpetX/src/subcycling_runtime_clock.hxx
+++ b/CarpetX/src/subcycling_runtime_clock.hxx
@@ -1,0 +1,46 @@
+#ifndef CARPETX_SUBCYCLING_RUNTIME_CLOCK_HXX
+#define CARPETX_SUBCYCLING_RUNTIME_CLOCK_HXX
+
+#include "subcycling_step_context.hxx"
+
+#include <array>
+#include <cstdint>
+
+namespace CarpetX {
+
+struct RuntimeClockMetadata {
+  int iteration;
+  double end_time;
+  double base_delta_time;
+  int timefac;
+};
+
+struct StaticV1ClockEnvelope {
+  int level_count;
+  int refinement_ratio;
+  bool recovering;
+  bool dynamic_regrid;
+  step_clock_t synchronized_clock;
+  std::array<step_clock_t, 2> level_clocks;
+  std::array<step_clock_t, 2> level_delta_clocks;
+  std::uint64_t completed_epoch;
+  std::array<std::uint64_t, 2> accepted_steps;
+};
+
+double static_v1_base_delta_time(double legacy_finest_delta_time,
+                                 int level_count);
+
+RuntimeClockMetadata candidate_runtime_clock(const StepContext &context,
+                                             double base_delta_time);
+
+RuntimeClockMetadata
+full_sync_root_runtime_clock(std::uint64_t completed_epoch,
+                             double synchronized_time,
+                             double base_delta_time);
+
+void validate_static_v1_clock_envelope(
+    const StaticV1ClockEnvelope &envelope);
+
+} // namespace CarpetX
+
+#endif // CARPETX_SUBCYCLING_RUNTIME_CLOCK_HXX

--- a/CarpetX/src/subcycling_runtime_clock.hxx
+++ b/CarpetX/src/subcycling_runtime_clock.hxx
@@ -27,6 +27,26 @@ struct StaticV1ClockEnvelope {
   std::array<std::uint64_t, 2> accepted_steps;
 };
 
+struct StaticV1RecoverySeedEnvelope {
+  int level_count;
+  int refinement_ratio;
+  bool strict_recovery;
+  bool dynamic_regrid;
+  int root_iteration;
+  int root_timefac;
+  double root_time;
+  double base_delta_time;
+  std::array<step_clock_t, 2> rebuilt_level_clocks;
+  std::array<step_clock_t, 2> level_delta_clocks;
+};
+
+struct StaticV1StepperSeed {
+  step_clock_t initial_clock;
+  double initial_physical_time;
+  std::uint64_t initial_epoch;
+  std::array<std::uint64_t, 2> initial_accepted_steps;
+};
+
 double static_v1_base_delta_time(double legacy_finest_delta_time,
                                  int level_count);
 
@@ -37,6 +57,9 @@ RuntimeClockMetadata
 full_sync_root_runtime_clock(std::uint64_t completed_epoch,
                              double synchronized_time,
                              double base_delta_time);
+
+StaticV1StepperSeed static_v1_recovery_seed(
+    const StaticV1RecoverySeedEnvelope &envelope);
 
 void validate_static_v1_clock_envelope(
     const StaticV1ClockEnvelope &envelope);

--- a/CarpetX/src/subcycling_schedule_certification.cxx
+++ b/CarpetX/src/subcycling_schedule_certification.cxx
@@ -1,0 +1,1704 @@
+#include "subcycling_schedule_certification.hxx"
+#include "subcycling_schedule_certification_native_gate.hxx"
+
+#ifndef CARPETX_SUBCYCLING_SCHEDULE_CERTIFICATION_STANDALONE
+#include <cctk_Constants.h>
+#include <cctk_Groups.h>
+#include <cctk_Schedule.h>
+#include <util_Table.h>
+#endif
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <limits>
+#include <map>
+#include <stdexcept>
+#include <tuple>
+
+namespace CarpetX {
+
+bool operator==(const SchedulePatchProvenance &a,
+                const SchedulePatchProvenance &b) noexcept {
+  return std::tie(a.phase, a.sha256) == std::tie(b.phase, b.sha256);
+}
+
+bool operator==(const ScheduleBuildProvenance &a,
+                const ScheduleBuildProvenance &b) noexcept {
+  return std::tie(a.schema_version, a.inventory_abi_version,
+                  a.cactus_flesh_parent, a.cactus_inventory_patch_sha256,
+                  a.carpetx_parent, a.ordered_carpetx_patches, a.compiler_id,
+                  a.compiler_version, a.target_triple, a.cxx_abi, a.byte_order,
+                  a.cctk_type_sizes, a.executable_sha256) ==
+         std::tie(b.schema_version, b.inventory_abi_version,
+                  b.cactus_flesh_parent, b.cactus_inventory_patch_sha256,
+                  b.carpetx_parent, b.ordered_carpetx_patches, b.compiler_id,
+                  b.compiler_version, b.target_triple, b.cxx_abi, b.byte_order,
+                  b.cctk_type_sizes, b.executable_sha256);
+}
+
+bool operator==(const CanonicalTag &a, const CanonicalTag &b) noexcept {
+  return std::tie(a.key, a.type_code, a.element_count, a.value_bytes) ==
+         std::tie(b.key, b.type_code, b.element_count, b.value_bytes);
+}
+
+bool operator==(const CanonicalAccess &a, const CanonicalAccess &b) noexcept {
+  return std::tie(a.variable_name, a.timelevel, a.read_mask, a.write_mask,
+                  a.invalidate_mask) ==
+         std::tie(b.variable_name, b.timelevel, b.read_mask, b.write_mask,
+                  b.invalidate_mask);
+}
+
+bool operator==(const CanonicalGroupTimelevel &a,
+                const CanonicalGroupTimelevel &b) noexcept {
+  return std::tie(a.group, a.timelevel) == std::tie(b.group, b.timelevel);
+}
+
+bool operator==(const CanonicalExecutionFlags &a,
+                const CanonicalExecutionFlags &b) noexcept {
+  return std::tie(a.meta, a.meta_early, a.meta_late, a.global, a.global_early,
+                  a.global_late, a.level, a.singlemap, a.local, a.loop_meta,
+                  a.loop_global, a.loop_level, a.loop_singlemap,
+                  a.loop_local) ==
+         std::tie(b.meta, b.meta_early, b.meta_late, b.global, b.global_early,
+                  b.global_late, b.level, b.singlemap, b.local, b.loop_meta,
+                  b.loop_global, b.loop_level, b.loop_singlemap,
+                  b.loop_local);
+}
+
+bool operator==(const CanonicalScheduleItem &a,
+                const CanonicalScheduleItem &b) noexcept {
+  return std::tie(a.description, a.implementation, a.where, a.thorn, a.routine,
+                  a.language, a.function_type, a.execution_flags,
+                  a.effective_mode, a.tags, a.reads_clauses, a.writes_clauses,
+                  a.invalidates_clauses, a.accesses, a.storage_groups,
+                  a.communication_groups, a.sync_groups, a.trigger_groups,
+                  a.ifs, a.whiles) ==
+         std::tie(b.description, b.implementation, b.where, b.thorn, b.routine,
+                  b.language, b.function_type, b.execution_flags,
+                  b.effective_mode, b.tags, b.reads_clauses, b.writes_clauses,
+                  b.invalidates_clauses, b.accesses, b.storage_groups,
+                  b.communication_groups, b.sync_groups, b.trigger_groups,
+                  b.ifs, b.whiles);
+}
+
+bool operator==(const CanonicalScheduleScope &a,
+                const CanonicalScheduleScope &b) noexcept {
+  return std::tie(a.item_ordinal, a.parent_local_ordinal, a.item) ==
+         std::tie(b.item_ordinal, b.parent_local_ordinal, b.item);
+}
+
+bool operator==(const CanonicalScheduleRecord &a,
+                const CanonicalScheduleRecord &b) noexcept {
+  return std::tie(a.traversal_ordinal, a.item_ordinal, a.parent_local_ordinal,
+                  a.item, a.ancestry) ==
+         std::tie(b.traversal_ordinal, b.item_ordinal, b.parent_local_ordinal,
+                  b.item, b.ancestry);
+}
+
+bool operator==(const CanonicalTargetSchedule &a,
+                const CanonicalTargetSchedule &b) noexcept {
+  return std::tie(a.target, a.body_root, a.entry_state, a.exit_state,
+                  a.entry_exit_included, a.records) ==
+         std::tie(b.target, b.body_root, b.entry_state, b.exit_state,
+                  b.entry_exit_included, b.records);
+}
+
+bool CanonicalScheduleBundle::operator==(
+    const CanonicalScheduleBundle &other) const noexcept {
+  return targets == other.targets;
+}
+
+namespace {
+
+constexpr std::size_t max_ancestry_depth = 256;
+constexpr std::uint32_t provenance_schema_version = 1;
+
+struct TableHandle final {
+  int handle{-1};
+  TableHandle() = default;
+  explicit TableHandle(const int value) : handle(value) {}
+  ~TableHandle() {
+    if (handle >= 0)
+      (void)Util_TableDestroy(handle);
+  }
+  TableHandle(const TableHandle &) = delete;
+  TableHandle &operator=(const TableHandle &) = delete;
+  TableHandle(TableHandle &&other) noexcept : handle(other.handle) {
+    other.handle = -1;
+  }
+  TableHandle &operator=(TableHandle &&other) noexcept {
+    if (this != &other) {
+      if (handle >= 0)
+        (void)Util_TableDestroy(handle);
+      handle = other.handle;
+      other.handle = -1;
+    }
+    return *this;
+  }
+};
+
+struct TableIterator final {
+  int handle{-1};
+  explicit TableIterator(const int value) : handle(value) {}
+  ~TableIterator() {
+    if (handle >= 0)
+      (void)Util_TableItDestroy(handle);
+  }
+  TableIterator(const TableIterator &) = delete;
+  TableIterator &operator=(const TableIterator &) = delete;
+};
+
+[[nodiscard]] ScheduleCertificationFailure
+make_failure(const ScheduleCertificationErrorCode code,
+             const std::optional<SubcyclingScheduleTarget> target,
+             const std::optional<std::uint64_t> ordinal,
+             std::string field, std::string detail) {
+  return {code, target, ordinal, std::move(field), std::move(detail)};
+}
+
+[[nodiscard]] std::string copy_string(const char *const value) {
+  return value == nullptr ? std::string{} : std::string(value);
+}
+
+[[nodiscard]] std::vector<char> copy_buffer(const char *const value) {
+  if (value == nullptr)
+    return {'\0'};
+  const auto length = std::strlen(value);
+  std::vector<char> result(length + 1);
+  std::memcpy(result.data(), value, length + 1);
+  return result;
+}
+
+[[nodiscard]] std::string ascii_lower(std::string value) {
+  for (char &c : value) {
+    if (c >= 'A' && c <= 'Z')
+      c = static_cast<char>(c - 'A' + 'a');
+  }
+  return value;
+}
+
+[[nodiscard]] bool is_hex_string(const std::string &value,
+                                 const std::size_t expected_size) {
+  if (value.size() != expected_size)
+    return false;
+  return std::all_of(value.begin(), value.end(), [](const char c) {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
+           (c >= 'A' && c <= 'F');
+  });
+}
+
+[[nodiscard]] bool normalize_provenance(
+    const ScheduleBuildProvenance &input, ScheduleBuildProvenance &output,
+    std::string &field, std::string &detail) {
+  output = input;
+  if (output.schema_version != provenance_schema_version) {
+    field = "provenance.schema_version";
+    detail = "unsupported provenance schema";
+    return false;
+  }
+  if (output.inventory_abi_version != CCTK_SCHEDULE_INVENTORY_ABI_VERSION) {
+    field = "provenance.inventory_abi_version";
+    detail = "schedule inventory ABI does not match this build";
+    return false;
+  }
+  const auto normalize_git = [&](std::string &value,
+                                 const char *const name) -> bool {
+    if (!is_hex_string(value, 40)) {
+      field = name;
+      detail = "expected exactly 40 hexadecimal characters";
+      return false;
+    }
+    value = ascii_lower(std::move(value));
+    return true;
+  };
+  const auto normalize_sha = [&](std::string &value,
+                                 const char *const name) -> bool {
+    if (!is_hex_string(value, 64)) {
+      field = name;
+      detail = "expected exactly 64 hexadecimal characters";
+      return false;
+    }
+    value = ascii_lower(std::move(value));
+    return true;
+  };
+  if (!normalize_git(output.cactus_flesh_parent,
+                     "provenance.cactus_flesh_parent") ||
+      !normalize_sha(output.cactus_inventory_patch_sha256,
+                     "provenance.cactus_inventory_patch_sha256") ||
+      !normalize_git(output.carpetx_parent, "provenance.carpetx_parent"))
+    return false;
+  if (output.ordered_carpetx_patches.empty()) {
+    field = "provenance.ordered_carpetx_patches";
+    detail = "ordered overlay list must not be empty";
+    return false;
+  }
+  for (std::size_t i = 0; i < output.ordered_carpetx_patches.size(); ++i) {
+    auto &patch = output.ordered_carpetx_patches[i];
+    if (patch.phase.empty()) {
+      field = "provenance.ordered_carpetx_patches[" + std::to_string(i) +
+              "].phase";
+      detail = "phase must not be empty";
+      return false;
+    }
+    if (!normalize_sha(patch.sha256,
+                       ("provenance.ordered_carpetx_patches[" +
+                        std::to_string(i) + "].sha256")
+                           .c_str()))
+      return false;
+  }
+  if (output.compiler_id.empty() || output.compiler_version.empty() ||
+      output.target_triple.empty() || output.cxx_abi.empty() ||
+      output.byte_order.empty()) {
+    field = "provenance.compiler_abi";
+    detail = "compiler, target, ABI, and byte order fields must be nonempty";
+    return false;
+  }
+  if (output.byte_order != "little" && output.byte_order != "big") {
+    field = "provenance.byte_order";
+    detail = "byte order must be 'little' or 'big'";
+    return false;
+  }
+  if (output.cctk_type_sizes.empty()) {
+    field = "provenance.cctk_type_sizes";
+    detail = "CCTK type-size tuple must not be empty";
+    return false;
+  }
+  std::map<int, int> type_sizes;
+  for (std::size_t i = 0; i < output.cctk_type_sizes.size(); ++i) {
+    const auto &entry = output.cctk_type_sizes[i];
+    if (entry.second <= 0 || !type_sizes.emplace(entry).second) {
+      field = "provenance.cctk_type_sizes";
+      detail = "type codes must be unique and sizes positive";
+      return false;
+    }
+    const int live_size = CCTK_VarTypeSize(entry.first);
+    if (live_size <= 0 || entry.second != live_size) {
+      field = "provenance.cctk_type_sizes[" + std::to_string(i) + "].size";
+      detail = "type size does not match CCTK_VarTypeSize in this build";
+      return false;
+    }
+  }
+  if (!normalize_sha(output.executable_sha256,
+                     "provenance.executable_sha256"))
+    return false;
+  return true;
+}
+
+[[nodiscard]] bool valid_count_and_pointer(const int count, const void *pointer) {
+  return count >= 0 && (count == 0 || pointer != nullptr);
+}
+
+[[nodiscard]] CanonicalExecutionFlags
+execution_flags(const cFunctionData &data) {
+  return {data.meta,
+          data.meta_early,
+          data.meta_late,
+          data.global,
+          data.global_early,
+          data.global_late,
+          data.level,
+          data.singlemap,
+          data.local,
+          data.loop_meta,
+          data.loop_global,
+          data.loop_level,
+          data.loop_singlemap,
+          data.loop_local};
+}
+
+[[nodiscard]] bool validate_local_scope(
+    const cFunctionData &data, CanonicalScheduleMode &mode,
+    ScheduleCertificationFailure &failure,
+    const SubcyclingScheduleTarget target, const std::uint64_t ordinal,
+    const std::string &prefix) {
+  const auto flags = execution_flags(data);
+  if (flags.meta != 0 || flags.meta_early != 0 || flags.meta_late != 0 ||
+      flags.global != 0 || flags.global_early != 0 ||
+      flags.global_late != 0 || flags.level != 0 || flags.singlemap != 0 ||
+      flags.local < 0 || flags.local > 1 || flags.loop_meta != 0 ||
+      flags.loop_global != 0 || flags.loop_level != 0 ||
+      flags.loop_singlemap != 0 || flags.loop_local != 0) {
+    failure = make_failure(ScheduleCertificationErrorCode::unsupported_metadata,
+                           target, ordinal, prefix + ".execution_mode",
+                           "only default-local or explicit local is supported");
+    return false;
+  }
+  mode = data.local == 0 ? CanonicalScheduleMode::default_local
+                         : CanonicalScheduleMode::local;
+  return true;
+}
+
+[[nodiscard]] bool canonicalize_table(
+    const int source_handle, const bool clone_leaf,
+    std::vector<CanonicalTag> &tags, TableHandle &owned_clone,
+    ScheduleCertificationFailure &failure,
+    const SubcyclingScheduleTarget target, const std::uint64_t ordinal,
+    const std::string &prefix) {
+  const int flags = Util_TableQueryFlags(source_handle);
+  if (flags != UTIL_TABLE_FLAGS_CASE_INSENSITIVE) {
+    failure = make_failure(ScheduleCertificationErrorCode::tag_error, target,
+                           ordinal, prefix + ".tags.flags",
+                           "tag table must be exactly case-insensitive");
+    return false;
+  }
+  const int key_count = Util_TableQueryNKeys(source_handle);
+  const int max_key_length = Util_TableQueryMaxKeyLength(source_handle);
+  if (key_count < 0 || max_key_length < 0) {
+    failure = make_failure(ScheduleCertificationErrorCode::tag_error, target,
+                           ordinal, prefix + ".tags.shape",
+                           "failed to query tag table shape");
+    return false;
+  }
+  TableIterator iterator(Util_TableItCreate(source_handle));
+  if (iterator.handle < 0) {
+    failure = make_failure(ScheduleCertificationErrorCode::tag_error, target,
+                           ordinal, prefix + ".tags.iterator",
+                           "failed to create tag-table iterator");
+    return false;
+  }
+  tags.clear();
+  tags.reserve(static_cast<std::size_t>(key_count));
+  std::map<std::string, bool> normalized_keys;
+  for (int i = 0; i < key_count; ++i) {
+    std::vector<char> key(static_cast<std::size_t>(max_key_length) + 1U, '\0');
+    CCTK_INT type_code = 0;
+    CCTK_INT element_count = 0;
+    const int key_length = Util_TableItQueryKeyValueInfo(
+        iterator.handle, static_cast<int>(key.size()), key.data(), &type_code,
+        &element_count);
+    if (key_length < 0) {
+      failure = make_failure(ScheduleCertificationErrorCode::tag_error, target,
+                             ordinal, prefix + ".tags.iterator",
+                             "failed to query tag-table iterator entry");
+      return false;
+    }
+    if (key_length > max_key_length || element_count <= 0) {
+      failure = make_failure(ScheduleCertificationErrorCode::tag_error, target,
+                             ordinal, prefix + ".tags.entry",
+                             "malformed tag-table entry");
+      return false;
+    }
+    std::string normalized = ascii_lower(std::string(key.data()));
+    if (!normalized_keys.emplace(normalized, true).second) {
+      failure = make_failure(ScheduleCertificationErrorCode::tag_error, target,
+                             ordinal, prefix + ".tags.key",
+                             "duplicate normalized tag key");
+      return false;
+    }
+    const int type = static_cast<int>(type_code);
+    if (type == CCTK_VARIABLE_STRING || type == CCTK_VARIABLE_POINTER ||
+        type == CCTK_VARIABLE_POINTER_TO_CONST ||
+        type == CCTK_VARIABLE_FPOINTER) {
+      failure = make_failure(ScheduleCertificationErrorCode::tag_error, target,
+                             ordinal, prefix + ".tags.type",
+                             "pointer-valued tags are unsupported");
+      return false;
+    }
+    const int type_size = CCTK_VarTypeSize(type);
+    if (type_size <= 0) {
+      failure = make_failure(ScheduleCertificationErrorCode::tag_error, target,
+                             ordinal, prefix + ".tags.type",
+                             "unknown or zero-size tag type");
+      return false;
+    }
+    const auto count = static_cast<std::uint64_t>(element_count);
+    if (count > std::numeric_limits<std::size_t>::max() /
+                    static_cast<std::size_t>(type_size)) {
+      failure = make_failure(ScheduleCertificationErrorCode::tag_error, target,
+                             ordinal, prefix + ".tags.size",
+                             "tag byte size overflows size_t");
+      return false;
+    }
+    std::vector<std::uint8_t> bytes(
+        static_cast<std::size_t>(count) * static_cast<std::size_t>(type_size));
+    const int got = Util_TableGetGenericArray(source_handle, type,
+                                              static_cast<int>(element_count),
+                                              bytes.data(), key.data());
+    if (got != static_cast<int>(element_count)) {
+      failure = make_failure(ScheduleCertificationErrorCode::tag_error, target,
+                             ordinal, prefix + ".tags.value",
+                             "tag element count changed while reading");
+      return false;
+    }
+    tags.push_back({std::move(normalized), type, count, std::move(bytes)});
+    const int advance = Util_TableItAdvance(iterator.handle);
+    const int expected_advance = i + 1 < key_count ? 1 : 0;
+    if (advance != expected_advance) {
+      failure = make_failure(ScheduleCertificationErrorCode::tag_error, target,
+                             ordinal, prefix + ".tags.iterator",
+                             "iterator cardinality differs from key count");
+      return false;
+    }
+  }
+  if (Util_TableItQueryIsNull(iterator.handle) != 1) {
+    failure = make_failure(ScheduleCertificationErrorCode::tag_error, target,
+                           ordinal, prefix + ".tags.iterator",
+                           "iterator did not end after exact key count");
+    return false;
+  }
+  std::sort(tags.begin(), tags.end(), [](const CanonicalTag &a,
+                                         const CanonicalTag &b) {
+    return a.key < b.key;
+  });
+  if (clone_leaf) {
+    const int clone = Util_TableClone(source_handle);
+    if (clone < 0) {
+      failure = make_failure(ScheduleCertificationErrorCode::tag_error, target,
+                             ordinal, prefix + ".tags.clone",
+                             "failed to clone leaf tag table");
+      return false;
+    }
+    owned_clone = TableHandle(clone);
+  }
+  return true;
+}
+
+[[nodiscard]] bool canonical_group_name(
+    const int index, std::string &name, ScheduleCertificationFailure &failure,
+    const SubcyclingScheduleTarget target, const std::uint64_t ordinal,
+    const std::string &field) {
+  const char *const raw = CCTK_FullGroupName(index);
+  if (raw == nullptr) {
+    failure = make_failure(ScheduleCertificationErrorCode::name_resolution_error,
+                           target, ordinal, field,
+                           "group index has no fully qualified name");
+    return false;
+  }
+  name = raw;
+  if (CCTK_GroupIndex(name.c_str()) != index) {
+    failure = make_failure(ScheduleCertificationErrorCode::name_resolution_error,
+                           target, ordinal, field,
+                           "group full-name roundtrip failed");
+    return false;
+  }
+  return true;
+}
+
+[[nodiscard]] bool canonical_variable_name(
+    const int index, std::string &name, ScheduleCertificationFailure &failure,
+    const SubcyclingScheduleTarget target, const std::uint64_t ordinal,
+    const std::string &field) {
+  const char *const raw = CCTK_FullVarName(index);
+  if (raw == nullptr) {
+    failure = make_failure(ScheduleCertificationErrorCode::name_resolution_error,
+                           target, ordinal, field,
+                           "variable index has no fully qualified name");
+    return false;
+  }
+  name = raw;
+  if (CCTK_VarIndex(name.c_str()) != index) {
+    failure = make_failure(ScheduleCertificationErrorCode::name_resolution_error,
+                           target, ordinal, field,
+                           "variable full-name roundtrip failed");
+    return false;
+  }
+  return true;
+}
+
+[[nodiscard]] bool canonicalize_accesses(
+    const cFunctionData &data, std::vector<CanonicalAccess> &accesses,
+    ScheduleCertificationFailure &failure,
+    const SubcyclingScheduleTarget target, const std::uint64_t ordinal,
+    const std::string &prefix) {
+  if (!valid_count_and_pointer(data.n_RDWR, data.RDWR)) {
+    failure = make_failure(ScheduleCertificationErrorCode::malformed_record,
+                           target, ordinal, prefix + ".rdwr",
+                           "invalid RDWR count/pointer pair");
+    return false;
+  }
+  using AccessKey = std::pair<std::string, int>;
+  std::map<AccessKey, CanonicalAccess> merged;
+  constexpr int valid_regions = CCTK_VALID_GHOSTS | CCTK_VALID_BOUNDARY |
+                                CCTK_VALID_INTERIOR;
+  for (int i = 0; i < data.n_RDWR; ++i) {
+    const auto &entry = data.RDWR[i];
+    if (entry.timelevel != 0 || entry.where_rd < 0 || entry.where_wr < 0 ||
+        entry.where_inv < 0 ||
+        ((entry.where_rd | entry.where_wr | entry.where_inv) &
+         ~valid_regions) != 0) {
+      failure = make_failure(ScheduleCertificationErrorCode::unsupported_metadata,
+                             target, ordinal, prefix + ".accesses",
+                             "only timelevel-zero standard region masks are supported");
+      return false;
+    }
+    std::string variable_name;
+    if (!canonical_variable_name(entry.varindex, variable_name, failure, target,
+                                 ordinal, prefix + ".accesses.variable_name"))
+      return false;
+    const int group_index = CCTK_GroupIndexFromVarI(entry.varindex);
+    std::string group_name;
+    if (group_index < 0 ||
+        !canonical_group_name(group_index, group_name, failure, target, ordinal,
+                              prefix + ".accesses.group_name"))
+      return false;
+    cGroup group{};
+    if (CCTK_GroupData(group_index, &group) != 0 ||
+        group.grouptype != CCTK_GF || group.vartype != CCTK_VARIABLE_REAL ||
+        CCTK_VarTypeI(entry.varindex) != CCTK_VARIABLE_REAL ||
+        CCTK_DeclaredTimeLevelsVI(entry.varindex) <= 0) {
+      failure = make_failure(ScheduleCertificationErrorCode::unsupported_metadata,
+                             target, ordinal, prefix + ".accesses.variable",
+                             "only GF REAL variables with declared TL0 are supported");
+      return false;
+    }
+    const AccessKey key{variable_name, entry.timelevel};
+    auto found = merged.find(key);
+    if (found == merged.end()) {
+      found = merged
+                  .emplace(key, CanonicalAccess{variable_name, entry.timelevel,
+                                                0, 0, 0})
+                  .first;
+    }
+    found->second.read_mask |= entry.where_rd;
+    found->second.write_mask |= entry.where_wr;
+    found->second.invalidate_mask |= entry.where_inv;
+  }
+  accesses.clear();
+  for (auto &entry : merged)
+    accesses.push_back(std::move(entry.second));
+  const bool normalized_reads = std::any_of(
+      accesses.begin(), accesses.end(),
+      [](const CanonicalAccess &a) { return a.read_mask != 0; });
+  const bool normalized_writes = std::any_of(
+      accesses.begin(), accesses.end(),
+      [](const CanonicalAccess &a) { return a.write_mask != 0; });
+  const bool normalized_invalidates = std::any_of(
+      accesses.begin(), accesses.end(),
+      [](const CanonicalAccess &a) { return a.invalidate_mask != 0; });
+  if ((data.n_ReadsClauses > 0) != normalized_reads ||
+      (data.n_WritesClauses > 0) != normalized_writes ||
+      (data.n_InvalidatesClauses > 0) != normalized_invalidates) {
+    failure = make_failure(ScheduleCertificationErrorCode::malformed_record,
+                           target, ordinal, prefix + ".accesses.raw_normalized",
+                           "raw clauses contradict normalized access masks");
+    return false;
+  }
+  return true;
+}
+
+[[nodiscard]] bool copy_string_array(
+    const int count, const char *const *const values,
+    std::vector<std::string> &output, ScheduleCertificationFailure &failure,
+    const SubcyclingScheduleTarget target, const std::uint64_t ordinal,
+    const std::string &field) {
+  if (!valid_count_and_pointer(count, values)) {
+    failure = make_failure(ScheduleCertificationErrorCode::malformed_record,
+                           target, ordinal, field,
+                           "invalid string-array count/pointer pair");
+    return false;
+  }
+  output.clear();
+  output.reserve(static_cast<std::size_t>(count));
+  for (int i = 0; i < count; ++i) {
+    if (values[i] == nullptr) {
+      failure = make_failure(ScheduleCertificationErrorCode::malformed_record,
+                             target, ordinal, field,
+                             "string-array element is null");
+      return false;
+    }
+    output.emplace_back(values[i]);
+  }
+  return true;
+}
+
+[[nodiscard]] bool canonicalize_group_array(
+    const int count, const int *const indices, std::vector<std::string> &output,
+    ScheduleCertificationFailure &failure,
+    const SubcyclingScheduleTarget target, const std::uint64_t ordinal,
+    const std::string &field) {
+  if (!valid_count_and_pointer(count, indices)) {
+    failure = make_failure(ScheduleCertificationErrorCode::malformed_record,
+                           target, ordinal, field,
+                           "invalid group-array count/pointer pair");
+    return false;
+  }
+  output.clear();
+  output.reserve(static_cast<std::size_t>(count));
+  for (int i = 0; i < count; ++i) {
+    std::string name;
+    if (!canonical_group_name(indices[i], name, failure, target, ordinal,
+                              field + ".name"))
+      return false;
+    output.push_back(std::move(name));
+  }
+  return true;
+}
+
+[[nodiscard]] bool canonicalize_item(
+    const char *const description, const char *const implementation,
+    const cFunctionData *const function_data, const int n_storage_groups,
+    const int *const storage_groups, const int *const storage_timelevels,
+    const int n_communication_groups, const int *const communication_groups,
+    const int n_ifs, const char *const *const ifs, const int n_whiles,
+    const char *const *const whiles, const bool leaf,
+    CanonicalScheduleItem &item, TableHandle &leaf_tag_clone,
+    ScheduleCertificationFailure &failure,
+    const SubcyclingScheduleTarget target, const std::uint64_t ordinal,
+    const std::string &prefix) {
+  if (function_data == nullptr) {
+    failure = make_failure(ScheduleCertificationErrorCode::malformed_record,
+                           target, ordinal, prefix + ".function_data",
+                           "function data is null");
+    return false;
+  }
+  const cFunctionData &data = *function_data;
+  if (description == nullptr || implementation == nullptr ||
+      data.where == nullptr || data.thorn == nullptr ||
+      data.routine == nullptr) {
+    failure = make_failure(ScheduleCertificationErrorCode::malformed_record,
+                           target, ordinal, prefix + ".identity",
+                           "schedule identity strings must not be null");
+    return false;
+  }
+  item.description = copy_string(description);
+  item.implementation = copy_string(implementation);
+  item.where = copy_string(data.where);
+  item.thorn = copy_string(data.thorn);
+  item.routine = copy_string(data.routine);
+  item.language = static_cast<int>(data.language);
+  item.function_type = static_cast<int>(data.type);
+  item.execution_flags = execution_flags(data);
+
+  if (!canonicalize_table(data.tags, leaf, item.tags, leaf_tag_clone, failure,
+                          target, ordinal, prefix))
+    return false;
+
+  if (!validate_local_scope(data, item.effective_mode, failure, target,
+                            ordinal, prefix))
+    return false;
+  if (leaf &&
+      (data.language != LangC || data.type != FunctionStandard)) {
+    failure = make_failure(ScheduleCertificationErrorCode::unsupported_metadata,
+                           target, ordinal, prefix + ".call_convention",
+                           "leaf must be LangC and FunctionStandard");
+    return false;
+  }
+
+  if (!valid_count_and_pointer(data.n_SyncGroups, data.SyncGroups) ||
+      !valid_count_and_pointer(data.n_TriggerGroups, data.TriggerGroups)) {
+    failure = make_failure(ScheduleCertificationErrorCode::malformed_record,
+                           target, ordinal, prefix + ".hazard_groups",
+                           "invalid sync/trigger count/pointer pair");
+    return false;
+  }
+  if (!canonicalize_group_array(data.n_SyncGroups, data.SyncGroups,
+                                item.sync_groups, failure, target, ordinal,
+                                prefix + ".sync_groups") ||
+      !canonicalize_group_array(data.n_TriggerGroups, data.TriggerGroups,
+                                item.trigger_groups, failure, target, ordinal,
+                                prefix + ".trigger_groups"))
+    return false;
+
+  if (!copy_string_array(data.n_ReadsClauses, data.ReadsClauses,
+                         item.reads_clauses, failure, target, ordinal,
+                         prefix + ".reads_clauses") ||
+      !copy_string_array(data.n_WritesClauses, data.WritesClauses,
+                         item.writes_clauses, failure, target, ordinal,
+                         prefix + ".writes_clauses") ||
+      !copy_string_array(data.n_InvalidatesClauses,
+                         data.InvalidatesClauses,
+                         item.invalidates_clauses, failure, target, ordinal,
+                         prefix + ".invalidates_clauses") ||
+      !canonicalize_accesses(data, item.accesses, failure, target, ordinal,
+                             prefix))
+    return false;
+
+  if (!valid_count_and_pointer(n_storage_groups, storage_groups) ||
+      !valid_count_and_pointer(n_storage_groups, storage_timelevels)) {
+    failure = make_failure(ScheduleCertificationErrorCode::malformed_record,
+                           target, ordinal, prefix + ".storage_groups",
+                           "invalid storage count/pointer pair");
+    return false;
+  }
+  item.storage_groups.clear();
+  item.storage_groups.reserve(static_cast<std::size_t>(n_storage_groups));
+  for (int i = 0; i < n_storage_groups; ++i) {
+    std::string name;
+    if (!canonical_group_name(storage_groups[i], name, failure, target,
+                              ordinal, prefix + ".storage_groups.name"))
+      return false;
+    item.storage_groups.push_back({std::move(name), storage_timelevels[i]});
+  }
+  if (!canonicalize_group_array(n_communication_groups, communication_groups,
+                                item.communication_groups, failure, target,
+                                ordinal, prefix + ".communication_groups") ||
+      !copy_string_array(n_ifs, ifs, item.ifs, failure, target, ordinal,
+                         prefix + ".ifs") ||
+      !copy_string_array(n_whiles, whiles, item.whiles, failure, target,
+                         ordinal, prefix + ".whiles"))
+    return false;
+
+  if (!item.storage_groups.empty() || !item.communication_groups.empty() ||
+      !item.sync_groups.empty() || !item.trigger_groups.empty() ||
+      !item.ifs.empty() || !item.whiles.empty()) {
+    failure = make_failure(ScheduleCertificationErrorCode::unsupported_metadata,
+                           target, ordinal, prefix + ".hazards",
+                           "storage, communication, sync, trigger, IF, and WHILE are unsupported");
+    return false;
+  }
+  return true;
+}
+
+struct OwnedFunctionData final {
+  cFunctionData data{};
+  void *opaque_call_handle{};
+  TableHandle tags;
+  std::vector<int> sync_groups;
+  std::vector<int> trigger_groups;
+  std::vector<RDWR_entry> rdwr;
+  std::vector<std::vector<char>> reads_buffers;
+  std::vector<std::vector<char>> writes_buffers;
+  std::vector<std::vector<char>> invalidates_buffers;
+  std::vector<const char *> reads_pointers;
+  std::vector<const char *> writes_pointers;
+  std::vector<const char *> invalidates_pointers;
+  std::vector<char> where;
+  std::vector<char> routine;
+  std::vector<char> thorn;
+  std::vector<int> storage_group_indices;
+  std::vector<int> storage_timelevels;
+  std::vector<int> communication_group_indices;
+  std::vector<std::string> if_strings;
+  std::vector<std::string> while_strings;
+  CanonicalScheduleRecord canonical;
+
+  OwnedFunctionData() = default;
+  OwnedFunctionData(const OwnedFunctionData &) = delete;
+  OwnedFunctionData &operator=(const OwnedFunctionData &) = delete;
+  OwnedFunctionData(OwnedFunctionData &&) = delete;
+  OwnedFunctionData &operator=(OwnedFunctionData &&) = delete;
+
+  void capture(const cFunctionData &source, TableHandle source_tags,
+               void *const handle, const cScheduleInventoryRecord &record) {
+    data = source;
+    // The call-convention bridge is metadata only in this phase. Preserve its
+    // exact value with the rest of cFunctionData, but never invoke it.
+    data.FortranCaller = source.FortranCaller;
+    opaque_call_handle = handle;
+    tags = std::move(source_tags);
+    if (source.n_SyncGroups > 0)
+      sync_groups.assign(source.SyncGroups,
+                         source.SyncGroups + source.n_SyncGroups);
+    if (source.n_TriggerGroups > 0)
+      trigger_groups.assign(source.TriggerGroups,
+                            source.TriggerGroups + source.n_TriggerGroups);
+    if (source.n_RDWR > 0)
+      rdwr.assign(source.RDWR, source.RDWR + source.n_RDWR);
+    copy_clause_buffers(source.n_ReadsClauses, source.ReadsClauses,
+                        reads_buffers, reads_pointers);
+    copy_clause_buffers(source.n_WritesClauses, source.WritesClauses,
+                        writes_buffers, writes_pointers);
+    copy_clause_buffers(source.n_InvalidatesClauses,
+                        source.InvalidatesClauses, invalidates_buffers,
+                        invalidates_pointers);
+    where = copy_buffer(source.where);
+    routine = copy_buffer(source.routine);
+    thorn = copy_buffer(source.thorn);
+    if (record.n_storage_groups > 0) {
+      storage_group_indices.assign(
+          record.storage_groups,
+          record.storage_groups + record.n_storage_groups);
+      storage_timelevels.assign(
+          record.storage_timelevels,
+          record.storage_timelevels + record.n_storage_groups);
+    }
+    if (record.n_communication_groups > 0)
+      communication_group_indices.assign(
+          record.communication_groups,
+          record.communication_groups + record.n_communication_groups);
+    for (int i = 0; i < record.n_ifs; ++i)
+      if_strings.emplace_back(record.ifs[i]);
+    for (int i = 0; i < record.n_whiles; ++i)
+      while_strings.emplace_back(record.whiles[i]);
+    rebind();
+  }
+
+private:
+  static void copy_clause_buffers(
+      const int count, const char *const *const source,
+      std::vector<std::vector<char>> &buffers,
+      std::vector<const char *> &pointers) {
+    buffers.clear();
+    pointers.clear();
+    buffers.reserve(static_cast<std::size_t>(count));
+    pointers.reserve(static_cast<std::size_t>(count));
+    for (int i = 0; i < count; ++i)
+      buffers.push_back(copy_buffer(source[i]));
+    for (const auto &buffer : buffers)
+      pointers.push_back(buffer.data());
+  }
+
+  void rebind() noexcept {
+    data.SyncGroups = sync_groups.empty() ? nullptr : sync_groups.data();
+    data.TriggerGroups =
+        trigger_groups.empty() ? nullptr : trigger_groups.data();
+    data.RDWR = rdwr.empty() ? nullptr : rdwr.data();
+    data.ReadsClauses =
+        reads_pointers.empty() ? nullptr : reads_pointers.data();
+    data.WritesClauses =
+        writes_pointers.empty() ? nullptr : writes_pointers.data();
+    data.InvalidatesClauses =
+        invalidates_pointers.empty() ? nullptr : invalidates_pointers.data();
+    data.where = where.data();
+    data.routine = routine.data();
+    data.thorn = thorn.data();
+    data.tags = tags.handle;
+  }
+};
+
+struct CandidateTarget final {
+  CanonicalTargetSchedule manifest;
+  std::vector<std::unique_ptr<OwnedFunctionData>> functions;
+};
+
+using ObservedParentPath = std::vector<std::uint64_t>;
+
+struct ObservedScheduleNode final {
+  CanonicalScheduleItem item;
+  ObservedParentPath parent_path;
+  std::uint64_t parent_local_ordinal{};
+  bool is_scope{};
+};
+
+struct CollectContext final {
+  SubcyclingScheduleTarget target;
+  std::string root;
+  CandidateTarget *candidate{};
+  std::optional<ScheduleCertificationFailure> failure;
+  std::uint64_t next_traversal_ordinal{};
+  std::optional<std::uint64_t> last_item_ordinal;
+  // This flag is the only state touched from a catch block in the noexcept C
+  // callback. Constructing the diagnostic is deliberately deferred until the
+  // inventory call has returned to the ordinary C++ boundary.
+  bool callback_exception{};
+  std::optional<std::uint64_t> last_first_seen_item_ordinal;
+  std::map<std::uint64_t, ObservedScheduleNode> nodes_by_item_ordinal;
+  std::map<ObservedParentPath, std::map<std::uint64_t, std::uint64_t>>
+      children_by_parent_path;
+};
+
+[[nodiscard]] bool validate_observed_node(
+    CollectContext &context, const std::uint64_t item_ordinal,
+    const std::uint64_t parent_local_ordinal,
+    const CanonicalScheduleItem &item, const ObservedParentPath &parent_path,
+    const bool is_scope, const std::uint64_t traversal,
+    const std::string &prefix) {
+  const auto known_node = context.nodes_by_item_ordinal.find(item_ordinal);
+  if (known_node != context.nodes_by_item_ordinal.end()) {
+    if (known_node->second.is_scope != is_scope) {
+      context.failure = make_failure(
+          ScheduleCertificationErrorCode::malformed_record, context.target,
+          traversal, prefix + ".node_kind",
+          "repeated item ordinal changed between scope and leaf");
+      return false;
+    }
+    if (!(known_node->second.item == item)) {
+      context.failure = make_failure(
+          ScheduleCertificationErrorCode::malformed_record, context.target,
+          traversal, prefix + ".item_identity",
+          "repeated item ordinal changed canonical item metadata");
+      return false;
+    }
+    if (known_node->second.parent_path != parent_path) {
+      context.failure = make_failure(
+          ScheduleCertificationErrorCode::malformed_record, context.target,
+          traversal, prefix + ".parent_path",
+          "repeated item ordinal changed its observed parent path");
+      return false;
+    }
+    if (known_node->second.parent_local_ordinal != parent_local_ordinal) {
+      context.failure = make_failure(
+          ScheduleCertificationErrorCode::malformed_record, context.target,
+          traversal, prefix + ".parent_local_ordinal",
+          "repeated item ordinal changed its sibling-local ordinal");
+      return false;
+    }
+  } else if (context.last_first_seen_item_ordinal.has_value() &&
+             item_ordinal <= *context.last_first_seen_item_ordinal) {
+    context.failure = make_failure(
+        ScheduleCertificationErrorCode::malformed_record, context.target,
+        traversal, prefix + ".item_ordinal",
+        "first-seen item ordinals must be strictly increasing");
+    return false;
+  }
+
+  auto &children = context.children_by_parent_path[parent_path];
+  const auto known_slot = children.find(parent_local_ordinal);
+  if (known_slot != children.end() && known_slot->second != item_ordinal) {
+    context.failure = make_failure(
+        ScheduleCertificationErrorCode::malformed_record, context.target,
+        traversal, prefix + ".parent_local_ordinal",
+        "parent path and sibling-local ordinal identify multiple items");
+    return false;
+  }
+  if (known_slot == children.end()) {
+    const auto expected_local_ordinal =
+        static_cast<std::uint64_t>(children.size());
+    if (parent_local_ordinal != expected_local_ordinal) {
+      context.failure = make_failure(
+          ScheduleCertificationErrorCode::malformed_record, context.target,
+          traversal, prefix + ".parent_local_ordinal",
+          "new observed siblings must have contiguous local ordinals");
+      return false;
+    }
+    children.emplace(parent_local_ordinal, item_ordinal);
+  }
+  if (known_node == context.nodes_by_item_ordinal.end())
+    context.nodes_by_item_ordinal.emplace(
+        item_ordinal,
+        ObservedScheduleNode{item, parent_path, parent_local_ordinal,
+                             is_scope});
+  if (known_node == context.nodes_by_item_ordinal.end())
+    context.last_first_seen_item_ordinal = item_ordinal;
+  return true;
+}
+
+[[nodiscard]] bool validate_scope_shape(
+    const cScheduleInventoryScope &scope, const std::uint64_t traversal,
+    const SubcyclingScheduleTarget target, const std::size_t index,
+    ScheduleCertificationFailure &failure) {
+  if (scope.abi_version != CCTK_SCHEDULE_INVENTORY_ABI_VERSION ||
+      scope.struct_size != sizeof(cScheduleInventoryScope)) {
+    failure = make_failure(ScheduleCertificationErrorCode::abi_mismatch, target,
+                           traversal,
+                           "record.ancestry[" + std::to_string(index) +
+                               "].abi",
+                           "scope ABI version or size mismatch");
+    return false;
+  }
+  return true;
+}
+
+[[nodiscard]] bool collect_one_record(CollectContext &context,
+                                      const cScheduleInventoryRecord &record,
+                                      void *const opaque_call_handle) {
+  const auto ordinal = context.next_traversal_ordinal;
+  if (record.abi_version != CCTK_SCHEDULE_INVENTORY_ABI_VERSION ||
+      record.struct_size != sizeof(cScheduleInventoryRecord)) {
+    context.failure = make_failure(
+        ScheduleCertificationErrorCode::abi_mismatch, context.target, ordinal,
+        "record.abi", "record ABI version or size mismatch");
+    return false;
+  }
+  if (record.root_group == nullptr || context.root != record.root_group ||
+      record.entry_exit_included != 0) {
+    context.failure = make_failure(
+        ScheduleCertificationErrorCode::malformed_record, context.target,
+        ordinal, "record.root",
+        "record root mismatch or ENTRY/EXIT was included");
+    return false;
+  }
+  if (record.traversal_ordinal != ordinal ||
+      (context.last_item_ordinal.has_value() &&
+       record.item_ordinal <= *context.last_item_ordinal)) {
+    context.failure = make_failure(
+        ScheduleCertificationErrorCode::malformed_record, context.target,
+        ordinal, "record.ordinals",
+        "traversal ordinals must be contiguous and item ordinals increasing");
+    return false;
+  }
+  if (record.n_enclosing_groups > max_ancestry_depth ||
+      (record.n_enclosing_groups > 0 && record.enclosing_groups == nullptr)) {
+    context.failure = make_failure(
+        ScheduleCertificationErrorCode::malformed_record, context.target,
+        ordinal, "record.ancestry", "invalid ancestry depth/pointer pair");
+    return false;
+  }
+
+  auto owned = std::make_unique<OwnedFunctionData>();
+  owned->canonical.traversal_ordinal = record.traversal_ordinal;
+  owned->canonical.item_ordinal = record.item_ordinal;
+  owned->canonical.parent_local_ordinal = record.parent_local_ordinal;
+  TableHandle leaf_tag_clone;
+  ScheduleCertificationFailure failure{};
+  if (!canonicalize_item(
+          record.description, record.implementation, record.function_data,
+          record.n_storage_groups, record.storage_groups,
+          record.storage_timelevels, record.n_communication_groups,
+          record.communication_groups, record.n_ifs, record.ifs,
+          record.n_whiles, record.whiles, true, owned->canonical.item,
+          leaf_tag_clone, failure, context.target, ordinal, "record.item")) {
+    context.failure = std::move(failure);
+    return false;
+  }
+  std::optional<std::uint64_t> previous_scope_item;
+  ObservedParentPath parent_path;
+  owned->canonical.ancestry.reserve(record.n_enclosing_groups);
+  for (std::size_t i = 0; i < record.n_enclosing_groups; ++i) {
+    const auto &scope = record.enclosing_groups[i];
+    if (!validate_scope_shape(scope, ordinal, context.target, i, failure)) {
+      context.failure = std::move(failure);
+      return false;
+    }
+    if ((previous_scope_item.has_value() &&
+         scope.item_ordinal <= *previous_scope_item) ||
+        scope.item_ordinal >= record.item_ordinal) {
+      context.failure = make_failure(
+          ScheduleCertificationErrorCode::malformed_record, context.target,
+          ordinal,
+          "record.ancestry[" + std::to_string(i) + "].item_ordinal",
+          "ancestry item ordinals are not outer-to-inner increasing");
+      return false;
+    }
+    CanonicalScheduleScope canonical_scope;
+    canonical_scope.item_ordinal = scope.item_ordinal;
+    canonical_scope.parent_local_ordinal = scope.parent_local_ordinal;
+    TableHandle no_clone;
+    if (!canonicalize_item(
+            scope.description, scope.implementation, scope.function_data,
+            scope.n_storage_groups, scope.storage_groups,
+            scope.storage_timelevels, scope.n_communication_groups,
+            scope.communication_groups, scope.n_ifs, scope.ifs,
+            scope.n_whiles, scope.whiles, false, canonical_scope.item,
+            no_clone, failure, context.target, ordinal,
+            "record.ancestry[" + std::to_string(i) + "].item")) {
+      context.failure = std::move(failure);
+      return false;
+    }
+    const std::string scope_prefix =
+        "record.ancestry[" + std::to_string(i) + "]";
+    if (!validate_observed_node(context, canonical_scope.item_ordinal,
+                                canonical_scope.parent_local_ordinal,
+                                canonical_scope.item, parent_path, true, ordinal,
+                                scope_prefix))
+      return false;
+    previous_scope_item = scope.item_ordinal;
+    parent_path.push_back(scope.item_ordinal);
+    owned->canonical.ancestry.push_back(std::move(canonical_scope));
+  }
+  if (!validate_observed_node(
+          context, owned->canonical.item_ordinal,
+          owned->canonical.parent_local_ordinal, owned->canonical.item,
+          parent_path, false, ordinal, "record"))
+    return false;
+  owned->capture(*record.function_data, std::move(leaf_tag_clone),
+                 opaque_call_handle, record);
+  context.last_item_ordinal = record.item_ordinal;
+  ++context.next_traversal_ordinal;
+  context.candidate->manifest.records.push_back(owned->canonical);
+  context.candidate->functions.push_back(std::move(owned));
+  return true;
+}
+
+extern "C" int certification_inventory_callback(
+    const cScheduleInventoryRecord *const record, void *const opaque_call_handle,
+    void *const user_data) noexcept {
+  auto *const context = static_cast<CollectContext *>(user_data);
+  if (context == nullptr)
+    return 1;
+  if (context->failure.has_value())
+    return 1;
+  try {
+    if (record == nullptr) {
+      context->failure = make_failure(
+          ScheduleCertificationErrorCode::malformed_record, context->target,
+          context->next_traversal_ordinal, "record", "record pointer is null");
+      return 1;
+    }
+    return collect_one_record(*context, *record, opaque_call_handle) ? 0 : 1;
+  } catch (...) {
+    context->callback_exception = true;
+    return 1;
+  }
+}
+
+extern "C" int reject_special_callback(
+    const cScheduleInventoryRecord *, void *, void *) noexcept {
+  return 0;
+}
+
+[[nodiscard]] std::string first_string_vector_difference(
+    const std::string &prefix, const std::vector<std::string> &expected,
+    const std::vector<std::string> &observed) {
+  if (expected.size() != observed.size())
+    return prefix + ".size";
+  for (std::size_t i = 0; i < expected.size(); ++i) {
+    if (expected[i] != observed[i])
+      return prefix + "[" + std::to_string(i) + "]";
+  }
+  return {};
+}
+
+[[nodiscard]] std::string first_flags_difference(
+    const std::string &prefix, const CanonicalExecutionFlags &a,
+    const CanonicalExecutionFlags &b) {
+#define CARPETX_COMPARE_FLAG(field_name)                                       \
+  if (a.field_name != b.field_name)                                            \
+    return prefix + "." #field_name
+  CARPETX_COMPARE_FLAG(meta);
+  CARPETX_COMPARE_FLAG(meta_early);
+  CARPETX_COMPARE_FLAG(meta_late);
+  CARPETX_COMPARE_FLAG(global);
+  CARPETX_COMPARE_FLAG(global_early);
+  CARPETX_COMPARE_FLAG(global_late);
+  CARPETX_COMPARE_FLAG(level);
+  CARPETX_COMPARE_FLAG(singlemap);
+  CARPETX_COMPARE_FLAG(local);
+  CARPETX_COMPARE_FLAG(loop_meta);
+  CARPETX_COMPARE_FLAG(loop_global);
+  CARPETX_COMPARE_FLAG(loop_level);
+  CARPETX_COMPARE_FLAG(loop_singlemap);
+  CARPETX_COMPARE_FLAG(loop_local);
+#undef CARPETX_COMPARE_FLAG
+  return {};
+}
+
+[[nodiscard]] std::string first_tags_difference(
+    const std::string &prefix, const std::vector<CanonicalTag> &a,
+    const std::vector<CanonicalTag> &b) {
+  if (a.size() != b.size())
+    return prefix + ".size";
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    const auto item = prefix + "[" + std::to_string(i) + "]";
+    if (a[i].key != b[i].key)
+      return item + ".key";
+    if (a[i].type_code != b[i].type_code)
+      return item + ".type_code";
+    if (a[i].element_count != b[i].element_count)
+      return item + ".element_count";
+    if (a[i].value_bytes.size() != b[i].value_bytes.size())
+      return item + ".value_bytes.size";
+    for (std::size_t j = 0; j < a[i].value_bytes.size(); ++j) {
+      if (a[i].value_bytes[j] != b[i].value_bytes[j])
+        return item + ".value_bytes[" + std::to_string(j) + "]";
+    }
+  }
+  return {};
+}
+
+[[nodiscard]] std::string first_accesses_difference(
+    const std::string &prefix, const std::vector<CanonicalAccess> &a,
+    const std::vector<CanonicalAccess> &b) {
+  if (a.size() != b.size())
+    return prefix + ".size";
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    const auto item = prefix + "[" + std::to_string(i) + "]";
+    if (a[i].variable_name != b[i].variable_name)
+      return item + ".variable_name";
+    if (a[i].timelevel != b[i].timelevel)
+      return item + ".timelevel";
+    if (a[i].read_mask != b[i].read_mask)
+      return item + ".read_mask";
+    if (a[i].write_mask != b[i].write_mask)
+      return item + ".write_mask";
+    if (a[i].invalidate_mask != b[i].invalidate_mask)
+      return item + ".invalidate_mask";
+  }
+  return {};
+}
+
+[[nodiscard]] std::string first_storage_difference(
+    const std::string &prefix,
+    const std::vector<CanonicalGroupTimelevel> &a,
+    const std::vector<CanonicalGroupTimelevel> &b) {
+  if (a.size() != b.size())
+    return prefix + ".size";
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    const auto item = prefix + "[" + std::to_string(i) + "]";
+    if (a[i].group != b[i].group)
+      return item + ".group";
+    if (a[i].timelevel != b[i].timelevel)
+      return item + ".timelevel";
+  }
+  return {};
+}
+
+[[nodiscard]] std::string first_item_difference(
+    const std::string &prefix, const CanonicalScheduleItem &a,
+    const CanonicalScheduleItem &b) {
+#define CARPETX_COMPARE_ITEM_FIELD(field_name)                                 \
+  if (a.field_name != b.field_name)                                            \
+    return prefix + "." #field_name
+  CARPETX_COMPARE_ITEM_FIELD(description);
+  CARPETX_COMPARE_ITEM_FIELD(implementation);
+  CARPETX_COMPARE_ITEM_FIELD(where);
+  CARPETX_COMPARE_ITEM_FIELD(thorn);
+  CARPETX_COMPARE_ITEM_FIELD(routine);
+  CARPETX_COMPARE_ITEM_FIELD(language);
+  CARPETX_COMPARE_ITEM_FIELD(function_type);
+#undef CARPETX_COMPARE_ITEM_FIELD
+  if (const auto difference =
+          first_flags_difference(prefix + ".execution_flags",
+                                 a.execution_flags, b.execution_flags);
+      !difference.empty())
+    return difference;
+  if (a.effective_mode != b.effective_mode)
+    return prefix + ".effective_mode";
+  if (const auto difference =
+          first_tags_difference(prefix + ".tags", a.tags, b.tags);
+      !difference.empty())
+    return difference;
+  if (const auto difference = first_string_vector_difference(
+          prefix + ".reads_clauses", a.reads_clauses, b.reads_clauses);
+      !difference.empty())
+    return difference;
+  if (const auto difference = first_string_vector_difference(
+          prefix + ".writes_clauses", a.writes_clauses, b.writes_clauses);
+      !difference.empty())
+    return difference;
+  if (const auto difference = first_string_vector_difference(
+          prefix + ".invalidates_clauses", a.invalidates_clauses,
+          b.invalidates_clauses);
+      !difference.empty())
+    return difference;
+  if (const auto difference = first_accesses_difference(
+          prefix + ".accesses", a.accesses, b.accesses);
+      !difference.empty())
+    return difference;
+  if (const auto difference = first_storage_difference(
+          prefix + ".storage_groups", a.storage_groups, b.storage_groups);
+      !difference.empty())
+    return difference;
+  for (const auto &entry :
+       {std::pair<const char *, const std::vector<std::string> *>{
+            "communication_groups", &a.communication_groups},
+        {"sync_groups", &a.sync_groups},
+        {"trigger_groups", &a.trigger_groups}, {"ifs", &a.ifs},
+        {"whiles", &a.whiles}}) {
+    const std::vector<std::string> *other = nullptr;
+    const std::string name = entry.first;
+    if (name == "communication_groups")
+      other = &b.communication_groups;
+    else if (name == "sync_groups")
+      other = &b.sync_groups;
+    else if (name == "trigger_groups")
+      other = &b.trigger_groups;
+    else if (name == "ifs")
+      other = &b.ifs;
+    else
+      other = &b.whiles;
+    if (const auto difference = first_string_vector_difference(
+            prefix + "." + name, *entry.second, *other);
+        !difference.empty())
+      return difference;
+  }
+  return {};
+}
+
+[[nodiscard]] std::string first_manifest_difference(
+    const CanonicalScheduleBundle &expected,
+    const CanonicalScheduleBundle &observed) {
+  for (std::size_t ti = 0; ti < expected.targets.size(); ++ti) {
+    const auto prefix = "manifest.targets[" + std::to_string(ti) + "]";
+    const auto &a = expected.targets[ti];
+    const auto &b = observed.targets[ti];
+    if (a.target != b.target)
+      return prefix + ".target";
+    if (a.body_root != b.body_root)
+      return prefix + ".body_root";
+    if (a.entry_state != b.entry_state)
+      return prefix + ".entry_state";
+    if (a.exit_state != b.exit_state)
+      return prefix + ".exit_state";
+    if (a.entry_exit_included != b.entry_exit_included)
+      return prefix + ".entry_exit_included";
+    if (a.records.size() != b.records.size())
+      return prefix + ".records.size";
+    for (std::size_t ri = 0; ri < a.records.size(); ++ri) {
+      const auto record_prefix =
+          prefix + ".records[" + std::to_string(ri) + "]";
+      const auto &ar = a.records[ri];
+      const auto &br = b.records[ri];
+      if (ar.traversal_ordinal != br.traversal_ordinal)
+        return record_prefix + ".traversal_ordinal";
+      if (ar.item_ordinal != br.item_ordinal)
+        return record_prefix + ".item_ordinal";
+      if (ar.parent_local_ordinal != br.parent_local_ordinal)
+        return record_prefix + ".parent_local_ordinal";
+      if (const auto difference = first_item_difference(
+              record_prefix + ".item", ar.item, br.item);
+          !difference.empty())
+        return difference;
+      if (ar.ancestry.size() != br.ancestry.size())
+        return record_prefix + ".ancestry.size";
+      for (std::size_t si = 0; si < ar.ancestry.size(); ++si) {
+        const auto scope_prefix =
+            record_prefix + ".ancestry[" + std::to_string(si) + "]";
+        if (ar.ancestry[si].item_ordinal != br.ancestry[si].item_ordinal)
+          return scope_prefix + ".item_ordinal";
+        if (ar.ancestry[si].parent_local_ordinal !=
+            br.ancestry[si].parent_local_ordinal)
+          return scope_prefix + ".parent_local_ordinal";
+        if (const auto difference = first_item_difference(
+                scope_prefix + ".item", ar.ancestry[si].item,
+                br.ancestry[si].item);
+            !difference.empty())
+          return difference;
+      }
+    }
+  }
+  return {};
+}
+
+[[nodiscard]] bool compare_manifest(const CanonicalScheduleBundle &expected,
+                                    const CanonicalScheduleBundle &observed,
+                                    std::string &field) {
+  if (expected == observed) {
+    field.clear();
+    return true;
+  }
+  field = first_manifest_difference(expected, observed);
+  if (field.empty())
+    field = "manifest.unknown";
+  return false;
+}
+
+[[nodiscard]] std::string first_provenance_difference(
+    const ScheduleBuildProvenance &a, const ScheduleBuildProvenance &b) {
+#define CARPETX_COMPARE_PROVENANCE_FIELD(field_name)                           \
+  if (a.field_name != b.field_name)                                            \
+    return "provenance." #field_name
+  CARPETX_COMPARE_PROVENANCE_FIELD(schema_version);
+  CARPETX_COMPARE_PROVENANCE_FIELD(inventory_abi_version);
+  CARPETX_COMPARE_PROVENANCE_FIELD(cactus_flesh_parent);
+  CARPETX_COMPARE_PROVENANCE_FIELD(cactus_inventory_patch_sha256);
+  CARPETX_COMPARE_PROVENANCE_FIELD(carpetx_parent);
+  if (a.ordered_carpetx_patches.size() != b.ordered_carpetx_patches.size())
+    return "provenance.ordered_carpetx_patches.size";
+  for (std::size_t i = 0; i < a.ordered_carpetx_patches.size(); ++i) {
+    const auto prefix = "provenance.ordered_carpetx_patches[" +
+                        std::to_string(i) + "]";
+    if (a.ordered_carpetx_patches[i].phase !=
+        b.ordered_carpetx_patches[i].phase)
+      return prefix + ".phase";
+    if (a.ordered_carpetx_patches[i].sha256 !=
+        b.ordered_carpetx_patches[i].sha256)
+      return prefix + ".sha256";
+  }
+  CARPETX_COMPARE_PROVENANCE_FIELD(compiler_id);
+  CARPETX_COMPARE_PROVENANCE_FIELD(compiler_version);
+  CARPETX_COMPARE_PROVENANCE_FIELD(target_triple);
+  CARPETX_COMPARE_PROVENANCE_FIELD(cxx_abi);
+  CARPETX_COMPARE_PROVENANCE_FIELD(byte_order);
+  if (a.cctk_type_sizes.size() != b.cctk_type_sizes.size())
+    return "provenance.cctk_type_sizes.size";
+  for (std::size_t i = 0; i < a.cctk_type_sizes.size(); ++i) {
+    if (a.cctk_type_sizes[i].first != b.cctk_type_sizes[i].first)
+      return "provenance.cctk_type_sizes[" + std::to_string(i) + "].type";
+    if (a.cctk_type_sizes[i].second != b.cctk_type_sizes[i].second)
+      return "provenance.cctk_type_sizes[" + std::to_string(i) + "].size";
+  }
+  CARPETX_COMPARE_PROVENANCE_FIELD(executable_sha256);
+#undef CARPETX_COMPARE_PROVENANCE_FIELD
+  return "provenance.unknown";
+}
+
+[[nodiscard]] bool validate_and_compare_provenance(
+    const ScheduleBuildProvenance &expected,
+    const ScheduleBuildProvenance &observed,
+    ScheduleBuildProvenance &normalized_observed, std::string &field,
+    std::string &detail) {
+  ScheduleBuildProvenance normalized_expected;
+  if (!normalize_provenance(expected, normalized_expected, field, detail) ||
+      !normalize_provenance(observed, normalized_observed, field, detail))
+    return false;
+  if (!(normalized_expected == normalized_observed)) {
+    field = first_provenance_difference(normalized_expected,
+                                        normalized_observed);
+    detail = "expected and observed build provenance differ";
+    return false;
+  }
+  return true;
+}
+
+[[nodiscard]] bool validate_provenance_tag_type_coverage(
+    const ScheduleBuildProvenance &provenance,
+    const CanonicalScheduleBundle &manifest, std::string &field,
+    std::string &detail) {
+  std::map<int, bool> described_types;
+  for (const auto &entry : provenance.cctk_type_sizes)
+    described_types.emplace(entry.first, true);
+  std::map<int, bool> used_types;
+  const auto observe_item = [&](const CanonicalScheduleItem &item) {
+    for (const auto &tag : item.tags)
+      used_types.emplace(tag.type_code, true);
+  };
+  for (const auto &target : manifest.targets) {
+    for (const auto &record : target.records) {
+      observe_item(record.item);
+      for (const auto &scope : record.ancestry)
+        observe_item(scope.item);
+    }
+  }
+  for (const auto &entry : used_types) {
+    if (described_types.find(entry.first) == described_types.end()) {
+      field = "provenance.cctk_type_sizes.missing[" +
+              std::to_string(entry.first) + "]";
+      detail = "canonical tag type is absent from build provenance";
+      return false;
+    }
+  }
+  return true;
+}
+
+[[nodiscard]] std::optional<ScheduleCertificationFailure>
+collect_native_gate_observation(
+    const ScheduleBuildProvenance &normalized_provenance,
+    CanonicalScheduleBundle &observed_manifest) {
+  constexpr std::array<SubcyclingScheduleTarget, 2> target_ids{
+      SubcyclingScheduleTarget::rhs, SubcyclingScheduleTarget::post_step};
+  constexpr std::array<const char *, 2> roots{"ODESolvers_RHS",
+                                               "ODESolvers_PostStep"};
+  std::array<CandidateTarget, 2> candidates;
+  for (std::size_t i = 0; i < candidates.size(); ++i) {
+    const auto target = target_ids[i];
+    const std::string root = roots[i];
+    candidates[i].manifest.target = target;
+    candidates[i].manifest.body_root = root;
+    candidates[i].manifest.entry_state = SpecialScheduleGroupState::missing;
+    candidates[i].manifest.exit_state = SpecialScheduleGroupState::missing;
+    candidates[i].manifest.entry_exit_included = false;
+
+    const std::string entry = root + "$ENTRY";
+    const int entry_result = CCTK_ScheduleInventoryDry(
+        entry.c_str(), reject_special_callback, nullptr);
+    if (entry_result == 0)
+      return make_failure(
+          ScheduleCertificationErrorCode::special_group_present, target,
+          std::nullopt, "entry_state",
+          "ENTRY group exists; missing named group was required");
+    if (entry_result != CCTK_SCHEDULE_INVENTORY_GROUP_NOT_FOUND)
+      return make_failure(
+          ScheduleCertificationErrorCode::inventory_error, target,
+          std::nullopt, "entry_inventory",
+          "ENTRY inventory did not return named-missing");
+
+    CollectContext context{target, root, &candidates[i], std::nullopt, 0,
+                           std::nullopt, false, std::nullopt, {}, {}};
+    const int body_result = CCTK_ScheduleInventoryDry(
+        root.c_str(), certification_inventory_callback, &context);
+    if (context.callback_exception)
+      return make_failure(
+          ScheduleCertificationErrorCode::callback_internal_error, target,
+          context.next_traversal_ordinal, "record.exception",
+          "exception contained while copying borrowed inventory metadata");
+    if (context.failure.has_value())
+      return std::move(context.failure);
+    if (body_result != 0)
+      return make_failure(
+          ScheduleCertificationErrorCode::inventory_error, target,
+          std::nullopt, "body_inventory",
+          "body inventory failed or body group is missing");
+
+    const std::string exit = root + "$EXIT";
+    const int exit_result = CCTK_ScheduleInventoryDry(
+        exit.c_str(), reject_special_callback, nullptr);
+    if (exit_result == 0)
+      return make_failure(
+          ScheduleCertificationErrorCode::special_group_present, target,
+          std::nullopt, "exit_state",
+          "EXIT group exists; missing named group was required");
+    if (exit_result != CCTK_SCHEDULE_INVENTORY_GROUP_NOT_FOUND)
+      return make_failure(
+          ScheduleCertificationErrorCode::inventory_error, target,
+          std::nullopt, "exit_inventory",
+          "EXIT inventory did not return named-missing");
+  }
+
+  for (std::size_t i = 0; i < candidates.size(); ++i)
+    observed_manifest.targets[i] = candidates[i].manifest;
+  std::string field;
+  std::string detail;
+  if (!validate_provenance_tag_type_coverage(
+          normalized_provenance, observed_manifest, field, detail))
+    return make_failure(ScheduleCertificationErrorCode::provenance_mismatch,
+                        std::nullopt, std::nullopt, std::move(field),
+                        std::move(detail));
+  return std::nullopt;
+}
+
+} // namespace
+
+struct CertifiedLocalScheduleRegistry::Storage final {
+  CanonicalScheduleBundle manifest;
+  ScheduleBuildProvenance provenance;
+  std::array<std::vector<std::unique_ptr<OwnedFunctionData>>, 2> functions;
+};
+
+CertifiedLocalScheduleRegistry::CertifiedLocalScheduleRegistry(
+    std::unique_ptr<Storage> storage)
+    : storage_(std::move(storage)) {}
+
+CertifiedLocalScheduleRegistry::~CertifiedLocalScheduleRegistry() = default;
+
+const CanonicalScheduleBundle &
+CertifiedLocalScheduleRegistry::manifest() const noexcept {
+  return storage_->manifest;
+}
+
+const ScheduleBuildProvenance &
+CertifiedLocalScheduleRegistry::provenance() const noexcept {
+  return storage_->provenance;
+}
+
+std::size_t CertifiedLocalScheduleRegistry::size(
+    const SubcyclingScheduleTarget target) const noexcept {
+  const auto index = target == SubcyclingScheduleTarget::rhs ? 0U : 1U;
+  return storage_->functions[index].size();
+}
+
+const CanonicalScheduleRecord &
+CertifiedLocalScheduleRegistry::record_for_executor(
+    const SubcyclingScheduleTarget target, const std::size_t ordinal) const {
+  const auto index = target == SubcyclingScheduleTarget::rhs ? 0U : 1U;
+  return storage_->functions.at(index).at(ordinal)->canonical;
+}
+
+int CertifiedLocalScheduleRegistry::invoke_for_executor(
+    const SubcyclingScheduleTarget target, const std::size_t ordinal,
+    cGH *const scratch_gh) const {
+#ifdef CARPETX_SUBCYCLING_SCHEDULE_CERTIFICATION_STANDALONE
+  (void)target;
+  (void)ordinal;
+  (void)scratch_gh;
+  throw std::logic_error(
+      "schedule invocation is unavailable in certification-only tests");
+#else
+  const auto index = target == SubcyclingScheduleTarget::rhs ? 0U : 1U;
+  auto &function = *storage_->functions.at(index).at(ordinal);
+  return CCTK_CallFunction(function.opaque_call_handle, &function.data,
+                           scratch_gh);
+#endif
+}
+
+NativeGateScheduleObservationResult
+observe_local_subcycling_schedules_for_native_gate(
+    const ScheduleBuildProvenance &observed_provenance) {
+  ScheduleBuildProvenance normalized;
+  std::string field;
+  std::string detail;
+  if (!normalize_provenance(observed_provenance, normalized, field, detail))
+    return {std::nullopt,
+            make_failure(ScheduleCertificationErrorCode::provenance_mismatch,
+                         std::nullopt, std::nullopt, std::move(field),
+                         std::move(detail))};
+
+  CanonicalScheduleBundle manifest;
+  if (auto failure =
+          collect_native_gate_observation(normalized, manifest))
+    return {std::nullopt, std::move(failure)};
+  return {ScheduleCertificationExpectation{std::move(manifest),
+                                            std::move(normalized)},
+          std::nullopt};
+}
+
+ScheduleCertificationResult certify_local_subcycling_schedules(
+    const ScheduleCertificationExpectation &expected,
+    const ScheduleBuildProvenance &observed_provenance) {
+  ScheduleBuildProvenance normalized_observed;
+  std::string provenance_field;
+  std::string provenance_detail;
+  if (!validate_and_compare_provenance(
+          expected.provenance, observed_provenance, normalized_observed,
+          provenance_field, provenance_detail)) {
+    return {nullptr,
+            make_failure(ScheduleCertificationErrorCode::provenance_mismatch,
+                         std::nullopt, std::nullopt,
+                         std::move(provenance_field),
+                         std::move(provenance_detail))};
+  }
+
+  constexpr std::array<SubcyclingScheduleTarget, 2> target_ids{
+      SubcyclingScheduleTarget::rhs, SubcyclingScheduleTarget::post_step};
+  constexpr std::array<const char *, 2> roots{"ODESolvers_RHS",
+                                               "ODESolvers_PostStep"};
+  std::array<CandidateTarget, 2> candidates;
+  for (std::size_t i = 0; i < candidates.size(); ++i) {
+    const auto target = target_ids[i];
+    const std::string root = roots[i];
+    candidates[i].manifest.target = target;
+    candidates[i].manifest.body_root = root;
+    candidates[i].manifest.entry_state = SpecialScheduleGroupState::missing;
+    candidates[i].manifest.exit_state = SpecialScheduleGroupState::missing;
+    candidates[i].manifest.entry_exit_included = false;
+
+    const std::string entry = root + "$ENTRY";
+    const int entry_result = CCTK_ScheduleInventoryDry(
+        entry.c_str(), reject_special_callback, nullptr);
+    if (entry_result == 0) {
+      return {nullptr,
+              make_failure(
+                  ScheduleCertificationErrorCode::special_group_present,
+                  target, std::nullopt, "entry_state",
+                  "ENTRY group exists; missing named group was required")};
+    }
+    if (entry_result != CCTK_SCHEDULE_INVENTORY_GROUP_NOT_FOUND) {
+      return {nullptr,
+              make_failure(ScheduleCertificationErrorCode::inventory_error,
+                           target, std::nullopt, "entry_inventory",
+                           "ENTRY inventory did not return named-missing")};
+    }
+
+    CollectContext context{target, root, &candidates[i], std::nullopt, 0,
+                           std::nullopt, false, std::nullopt, {}, {}};
+    const int body_result = CCTK_ScheduleInventoryDry(
+        root.c_str(), certification_inventory_callback, &context);
+    if (context.callback_exception) {
+      return {nullptr,
+              make_failure(
+                  ScheduleCertificationErrorCode::callback_internal_error,
+                  target,
+                  context.next_traversal_ordinal, "record.exception",
+                  "exception contained while copying borrowed inventory metadata")};
+    }
+    if (context.failure.has_value())
+      return {nullptr, std::move(context.failure)};
+    if (body_result != 0) {
+      return {nullptr,
+              make_failure(ScheduleCertificationErrorCode::inventory_error,
+                           target, std::nullopt, "body_inventory",
+                           "body inventory failed or body group is missing")};
+    }
+
+    const std::string exit = root + "$EXIT";
+    const int exit_result = CCTK_ScheduleInventoryDry(
+        exit.c_str(), reject_special_callback, nullptr);
+    if (exit_result == 0) {
+      return {nullptr,
+              make_failure(
+                  ScheduleCertificationErrorCode::special_group_present,
+                  target, std::nullopt, "exit_state",
+                  "EXIT group exists; missing named group was required")};
+    }
+    if (exit_result != CCTK_SCHEDULE_INVENTORY_GROUP_NOT_FOUND) {
+      return {nullptr,
+              make_failure(ScheduleCertificationErrorCode::inventory_error,
+                           target, std::nullopt, "exit_inventory",
+                           "EXIT inventory did not return named-missing")};
+    }
+  }
+
+  CanonicalScheduleBundle observed_manifest;
+  for (std::size_t i = 0; i < candidates.size(); ++i)
+    observed_manifest.targets[i] = candidates[i].manifest;
+  if (!validate_provenance_tag_type_coverage(
+          normalized_observed, observed_manifest, provenance_field,
+          provenance_detail)) {
+    return {nullptr,
+            make_failure(ScheduleCertificationErrorCode::provenance_mismatch,
+                         std::nullopt, std::nullopt,
+                         std::move(provenance_field),
+                         std::move(provenance_detail))};
+  }
+  std::string manifest_field;
+  if (!compare_manifest(expected.manifest, observed_manifest, manifest_field)) {
+    return {nullptr,
+            make_failure(ScheduleCertificationErrorCode::manifest_mismatch,
+                         std::nullopt, std::nullopt,
+                         std::move(manifest_field),
+                         "expected and observed typed manifests differ")};
+  }
+
+  std::unique_ptr<CertifiedLocalScheduleRegistry::Storage> storage =
+      std::make_unique<CertifiedLocalScheduleRegistry::Storage>();
+  storage->manifest = std::move(observed_manifest);
+  storage->provenance = std::move(normalized_observed);
+  for (std::size_t i = 0; i < candidates.size(); ++i)
+    storage->functions[i] = std::move(candidates[i].functions);
+  return {std::unique_ptr<CertifiedLocalScheduleRegistry>(
+              new CertifiedLocalScheduleRegistry(std::move(storage))),
+          std::nullopt};
+}
+
+} // namespace CarpetX

--- a/CarpetX/src/subcycling_schedule_certification.hxx
+++ b/CarpetX/src/subcycling_schedule_certification.hxx
@@ -1,0 +1,237 @@
+#ifndef CARPETX_SUBCYCLING_SCHEDULE_CERTIFICATION_HXX
+#define CARPETX_SUBCYCLING_SCHEDULE_CERTIFICATION_HXX
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#if !defined(CARPETX_SUBCYCLING_SCHEDULE_CERTIFICATION_STANDALONE) &&         \
+    !defined(CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_STANDALONE)
+#include <cctk.h>
+#else
+struct cGH;
+#endif
+
+namespace CarpetX {
+
+class CertifiedScratchStageExecutor;
+#ifdef CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_UNIT
+class CertifiedLocalScheduleRegistryExecutorTestAccess;
+#endif
+
+enum class SubcyclingScheduleTarget : std::uint8_t { rhs, post_step };
+enum class SpecialScheduleGroupState : std::uint8_t { missing };
+enum class CanonicalScheduleMode : std::uint8_t { default_local, local };
+
+struct SchedulePatchProvenance {
+  std::string phase;
+  std::string sha256;
+  friend bool operator==(const SchedulePatchProvenance &,
+                         const SchedulePatchProvenance &) noexcept;
+};
+
+struct ScheduleBuildProvenance {
+  std::uint32_t schema_version{};
+  std::uint32_t inventory_abi_version{};
+  std::string cactus_flesh_parent;
+  std::string cactus_inventory_patch_sha256;
+  std::string carpetx_parent;
+  std::vector<SchedulePatchProvenance> ordered_carpetx_patches;
+  std::string compiler_id;
+  std::string compiler_version;
+  std::string target_triple;
+  std::string cxx_abi;
+  std::string byte_order;
+  std::vector<std::pair<int, int>> cctk_type_sizes;
+  std::string executable_sha256;
+  friend bool operator==(const ScheduleBuildProvenance &,
+                         const ScheduleBuildProvenance &) noexcept;
+};
+
+struct CanonicalTag {
+  std::string key;
+  int type_code{};
+  std::uint64_t element_count{};
+  std::vector<std::uint8_t> value_bytes;
+  friend bool operator==(const CanonicalTag &, const CanonicalTag &) noexcept;
+};
+
+struct CanonicalAccess {
+  std::string variable_name;
+  int timelevel{};
+  int read_mask{};
+  int write_mask{};
+  int invalidate_mask{};
+  friend bool operator==(const CanonicalAccess &,
+                         const CanonicalAccess &) noexcept;
+};
+
+struct CanonicalGroupTimelevel {
+  std::string group;
+  int timelevel{};
+  friend bool operator==(const CanonicalGroupTimelevel &,
+                         const CanonicalGroupTimelevel &) noexcept;
+};
+
+struct CanonicalExecutionFlags {
+  int meta{};
+  int meta_early{};
+  int meta_late{};
+  int global{};
+  int global_early{};
+  int global_late{};
+  int level{};
+  int singlemap{};
+  int local{};
+  int loop_meta{};
+  int loop_global{};
+  int loop_level{};
+  int loop_singlemap{};
+  int loop_local{};
+  friend bool operator==(const CanonicalExecutionFlags &,
+                         const CanonicalExecutionFlags &) noexcept;
+};
+
+struct CanonicalScheduleItem {
+  std::string description;
+  std::string implementation;
+  std::string where;
+  std::string thorn;
+  std::string routine;
+  int language{};
+  int function_type{};
+  CanonicalExecutionFlags execution_flags;
+  CanonicalScheduleMode effective_mode{CanonicalScheduleMode::default_local};
+  std::vector<CanonicalTag> tags;
+  std::vector<std::string> reads_clauses;
+  std::vector<std::string> writes_clauses;
+  std::vector<std::string> invalidates_clauses;
+  std::vector<CanonicalAccess> accesses;
+  std::vector<CanonicalGroupTimelevel> storage_groups;
+  std::vector<std::string> communication_groups;
+  std::vector<std::string> sync_groups;
+  std::vector<std::string> trigger_groups;
+  std::vector<std::string> ifs;
+  std::vector<std::string> whiles;
+  friend bool operator==(const CanonicalScheduleItem &,
+                         const CanonicalScheduleItem &) noexcept;
+};
+
+struct CanonicalScheduleScope {
+  std::uint64_t item_ordinal{};
+  std::uint64_t parent_local_ordinal{};
+  CanonicalScheduleItem item;
+  friend bool operator==(const CanonicalScheduleScope &,
+                         const CanonicalScheduleScope &) noexcept;
+};
+
+struct CanonicalScheduleRecord {
+  std::uint64_t traversal_ordinal{};
+  std::uint64_t item_ordinal{};
+  std::uint64_t parent_local_ordinal{};
+  CanonicalScheduleItem item;
+  std::vector<CanonicalScheduleScope> ancestry;
+  friend bool operator==(const CanonicalScheduleRecord &,
+                         const CanonicalScheduleRecord &) noexcept;
+};
+
+struct CanonicalTargetSchedule {
+  SubcyclingScheduleTarget target{SubcyclingScheduleTarget::rhs};
+  std::string body_root;
+  SpecialScheduleGroupState entry_state{SpecialScheduleGroupState::missing};
+  SpecialScheduleGroupState exit_state{SpecialScheduleGroupState::missing};
+  bool entry_exit_included{};
+  std::vector<CanonicalScheduleRecord> records;
+  friend bool operator==(const CanonicalTargetSchedule &,
+                         const CanonicalTargetSchedule &) noexcept;
+};
+
+struct CanonicalScheduleBundle final {
+  std::array<CanonicalTargetSchedule, 2> targets;
+  bool operator==(const CanonicalScheduleBundle &) const noexcept;
+};
+
+struct ScheduleCertificationExpectation {
+  CanonicalScheduleBundle manifest;
+  ScheduleBuildProvenance provenance;
+};
+
+enum class ScheduleCertificationErrorCode : std::uint8_t {
+  inventory_error,
+  special_group_present,
+  abi_mismatch,
+  malformed_record,
+  callback_internal_error,
+  unsupported_metadata,
+  name_resolution_error,
+  tag_error,
+  manifest_mismatch,
+  provenance_mismatch,
+};
+
+struct ScheduleCertificationFailure {
+  ScheduleCertificationErrorCode code;
+  std::optional<SubcyclingScheduleTarget> target;
+  std::optional<std::uint64_t> traversal_ordinal;
+  std::string field;
+  std::string detail;
+};
+
+class CertifiedLocalScheduleRegistry;
+struct ScheduleCertificationResult;
+
+// Rank/process-local, read-only certification. The caller is responsible for
+// supplying an independently reviewed expectation and trusted build
+// provenance; this API intentionally offers no observed-to-expected approval
+// path. It inventories metadata only and never executes a scheduled routine.
+[[nodiscard]] ScheduleCertificationResult certify_local_subcycling_schedules(
+    const ScheduleCertificationExpectation &expected,
+    const ScheduleBuildProvenance &observed_provenance);
+
+class CertifiedLocalScheduleRegistry final {
+public:
+  ~CertifiedLocalScheduleRegistry();
+  CertifiedLocalScheduleRegistry(const CertifiedLocalScheduleRegistry &) =
+      delete;
+  CertifiedLocalScheduleRegistry &
+  operator=(const CertifiedLocalScheduleRegistry &) = delete;
+  CertifiedLocalScheduleRegistry(CertifiedLocalScheduleRegistry &&) = delete;
+  CertifiedLocalScheduleRegistry &
+  operator=(CertifiedLocalScheduleRegistry &&) = delete;
+
+  const CanonicalScheduleBundle &manifest() const noexcept;
+  const ScheduleBuildProvenance &provenance() const noexcept;
+  std::size_t size(SubcyclingScheduleTarget target) const noexcept;
+
+private:
+  struct Storage;
+  explicit CertifiedLocalScheduleRegistry(std::unique_ptr<Storage> storage);
+  const CanonicalScheduleRecord &
+  record_for_executor(SubcyclingScheduleTarget target,
+                      std::size_t ordinal) const;
+  int invoke_for_executor(SubcyclingScheduleTarget target,
+                          std::size_t ordinal, cGH *scratch_gh) const;
+  std::unique_ptr<Storage> storage_;
+  friend class CertifiedScratchStageExecutor;
+#ifdef CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_UNIT
+  friend class CertifiedLocalScheduleRegistryExecutorTestAccess;
+#endif
+  friend ScheduleCertificationResult certify_local_subcycling_schedules(
+      const ScheduleCertificationExpectation &expected,
+      const ScheduleBuildProvenance &observed_provenance);
+};
+
+struct ScheduleCertificationResult {
+  std::unique_ptr<CertifiedLocalScheduleRegistry> registry;
+  std::optional<ScheduleCertificationFailure> failure;
+  explicit operator bool() const noexcept { return registry != nullptr; }
+};
+
+} // namespace CarpetX
+
+#endif

--- a/CarpetX/src/subcycling_schedule_certification_native_gate.hxx
+++ b/CarpetX/src/subcycling_schedule_certification_native_gate.hxx
@@ -1,0 +1,24 @@
+#ifndef CARPETX_SUBCYCLING_SCHEDULE_CERTIFICATION_NATIVE_GATE_HXX
+#define CARPETX_SUBCYCLING_SCHEDULE_CERTIFICATION_NATIVE_GATE_HXX
+
+#include "subcycling_schedule_certification.hxx"
+
+#include <optional>
+
+namespace CarpetX {
+
+// Test-only inventory seam for the same-binary CPU-native gate. It returns
+// canonical data only and can never publish executable schedule handles.
+struct NativeGateScheduleObservationResult {
+  std::optional<ScheduleCertificationExpectation> expectation;
+  std::optional<ScheduleCertificationFailure> failure;
+  explicit operator bool() const noexcept { return expectation.has_value(); }
+};
+
+[[nodiscard]] NativeGateScheduleObservationResult
+observe_local_subcycling_schedules_for_native_gate(
+    const ScheduleBuildProvenance &observed_provenance);
+
+} // namespace CarpetX
+
+#endif

--- a/CarpetX/src/subcycling_schedule_state.hxx
+++ b/CarpetX/src/subcycling_schedule_state.hxx
@@ -1,0 +1,141 @@
+#ifndef CARPETX_SUBCYCLING_SCHEDULE_STATE_HXX
+#define CARPETX_SUBCYCLING_SCHEDULE_STATE_HXX
+
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+namespace CarpetX::ScheduleInternal {
+
+template <typename ActiveLevels> class ScopedActiveLevels {
+  static_assert(std::is_nothrow_move_constructible_v<ActiveLevels>);
+  static_assert(std::is_nothrow_move_assignable_v<ActiveLevels>);
+
+  std::optional<ActiveLevels> &slot_;
+  std::optional<ActiveLevels> saved_;
+
+public:
+  ScopedActiveLevels(std::optional<ActiveLevels> &slot, ActiveLevels active)
+      noexcept
+      : slot_(slot), saved_(std::move(slot)) {
+    slot_.emplace(std::move(active));
+  }
+
+  ScopedActiveLevels(const ScopedActiveLevels &) = delete;
+  ScopedActiveLevels &operator=(const ScopedActiveLevels &) = delete;
+  ScopedActiveLevels(ScopedActiveLevels &&) = delete;
+  ScopedActiveLevels &operator=(ScopedActiveLevels &&) = delete;
+
+  ~ScopedActiveLevels() noexcept { slot_ = std::move(saved_); }
+};
+
+template <typename Real> struct LevelTimeMetadata {
+  int iteration;
+  Real time;
+  Real delta_time;
+  int timefac;
+};
+
+template <typename Real>
+constexpr bool operator==(const LevelTimeMetadata<Real> &left,
+                          const LevelTimeMetadata<Real> &right) noexcept {
+  return left.iteration == right.iteration && left.time == right.time &&
+         left.delta_time == right.delta_time && left.timefac == right.timefac;
+}
+
+template <typename Real>
+constexpr bool operator!=(const LevelTimeMetadata<Real> &left,
+                          const LevelTimeMetadata<Real> &right) noexcept {
+  return !(left == right);
+}
+
+template <typename GH>
+constexpr auto capture_level_time_metadata(const GH &gh) noexcept {
+  using Real = std::remove_cv_t<
+      std::remove_reference_t<decltype(gh.cctk_time)>>;
+  return LevelTimeMetadata<Real>{gh.cctk_iteration, gh.cctk_time,
+                                 gh.cctk_delta_time, gh.cctk_timefac};
+}
+
+template <typename GH, typename Real>
+constexpr void apply_level_time_metadata(
+    GH &gh, const LevelTimeMetadata<Real> &metadata) noexcept {
+  gh.cctk_iteration = metadata.iteration;
+  gh.cctk_time = metadata.time;
+  gh.cctk_delta_time = metadata.delta_time;
+  gh.cctk_timefac = metadata.timefac;
+}
+
+template <typename TargetGH, typename SourceGH>
+constexpr void copy_level_time_metadata(TargetGH &target,
+                                        const SourceGH &source) noexcept {
+  apply_level_time_metadata(target, capture_level_time_metadata(source));
+}
+
+template <typename GH, typename Propagate> class ScopedLevelTimeMetadata {
+  static_assert(std::is_nothrow_invocable_v<Propagate &, GH &>);
+
+  GH &gh_;
+  decltype(capture_level_time_metadata(std::declval<const GH &>())) saved_;
+  Propagate propagate_;
+
+public:
+  using metadata_type = decltype(saved_);
+
+  ScopedLevelTimeMetadata(GH &gh, const metadata_type &metadata,
+                          Propagate propagate) noexcept
+      : gh_(gh), saved_(capture_level_time_metadata(gh)),
+        propagate_(std::move(propagate)) {
+    apply_level_time_metadata(gh_, metadata);
+    propagate_(gh_);
+  }
+
+  ScopedLevelTimeMetadata(const ScopedLevelTimeMetadata &) = delete;
+  ScopedLevelTimeMetadata &operator=(const ScopedLevelTimeMetadata &) = delete;
+  ScopedLevelTimeMetadata(ScopedLevelTimeMetadata &&) = delete;
+  ScopedLevelTimeMetadata &operator=(ScopedLevelTimeMetadata &&) = delete;
+
+  ~ScopedLevelTimeMetadata() noexcept {
+    apply_level_time_metadata(gh_, saved_);
+    propagate_(gh_);
+  }
+};
+
+enum class TimelevelGroupKind {
+  level_grid_function,
+  synchronized_global,
+};
+
+enum class TimelevelDomain {
+  legacy_all,
+  level_grid_functions,
+  synchronized_globals,
+};
+
+constexpr bool includes_timelevel_group(const TimelevelDomain domain,
+                                        const TimelevelGroupKind kind) noexcept {
+  switch (domain) {
+  case TimelevelDomain::legacy_all:
+    return true;
+  case TimelevelDomain::level_grid_functions:
+    return kind == TimelevelGroupKind::level_grid_function;
+  case TimelevelDomain::synchronized_globals:
+    return kind == TimelevelGroupKind::synchronized_global;
+  }
+  return false;
+}
+
+template <typename Classify, typename Visit>
+void for_each_timelevel_group(const int num_groups,
+                              const TimelevelDomain domain,
+                              Classify &&classify, Visit &&visit) {
+  for (int group = 0; group < num_groups; ++group) {
+    const auto kind = classify(group);
+    if (includes_timelevel_group(domain, kind))
+      visit(group, kind);
+  }
+}
+
+} // namespace CarpetX::ScheduleInternal
+
+#endif

--- a/CarpetX/src/subcycling_scratch_adapter.cxx
+++ b/CarpetX/src/subcycling_scratch_adapter.cxx
@@ -1,0 +1,523 @@
+#include "subcycling_scratch_adapter.hxx"
+
+#include <AMReX_MultiFab.H>
+
+#ifndef CARPETX_SUBCYCLING_ADAPTER_STANDALONE
+#include "driver.hxx"
+
+#include <AMReX_ParallelContext.H>
+#endif
+
+// driver.hxx provides the native Cactus feature macros (including CCTK_MPI).
+// Include the internal declarations only after those macros are visible so the
+// MPI collective declaration and its implementation use the same guard.
+#include "subcycling_scratch_adapter_internal.hxx"
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <new>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#if defined(CARPETX_SUBCYCLING_ADAPTER_MPI_UNIT) || defined(CCTK_MPI)
+#include <mpi.h>
+#endif
+
+namespace CarpetX {
+
+CertifiedScratchLevelFrame::CertifiedScratchLevelFrame(
+    const int patch, ScratchLevelFrame frame)
+    : patch_(patch), frame_(std::move(frame)) {}
+
+CertifiedScratchLevelFrame::CertifiedScratchLevelFrame(
+    CertifiedScratchLevelFrame &&other) noexcept
+    : patch_(other.patch_), frame_(std::move(other.frame_)) {
+  other.patch_ = -1;
+}
+
+CertifiedScratchLevelFrame &CertifiedScratchLevelFrame::operator=(
+    CertifiedScratchLevelFrame &&other) noexcept {
+  if (this == &other)
+    return *this;
+  patch_ = other.patch_;
+  frame_ = std::move(other.frame_);
+  other.patch_ = -1;
+  return *this;
+}
+
+int CertifiedScratchLevelFrame::patch() const noexcept { return patch_; }
+
+const ScratchLevelFrame &CertifiedScratchLevelFrame::frame() const noexcept {
+  return frame_;
+}
+
+namespace subcycling_detail {
+namespace {
+
+[[noreturn]] void reject(const char *message) {
+  throw ScratchAdapterCollectiveError(message);
+}
+
+bool size_to_i64(const std::size_t value, std::int64_t &converted) noexcept {
+  if constexpr (sizeof(std::size_t) > sizeof(std::int64_t)) {
+    if (value > static_cast<std::size_t>(
+                    std::numeric_limits<std::int64_t>::max()))
+      return false;
+  }
+  converted = static_cast<std::int64_t>(value);
+  return true;
+}
+
+bool matches_prevalidated_size(const std::size_t actual,
+                               const std::int64_t prevalidated) noexcept {
+  std::int64_t converted = 0;
+  return prevalidated >= 0 && size_to_i64(actual, converted) &&
+         converted == prevalidated;
+}
+
+} // namespace
+
+ScratchLevelFrame run_certification_transaction(
+    LocalScratchBatch &batch, CollectiveOps &collectives,
+    const EpochReader &epoch_reader, const CopyTL0 &copy_tl0) {
+  auto effective_status = batch.preflight_status;
+  if (!matches_prevalidated_size(batch.entries.size(),
+                                 batch.prevalidated_entry_count))
+    effective_status = ScratchAdapterFailure::invalid_schema;
+  for (const auto &entry : batch.entries)
+    if (!matches_prevalidated_size(entry.schema_fields.size(),
+                                   entry.prevalidated_schema_length))
+      effective_status = ScratchAdapterFailure::invalid_schema;
+
+  const auto local_status = static_cast<std::int64_t>(effective_status);
+  const auto local_count = batch.prevalidated_entry_count >= 0
+                               ? batch.prevalidated_entry_count
+                               : std::int64_t{0};
+
+  const auto status_min = collectives.reduce_min(
+      ScratchCollectivePhase::preflight_status, 0, local_status);
+  const auto status_max = collectives.reduce_max(
+      ScratchCollectivePhase::preflight_status, 0, local_status);
+  const auto count_min = collectives.reduce_min(
+      ScratchCollectivePhase::entry_count, 0, local_count);
+  const auto count_max = collectives.reduce_max(
+      ScratchCollectivePhase::entry_count, 0, local_count);
+  if (status_min != 0 || status_max != 0)
+    reject("canonical TL0 local preflight rejected collectively");
+  if (count_min != count_max || count_min <= 0)
+    reject("canonical TL0 entry count disagrees across ranks");
+
+  bool lengths_agree = true;
+  for (std::size_t entry_index = 0; entry_index < batch.entries.size();
+       ++entry_index) {
+    const auto local_length =
+        batch.entries[entry_index].prevalidated_schema_length;
+    const auto length_min = collectives.reduce_min(
+        ScratchCollectivePhase::schema_lengths, entry_index, local_length);
+    const auto length_max = collectives.reduce_max(
+        ScratchCollectivePhase::schema_lengths, entry_index, local_length);
+    lengths_agree = lengths_agree && length_min == length_max &&
+                    length_min > 0;
+  }
+  if (!lengths_agree)
+    reject("canonical TL0 schema descriptor lengths disagree across ranks");
+
+  bool schema_agrees = true;
+  std::size_t field_ordinal = 0;
+  for (const auto &entry : batch.entries) {
+    for (const auto local_field : entry.schema_fields) {
+      const auto field_min = collectives.reduce_min(
+          ScratchCollectivePhase::schema_fields, field_ordinal, local_field);
+      const auto field_max = collectives.reduce_max(
+          ScratchCollectivePhase::schema_fields, field_ordinal, local_field);
+      schema_agrees =
+          schema_agrees && field_min == field_max && field_min == local_field;
+      ++field_ordinal;
+    }
+  }
+  if (!schema_agrees)
+    reject("canonical TL0 ordered schema disagrees across ranks");
+
+  bool all_sources_ok = true;
+  for (const auto &entry : batch.entries) {
+    const bool entry_ok = entry.multifab->ok();
+    all_sources_ok = all_sources_ok && entry_ok;
+  }
+  const bool sources_ok = collectives.reduce_and(
+      ScratchCollectivePhase::source_ok, 0, all_sources_ok);
+  if (!sources_ok)
+    reject("canonical TL0 source allocation check rejected collectively");
+
+  const std::int64_t observed_epoch = epoch_reader();
+  const auto epoch_min = collectives.reduce_min(
+      ScratchCollectivePhase::epoch_reader, 0, observed_epoch);
+  const auto epoch_max = collectives.reduce_max(
+      ScratchCollectivePhase::epoch_reader, 0, observed_epoch);
+  if (epoch_min != epoch_max || epoch_min != batch.captured_epoch)
+    reject("hierarchy epoch changed during canonical TL0 certification");
+
+  UncertifiedScratchLevelManifest manifest{batch.captured_epoch, batch.level,
+                                            {}};
+  std::vector<ScratchGFView> views;
+  manifest.entries.reserve(batch.entries.size());
+  views.reserve(batch.entries.size());
+  for (auto &entry : batch.entries) {
+    manifest.entries.push_back(
+        ScratchGFManifestEntry{entry.key, entry.source_storage_identity});
+    views.push_back(ScratchGFView{entry.key, 0, entry.source_storage_identity,
+                                  entry.multifab, &entry.validity});
+  }
+
+  std::optional<ScratchLevelFrame> local_frame;
+  std::string local_diagnostic;
+  try {
+    local_frame.emplace(copy_tl0(manifest, views));
+  } catch (const std::bad_alloc &) {
+    throw;
+  } catch (const std::exception &error) {
+    local_diagnostic = error.what();
+  }
+  const bool all_copies_succeeded = collectives.reduce_and(
+      ScratchCollectivePhase::copy_success, 0, local_frame.has_value());
+  if (!all_copies_succeeded) {
+    local_frame.reset();
+    if (local_diagnostic.empty())
+      reject("canonical TL0 owned copy failed on a peer rank");
+    throw ScratchAdapterCollectiveError(
+        "canonical TL0 owned copy failed collectively: " +
+        local_diagnostic);
+  }
+  if (!local_frame.has_value())
+    reject("canonical TL0 owned copy protocol lost its local result");
+  return std::move(*local_frame);
+}
+
+#if defined(CARPETX_SUBCYCLING_ADAPTER_MPI_UNIT) || defined(CCTK_MPI)
+MpiCollectiveOps::MpiCollectiveOps(void *const communicator_storage) noexcept
+    : communicator_storage_(communicator_storage) {}
+
+std::int64_t MpiCollectiveOps::reduce_min(
+    const ScratchCollectivePhase, const std::size_t,
+    const std::int64_t local) {
+  std::int64_t global = 0;
+  const MPI_Comm communicator =
+      *static_cast<const MPI_Comm *>(communicator_storage_);
+  if (MPI_Allreduce(&local, &global, 1, MPI_INT64_T, MPI_MIN, communicator) !=
+      MPI_SUCCESS)
+    throw std::runtime_error("MPI minimum reduction failed");
+  return global;
+}
+
+std::int64_t MpiCollectiveOps::reduce_max(
+    const ScratchCollectivePhase, const std::size_t,
+    const std::int64_t local) {
+  std::int64_t global = 0;
+  const MPI_Comm communicator =
+      *static_cast<const MPI_Comm *>(communicator_storage_);
+  if (MPI_Allreduce(&local, &global, 1, MPI_INT64_T, MPI_MAX, communicator) !=
+      MPI_SUCCESS)
+    throw std::runtime_error("MPI maximum reduction failed");
+  return global;
+}
+
+bool MpiCollectiveOps::reduce_and(const ScratchCollectivePhase,
+                                  const std::size_t, const bool local) {
+  const int local_integer = local ? 1 : 0;
+  int global_integer = 0;
+  const MPI_Comm communicator =
+      *static_cast<const MPI_Comm *>(communicator_storage_);
+  if (MPI_Allreduce(&local_integer, &global_integer, 1, MPI_INT, MPI_LAND,
+                    communicator) != MPI_SUCCESS)
+    throw std::runtime_error("MPI logical-and reduction failed");
+  return global_integer != 0;
+}
+#endif
+
+} // namespace subcycling_detail
+
+#ifndef CARPETX_SUBCYCLING_ADAPTER_STANDALONE
+namespace {
+
+using subcycling_detail::LocalScratchBatch;
+using subcycling_detail::LocalScratchEntry;
+using subcycling_detail::ScratchAdapterFailure;
+using subcycling_detail::ScratchCollectivePhase;
+
+class SerialCollectiveOps final : public subcycling_detail::CollectiveOps {
+public:
+  std::int64_t reduce_min(ScratchCollectivePhase, std::size_t,
+                          const std::int64_t local) override {
+    return local;
+  }
+  std::int64_t reduce_max(ScratchCollectivePhase, std::size_t,
+                          const std::int64_t local) override {
+    return local;
+  }
+  bool reduce_and(ScratchCollectivePhase, std::size_t,
+                  const bool local) override {
+    return local;
+  }
+};
+
+bool native_size_to_i64(const std::size_t value,
+                        std::int64_t &converted) noexcept {
+  if constexpr (sizeof(std::size_t) > sizeof(std::int64_t)) {
+    if (value > static_cast<std::size_t>(
+                    std::numeric_limits<std::int64_t>::max()))
+      return false;
+  }
+  converted = static_cast<std::int64_t>(value);
+  return true;
+}
+
+template <typename Integer>
+bool integer_to_i64(const Integer value, std::int64_t &converted) noexcept {
+  using Raw = std::remove_cv_t<Integer>;
+  static_assert(std::is_integral_v<Raw>);
+  if constexpr (std::is_signed_v<Raw>) {
+    if constexpr (sizeof(Raw) > sizeof(std::int64_t)) {
+      if (value < static_cast<Raw>(std::numeric_limits<std::int64_t>::min()) ||
+          value > static_cast<Raw>(std::numeric_limits<std::int64_t>::max()))
+        return false;
+    }
+  } else {
+    if constexpr (sizeof(Raw) >= sizeof(std::int64_t)) {
+      if (value > static_cast<Raw>(
+                      std::numeric_limits<std::int64_t>::max()))
+        return false;
+    }
+  }
+  converted = static_cast<std::int64_t>(value);
+  return true;
+}
+
+template <typename Integer>
+bool append_integer(std::vector<std::int64_t> &fields, const Integer value) {
+  std::int64_t converted = 0;
+  if (!integer_to_i64(value, converted))
+    return false;
+  fields.push_back(converted);
+  return true;
+}
+
+bool checked_add(const std::size_t left, const std::size_t right,
+                 std::size_t &sum) noexcept {
+  if (right > std::numeric_limits<std::size_t>::max() - left)
+    return false;
+  sum = left + right;
+  return true;
+}
+
+bool checked_multiply(const std::size_t left, const std::size_t right,
+                      std::size_t &product) noexcept {
+  if (left != 0 && right > std::numeric_limits<std::size_t>::max() / left)
+    return false;
+  product = left * right;
+  return true;
+}
+
+bool descriptor_length(const std::size_t validity_count,
+                       const std::size_t box_count,
+                       const std::size_t processor_count,
+                       std::size_t &length) noexcept {
+  std::size_t validity_fields = 0;
+  std::size_t box_fields = 0;
+  std::size_t total = 18;
+  return checked_multiply(validity_count, 3, validity_fields) &&
+         checked_multiply(box_count, 6, box_fields) &&
+         checked_add(total, validity_fields, total) &&
+         checked_add(total, box_fields, total) &&
+         checked_add(total, processor_count, length);
+}
+
+LocalScratchBatch inventory_canonical_tl0(const GHExt &ghext,
+                                          const int patch,
+                                          const int level) {
+  LocalScratchBatch batch{ScratchAdapterFailure::none,
+                          static_cast<std::int64_t>(CarpetX_GetEpoch()), patch,
+                          level, {}, 0};
+  if (patch < 0 || static_cast<std::size_t>(patch) >= ghext.patchdata.size()) {
+    batch.preflight_status = ScratchAdapterFailure::invalid_patch;
+    return batch;
+  }
+  const auto &patchdata = ghext.patchdata[static_cast<std::size_t>(patch)];
+  if (level < 0 ||
+      static_cast<std::size_t>(level) >= patchdata.leveldata.size()) {
+    batch.preflight_status = ScratchAdapterFailure::invalid_level;
+    return batch;
+  }
+  if (batch.captured_epoch < 0) {
+    batch.preflight_status = ScratchAdapterFailure::invalid_epoch;
+    return batch;
+  }
+
+  const auto &leveldata = patchdata.leveldata[static_cast<std::size_t>(level)];
+  std::size_t complete_count = 0;
+  for (const auto &group : leveldata.groupdata) {
+    if (group != nullptr) {
+      if (complete_count == std::numeric_limits<std::size_t>::max()) {
+        batch.preflight_status = ScratchAdapterFailure::invalid_schema;
+        return batch;
+      }
+      ++complete_count;
+    }
+  }
+  if (!native_size_to_i64(complete_count,
+                          batch.prevalidated_entry_count) ||
+      complete_count > batch.entries.max_size()) {
+    batch.preflight_status = ScratchAdapterFailure::invalid_schema;
+    return batch;
+  }
+  batch.entries.reserve(complete_count);
+
+  for (std::size_t group_index = 0;
+       group_index < leveldata.groupdata.size(); ++group_index) {
+    const auto &group_owner = leveldata.groupdata[group_index];
+    if (group_owner == nullptr)
+      continue;
+    const auto &groupdata = *group_owner;
+    if (group_index >
+            static_cast<std::size_t>(std::numeric_limits<int>::max()) ||
+        groupdata.groupindex != static_cast<int>(group_index) ||
+        groupdata.mfab.empty() || groupdata.valid.empty() ||
+        groupdata.mfab.size() != groupdata.valid.size()) {
+      batch.preflight_status = ScratchAdapterFailure::invalid_tl0;
+      continue;
+    }
+    std::int64_t ignored_size = 0;
+    if (!native_size_to_i64(groupdata.mfab.size(), ignored_size) ||
+        !native_size_to_i64(groupdata.valid.size(), ignored_size)) {
+      batch.preflight_status = ScratchAdapterFailure::invalid_schema;
+      continue;
+    }
+    const auto *mfab = groupdata.mfab.at(0).get();
+    const auto &why_valid = groupdata.valid.at(0);
+    if (mfab == nullptr || !mfab->isDefined() || groupdata.numvars <= 0 ||
+        mfab->nComp() <= 0 || mfab->nComp() != groupdata.numvars ||
+        why_valid.size() != static_cast<std::size_t>(groupdata.numvars)) {
+      batch.preflight_status = ScratchAdapterFailure::invalid_components;
+      continue;
+    }
+
+    const auto &box_array = mfab->boxArray();
+    const auto box_count = box_array.size();
+    const auto &processor_map = mfab->DistributionMap().ProcessorMap();
+    if (!box_array.ok() || box_count < 0 ||
+        box_count > std::numeric_limits<int>::max() ||
+        static_cast<std::size_t>(box_count) != processor_map.size() ||
+        !native_size_to_i64(why_valid.size(), ignored_size) ||
+        !native_size_to_i64(processor_map.size(), ignored_size)) {
+      batch.preflight_status = ScratchAdapterFailure::invalid_schema;
+      continue;
+    }
+
+    std::vector<ScratchValidity> validity;
+    if (why_valid.size() > validity.max_size()) {
+      batch.preflight_status = ScratchAdapterFailure::invalid_schema;
+      continue;
+    }
+    validity.reserve(why_valid.size());
+    for (const auto &why : why_valid) {
+      const auto &bits = why.get();
+      validity.push_back(ScratchValidity{bits.valid_int, bits.valid_outer,
+                                         bits.valid_ghosts});
+    }
+
+    std::vector<std::int64_t> schema_fields;
+    std::size_t expected_schema_length = 0;
+    std::int64_t prevalidated_schema_length = 0;
+    if (!descriptor_length(validity.size(),
+                           static_cast<std::size_t>(box_count),
+                           processor_map.size(), expected_schema_length) ||
+        !native_size_to_i64(expected_schema_length,
+                            prevalidated_schema_length) ||
+        expected_schema_length > schema_fields.max_size()) {
+      batch.preflight_status = ScratchAdapterFailure::invalid_schema;
+      continue;
+    }
+    schema_fields.reserve(expected_schema_length);
+    bool fields_representable = true;
+    const auto append = [&](const auto value) {
+      if (fields_representable)
+        fields_representable = append_integer(schema_fields, value);
+    };
+    append(batch.captured_epoch);
+    append(patch);
+    append(level);
+    append(group_index);
+    append(groupdata.numvars);
+    append(mfab->nComp());
+    append(groupdata.mfab.size());
+    append(mfab->size());
+    append(groupdata.valid.size());
+    append(why_valid.size());
+    for (const auto &bits : validity) {
+      append(bits.interior);
+      append(bits.outer);
+      append(bits.ghosts);
+    }
+    append(box_count);
+    const auto index_type = box_array.ixType().toIntVect();
+    for (int direction = 0; direction < 3; ++direction)
+      append(index_type[direction]);
+    for (int box_index = 0; box_index < static_cast<int>(box_count);
+         ++box_index) {
+      const auto box = box_array[box_index];
+      for (int direction = 0; direction < 3; ++direction) {
+        append(box.smallEnd(direction));
+        append(box.bigEnd(direction));
+      }
+    }
+    const auto grow = mfab->nGrowVect();
+    for (int direction = 0; direction < 3; ++direction)
+      append(grow[direction]);
+    append(processor_map.size());
+    for (const auto owner_rank : processor_map)
+      append(owner_rank);
+    if (!fields_representable ||
+        schema_fields.size() != expected_schema_length) {
+      batch.preflight_status = ScratchAdapterFailure::invalid_schema;
+      continue;
+    }
+
+    batch.entries.push_back(LocalScratchEntry{
+        ScratchGFKey{batch.captured_epoch, level, patch,
+                     static_cast<int>(group_index)},
+        static_cast<const void *>(mfab), mfab, std::move(validity),
+        std::move(schema_fields), prevalidated_schema_length});
+  }
+  if (batch.entries.size() != complete_count &&
+      batch.preflight_status == ScratchAdapterFailure::none)
+    batch.preflight_status = ScratchAdapterFailure::omitted_group;
+  return batch;
+}
+
+} // namespace
+
+CertifiedScratchLevelFrame
+copy_canonical_tl0_collective(const GHExt &ghext, const int patch,
+                              const int level) {
+  auto batch = inventory_canonical_tl0(ghext, patch, level);
+#ifdef CCTK_MPI
+  MPI_Comm communicator = amrex::ParallelContext::CommunicatorSub();
+  subcycling_detail::MpiCollectiveOps collectives(&communicator);
+#else
+  SerialCollectiveOps collectives;
+#endif
+  auto frame = subcycling_detail::run_certification_transaction(
+      batch, collectives,
+      [] { return static_cast<std::int64_t>(CarpetX_GetEpoch()); },
+      [](const UncertifiedScratchLevelManifest &manifest,
+         const std::vector<ScratchGFView> &views) {
+        return ScratchLevelFrame::copy_tl0(manifest, views);
+      });
+  return CertifiedScratchLevelFrame(patch, std::move(frame));
+}
+#endif
+
+} // namespace CarpetX

--- a/CarpetX/src/subcycling_scratch_adapter.hxx
+++ b/CarpetX/src/subcycling_scratch_adapter.hxx
@@ -1,0 +1,49 @@
+#ifndef CARPETX_SUBCYCLING_SCRATCH_ADAPTER_HXX
+#define CARPETX_SUBCYCLING_SCRATCH_ADAPTER_HXX
+
+#include "subcycling_scratch_state.hxx"
+
+#include <utility>
+
+namespace CarpetX {
+
+class GHExt;
+class ScratchLocalLevelBinding;
+#ifdef CARPETX_SUBCYCLING_SCRATCH_LOCAL_GH_UNIT
+class ScratchLocalLevelBindingTestAccess;
+#endif
+
+class CertifiedScratchLevelFrame {
+public:
+  CertifiedScratchLevelFrame(const CertifiedScratchLevelFrame &) = delete;
+  CertifiedScratchLevelFrame &
+  operator=(const CertifiedScratchLevelFrame &) = delete;
+  CertifiedScratchLevelFrame(CertifiedScratchLevelFrame &&) noexcept;
+  CertifiedScratchLevelFrame &
+  operator=(CertifiedScratchLevelFrame &&) noexcept;
+
+  int patch() const noexcept;
+  const ScratchLevelFrame &frame() const noexcept;
+
+private:
+  friend class ScratchLocalLevelBinding;
+#ifdef CARPETX_SUBCYCLING_SCRATCH_LOCAL_GH_UNIT
+  friend class ScratchLocalLevelBindingTestAccess;
+#endif
+  friend CertifiedScratchLevelFrame
+  copy_canonical_tl0_collective(const GHExt &, int, int);
+  CertifiedScratchLevelFrame(int patch, ScratchLevelFrame frame);
+
+  int patch_;
+  ScratchLevelFrame frame_;
+};
+
+// Collective on amrex::ParallelContext::CommunicatorSub(). All participating
+// ranks must call at one quiescent hierarchy point with the same patch/level.
+// There is deliberately no caller-selected communicator, manifest, or subset.
+[[nodiscard]] CertifiedScratchLevelFrame
+copy_canonical_tl0_collective(const GHExt &ghext, int patch, int level);
+
+} // namespace CarpetX
+
+#endif // CARPETX_SUBCYCLING_SCRATCH_ADAPTER_HXX

--- a/CarpetX/src/subcycling_scratch_adapter_internal.hxx
+++ b/CarpetX/src/subcycling_scratch_adapter_internal.hxx
@@ -1,0 +1,105 @@
+#ifndef CARPETX_SUBCYCLING_SCRATCH_ADAPTER_INTERNAL_HXX
+#define CARPETX_SUBCYCLING_SCRATCH_ADAPTER_INTERNAL_HXX
+
+#include "subcycling_scratch_state.hxx"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <stdexcept>
+#include <vector>
+
+namespace CarpetX::subcycling_detail {
+
+enum class ScratchAdapterFailure : std::int64_t {
+  none = 0,
+  invalid_patch = 1,
+  invalid_level = 2,
+  invalid_epoch = 3,
+  invalid_tl0 = 4,
+  invalid_components = 5,
+  invalid_validity = 6,
+  invalid_schema = 7,
+  duplicate_group = 8,
+  omitted_group = 9,
+  extra_group = 10,
+};
+
+enum class ScratchCollectivePhase : std::int64_t {
+  preflight_status = 0,
+  entry_count = 1,
+  schema_lengths = 2,
+  schema_fields = 3,
+  source_ok = 4,
+  epoch_reader = 5,
+  copy_success = 6,
+};
+
+struct ScratchSchemaRow {
+  std::vector<std::int64_t> schema_fields;
+};
+
+struct LocalScratchEntry {
+  ScratchGFKey key;
+  const void *source_storage_identity;
+  const amrex::MultiFab *multifab;
+  std::vector<ScratchValidity> validity;
+  std::vector<std::int64_t> schema_fields;
+  std::int64_t prevalidated_schema_length;
+};
+
+struct LocalScratchBatch {
+  ScratchAdapterFailure preflight_status;
+  std::int64_t captured_epoch;
+  int patch;
+  int level;
+  std::vector<LocalScratchEntry> entries;
+  std::int64_t prevalidated_entry_count;
+};
+
+class CollectiveOps {
+public:
+  virtual ~CollectiveOps() = default;
+  virtual std::int64_t reduce_min(ScratchCollectivePhase phase,
+                                  std::size_t ordinal,
+                                  std::int64_t local) = 0;
+  virtual std::int64_t reduce_max(ScratchCollectivePhase phase,
+                                  std::size_t ordinal,
+                                  std::int64_t local) = 0;
+  virtual bool reduce_and(ScratchCollectivePhase phase, std::size_t ordinal,
+                          bool local) = 0;
+};
+
+class ScratchAdapterCollectiveError : public std::runtime_error {
+public:
+  using std::runtime_error::runtime_error;
+};
+
+using EpochReader = std::function<std::int64_t()>;
+using CopyTL0 = std::function<ScratchLevelFrame(
+    const UncertifiedScratchLevelManifest &,
+    const std::vector<ScratchGFView> &)>;
+
+[[nodiscard]] ScratchLevelFrame run_certification_transaction(
+    LocalScratchBatch &batch, CollectiveOps &collectives,
+    const EpochReader &epoch_reader, const CopyTL0 &copy_tl0);
+
+#if defined(CARPETX_SUBCYCLING_ADAPTER_MPI_UNIT) || defined(CCTK_MPI)
+class MpiCollectiveOps final : public CollectiveOps {
+public:
+  explicit MpiCollectiveOps(void *communicator_storage) noexcept;
+  std::int64_t reduce_min(ScratchCollectivePhase phase, std::size_t ordinal,
+                          std::int64_t local) override;
+  std::int64_t reduce_max(ScratchCollectivePhase phase, std::size_t ordinal,
+                          std::int64_t local) override;
+  bool reduce_and(ScratchCollectivePhase phase, std::size_t ordinal,
+                  bool local) override;
+
+private:
+  void *communicator_storage_;
+};
+#endif
+
+} // namespace CarpetX::subcycling_detail
+
+#endif // CARPETX_SUBCYCLING_SCRATCH_ADAPTER_INTERNAL_HXX

--- a/CarpetX/src/subcycling_scratch_local_gh.cxx
+++ b/CarpetX/src/subcycling_scratch_local_gh.cxx
@@ -1,0 +1,362 @@
+#include "subcycling_scratch_local_gh.hxx"
+
+#ifndef CARPETX_SUBCYCLING_SCRATCH_LOCAL_GH_STANDALONE
+#include "driver.hxx"
+#include "schedule.hxx"
+#include <cctk.h>
+#endif
+
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace CarpetX {
+namespace {
+
+[[noreturn]] void reject(const char *message) {
+  throw std::invalid_argument(message);
+}
+
+template <typename T>
+void copy_required(std::vector<T> &dst, const T *src, std::size_t count) {
+  if (src == nullptr)
+    reject("scratch local cGH geometry source is null");
+  dst.assign(src, src + count);
+}
+
+bool same_intvect(const amrex::IntVect &a,
+                  const amrex::IntVect &b) noexcept {
+  for (int d = 0; d < dim; ++d)
+    if (a[d] != b[d])
+      return false;
+  return true;
+}
+
+bool same_box(const amrex::Box &a, const amrex::Box &b) noexcept {
+  return same_intvect(a.smallEnd(), b.smallEnd()) &&
+         same_intvect(a.bigEnd(), b.bigEnd());
+}
+
+bool same_layout(const amrex::MultiFab &a, const amrex::MultiFab &b) {
+  if (a.nComp() != b.nComp() ||
+      !same_intvect(a.nGrowVect(), b.nGrowVect()))
+    return false;
+  const auto &aba = a.boxArray();
+  const auto &abb = b.boxArray();
+  if (aba.size() != abb.size() ||
+      !same_intvect(aba.ixType().toIntVect(), abb.ixType().toIntVect()))
+    return false;
+  for (int i = 0; i < aba.size(); ++i)
+    if (!same_box(aba[i], abb[i]))
+      return false;
+  return a.DistributionMap().ProcessorMap() ==
+         b.DistributionMap().ProcessorMap();
+}
+
+struct ValidatedEntry {
+  std::size_t frame_index;
+  int group_index;
+  int first_var;
+  int num_vars;
+};
+
+struct ValidatedBinding {
+  const GHExt::PatchData::LevelData *leveldata;
+  std::vector<ValidatedEntry> entries;
+  std::size_t local_context_count;
+};
+
+ValidatedBinding validate_binding(const GHExt &ghext,
+                                  const CertifiedScratchLevelFrame &certified) {
+  const int patch = certified.patch();
+  const auto &frame = certified.frame();
+  const int level = frame.level();
+  if (patch < 0 || static_cast<std::size_t>(patch) >= ghext.patchdata.size())
+    reject("scratch local cGH patch is out of range");
+  const auto &patchdata = ghext.patchdata[static_cast<std::size_t>(patch)];
+  if (level < 0 ||
+      static_cast<std::size_t>(level) >= patchdata.leveldata.size())
+    reject("scratch local cGH level is out of range");
+  if (frame.hierarchy_epoch() < 0 ||
+      frame.hierarchy_epoch() !=
+          static_cast<std::int64_t>(CarpetX_GetEpoch()))
+    reject("scratch local cGH frame epoch is stale");
+  const auto &leveldata =
+      patchdata.leveldata[static_cast<std::size_t>(level)];
+  if (leveldata.patch != patch || leveldata.level != level ||
+      leveldata.fab == nullptr)
+    reject("scratch local cGH level metadata is inconsistent");
+
+  const int total_vars = CCTK_NumVars();
+  if (total_vars < 0)
+    reject("scratch local cGH variable count is invalid");
+  std::vector<bool> claimed(static_cast<std::size_t>(total_vars), false);
+  std::vector<ValidatedEntry> entries;
+  entries.reserve(frame.entry_count());
+  std::size_t frame_index = 0;
+  for (std::size_t gi = 0; gi < leveldata.groupdata.size(); ++gi) {
+    const auto &owner = leveldata.groupdata[gi];
+    if (owner == nullptr)
+      continue;
+    if (frame_index >= frame.entry_count())
+      reject("scratch local cGH frame omits a canonical GF group");
+    const auto &groupdata = *owner;
+    const auto &key = frame.key(frame_index);
+    if (gi > static_cast<std::size_t>(std::numeric_limits<int>::max()) ||
+        key.hierarchy_epoch != frame.hierarchy_epoch() ||
+        key.patch != patch || key.level != level ||
+        key.group_index != static_cast<int>(gi) ||
+        groupdata.groupindex != static_cast<int>(gi) ||
+        groupdata.patch != patch || groupdata.level != level)
+      reject("scratch local cGH frame key or group metadata is inconsistent");
+    cGroup group;
+    if (CCTK_GroupData(static_cast<int>(gi), &group) != 0 ||
+        group.grouptype != CCTK_GF || group.numvars != groupdata.numvars ||
+        CCTK_FirstVarIndexI(static_cast<int>(gi)) !=
+            groupdata.firstvarindex)
+      reject("scratch local cGH canonical entry is not a grid function");
+    if (groupdata.firstvarindex < 0 || groupdata.numvars <= 0 ||
+        groupdata.numvars > total_vars ||
+        groupdata.firstvarindex > total_vars - groupdata.numvars)
+      reject("scratch local cGH group variable range is invalid");
+    for (int vi = 0; vi < groupdata.numvars; ++vi) {
+      const int var = groupdata.firstvarindex + vi;
+      if (claimed[static_cast<std::size_t>(var)])
+        reject("scratch local cGH group variable ranges overlap");
+      if (CCTK_DeclaredTimeLevelsVI(var) <= 0)
+        reject("scratch local cGH variable has no declared time level");
+      claimed[static_cast<std::size_t>(var)] = true;
+    }
+    if (groupdata.mfab.empty() || groupdata.valid.empty() ||
+        groupdata.mfab[0] == nullptr)
+      reject("scratch local cGH canonical TL0 is unavailable");
+    const auto &live = *groupdata.mfab[0];
+    const auto &scratch = frame.multifab(frame_index);
+    if (!live.isDefined() || !scratch.isDefined() ||
+        live.nComp() != groupdata.numvars ||
+        scratch.nComp() != groupdata.numvars ||
+        groupdata.valid[0].size() !=
+            static_cast<std::size_t>(groupdata.numvars) ||
+        frame.validity(frame_index).size() !=
+            static_cast<std::size_t>(groupdata.numvars) ||
+        !same_layout(live, scratch))
+      reject("scratch local cGH TL0 layout or validity is inconsistent");
+    entries.push_back(ValidatedEntry{frame_index, static_cast<int>(gi),
+                                     groupdata.firstvarindex,
+                                     groupdata.numvars});
+    ++frame_index;
+  }
+  if (entries.empty() || frame_index != frame.entry_count())
+    reject("scratch local cGH frame has an extra or empty canonical set");
+
+  std::size_t local_count = 0;
+  const auto mfitinfo = amrex::MFItInfo().EnableTiling();
+  for (amrex::MFIter mfi(*leveldata.fab, mfitinfo); mfi.isValid(); ++mfi) {
+    if (local_count >= leveldata.local_cctkGHs.size())
+      reject("scratch local cGH cache omits a tiled context");
+    const cGH *local = leveldata.local_cctkGHs[local_count].get();
+    if (local == nullptr || local->cctk_patch != patch ||
+        local->cctk_level != level || local->cctk_component != mfi.index())
+      reject("scratch local cGH cached context does not match MFIter");
+    ++local_count;
+  }
+  if (local_count != leveldata.local_cctkGHs.size())
+    reject("scratch local cGH cache contains extra tiled contexts");
+  return ValidatedBinding{&leveldata, std::move(entries), local_count};
+}
+
+} // namespace
+
+struct ScratchLocalLevelBinding::Storage {
+#ifdef CARPETX_SUBCYCLING_SCRATCH_LOCAL_GH_UNIT
+  inline static int live_count = 0;
+#endif
+  cGH gh{};
+  std::vector<int> gsh, lsh, lbnd, ubnd, tile_min, tile_max, ash;
+  std::vector<int> to, from, bbox, levfac, levoff, levoffdenom, nghostzones;
+  std::vector<CCTK_REAL> delta_space, origin_space;
+  std::vector<std::vector<void *>> data_rows;
+  std::vector<void **> data_row_pointers;
+
+  Storage(const cGH &src, const int total_vars) {
+    if (src.cctk_dim != dim || total_vars < 0)
+      reject("scratch local cGH source dimension is invalid");
+    gh.cctk_dim = src.cctk_dim;
+    gh.cctk_level = src.cctk_level;
+    gh.cctk_patch = src.cctk_patch;
+    gh.cctk_npatches = src.cctk_npatches;
+    gh.cctk_component = src.cctk_component;
+    gh.cctk_alignment = src.cctk_alignment;
+    gh.cctk_alignment_offset = src.cctk_alignment_offset;
+    gh.cctk_convlevel = src.cctk_convlevel;
+    gh.cctk_convfac = src.cctk_convfac;
+    gh.cctk_iteration = -1;
+    gh.cctk_delta_time = std::numeric_limits<CCTK_REAL>::quiet_NaN();
+    gh.cctk_time = std::numeric_limits<CCTK_REAL>::quiet_NaN();
+    gh.cctk_timefac = 0;
+    gh.current_scheduled_function = nullptr;
+    gh.identity = nullptr;
+    gh.extensions = nullptr;
+    gh.GroupData = nullptr;
+
+    copy_required(gsh, src.cctk_gsh, dim);
+    copy_required(lsh, src.cctk_lsh, dim);
+    copy_required(lbnd, src.cctk_lbnd, dim);
+    copy_required(ubnd, src.cctk_ubnd, dim);
+    copy_required(tile_min, src.cctk_tile_min, dim);
+    copy_required(tile_max, src.cctk_tile_max, dim);
+    copy_required(ash, src.cctk_ash, dim);
+    copy_required(to, src.cctk_to, dim);
+    copy_required(from, src.cctk_from, dim);
+    copy_required(delta_space, src.cctk_delta_space, dim);
+    copy_required(origin_space, src.cctk_origin_space, dim);
+    copy_required(bbox, src.cctk_bbox, 2 * dim);
+    copy_required(levfac, src.cctk_levfac, dim);
+    copy_required(levoff, src.cctk_levoff, dim);
+    copy_required(levoffdenom, src.cctk_levoffdenom, dim);
+    copy_required(nghostzones, src.cctk_nghostzones, dim);
+    gh.cctk_gsh = gsh.data(); gh.cctk_lsh = lsh.data();
+    gh.cctk_lbnd = lbnd.data(); gh.cctk_ubnd = ubnd.data();
+    gh.cctk_tile_min = tile_min.data(); gh.cctk_tile_max = tile_max.data();
+    gh.cctk_ash = ash.data(); gh.cctk_to = to.data(); gh.cctk_from = from.data();
+    gh.cctk_delta_space = delta_space.data();
+    gh.cctk_origin_space = origin_space.data(); gh.cctk_bbox = bbox.data();
+    gh.cctk_levfac = levfac.data(); gh.cctk_levoff = levoff.data();
+    gh.cctk_levoffdenom = levoffdenom.data();
+    gh.cctk_nghostzones = nghostzones.data();
+
+    data_rows.resize(static_cast<std::size_t>(total_vars));
+    data_row_pointers.resize(static_cast<std::size_t>(total_vars), nullptr);
+    for (int var = 0; var < total_vars; ++var) {
+      const int tls = CCTK_DeclaredTimeLevelsVI(var);
+      if (tls <= 0)
+        reject("scratch local cGH variable has no declared time level");
+      auto &row = data_rows[static_cast<std::size_t>(var)];
+      row.assign(static_cast<std::size_t>(tls), nullptr);
+      data_row_pointers[static_cast<std::size_t>(var)] = row.data();
+    }
+    gh.data = data_row_pointers.data();
+#ifdef CARPETX_SUBCYCLING_SCRATCH_LOCAL_GH_UNIT
+    ++live_count;
+#endif
+  }
+
+  ~Storage() {
+#ifdef CARPETX_SUBCYCLING_SCRATCH_LOCAL_GH_UNIT
+    --live_count;
+#endif
+  }
+};
+
+std::unique_ptr<ScratchLocalLevelBinding>
+ScratchLocalLevelBinding::bind(const GHExt &ghext,
+                               CertifiedScratchLevelFrame &&frame) {
+  (void)validate_binding(ghext, frame);
+  std::unique_ptr<ScratchLocalLevelBinding> result(
+      new ScratchLocalLevelBinding(std::move(frame)));
+  result->build_contexts(ghext);
+  return result;
+}
+
+ScratchLocalLevelBinding::ScratchLocalLevelBinding(
+    CertifiedScratchLevelFrame &&frame)
+    : frame_(std::move(frame)) {}
+ScratchLocalLevelBinding::~ScratchLocalLevelBinding() = default;
+
+void ScratchLocalLevelBinding::build_contexts(const GHExt &ghext) {
+  const auto validated = validate_binding(ghext, frame_);
+  const auto &leveldata = *validated.leveldata;
+  contexts_.reserve(validated.local_context_count);
+  std::size_t local_ordinal = 0;
+  const auto mfitinfo = amrex::MFItInfo().EnableTiling();
+  for (amrex::MFIter mfi(*leveldata.fab, mfitinfo); mfi.isValid(); ++mfi) {
+    cGH *const source = leveldata.local_cctkGHs.at(local_ordinal).get();
+    if (source == nullptr)
+      reject("scratch local cGH cached context is null during binding");
+    auto storage = std::make_unique<Storage>(*source, CCTK_NumVars());
+    for (const auto &entry : validated.entries) {
+      const auto &groupdata =
+          *leveldata.groupdata[static_cast<std::size_t>(entry.group_index)];
+      auto scratch_vars =
+          frame_.frame_.mutable_multifab(entry.frame_index).array(mfi.index());
+      auto live_vars = groupdata.mfab[0]->array(mfi.index());
+      GridPtrDesc1 grid(leveldata, groupdata, MFPointer(mfi));
+      for (int vi = 0; vi < entry.num_vars; ++vi) {
+        void *scratch_ptr = grid.ptr(scratch_vars, vi);
+        void *live_ptr = grid.ptr(live_vars, vi);
+        if (scratch_ptr == nullptr || scratch_ptr == live_ptr)
+          reject("scratch local cGH pointer aliases canonical TL0");
+        storage->gh.data[entry.first_var + vi][0] = scratch_ptr;
+      }
+    }
+    contexts_.push_back(std::move(storage));
+    ++local_ordinal;
+  }
+  if (frame_.frame_.hierarchy_epoch() !=
+      static_cast<std::int64_t>(CarpetX_GetEpoch()))
+    reject("hierarchy epoch changed while building scratch local cGH views");
+}
+
+int ScratchLocalLevelBinding::patch() const noexcept { return frame_.patch_; }
+int ScratchLocalLevelBinding::level() const noexcept {
+  return frame_.frame_.level();
+}
+std::int64_t ScratchLocalLevelBinding::hierarchy_epoch() const noexcept {
+  return frame_.frame_.hierarchy_epoch();
+}
+std::size_t ScratchLocalLevelBinding::local_context_count() const noexcept {
+  return contexts_.size();
+}
+
+cGH *ScratchLocalLevelBinding::context_for_executor(
+    const std::size_t ordinal) noexcept {
+  return ordinal < contexts_.size() ? &contexts_[ordinal]->gh : nullptr;
+}
+
+ScratchLevelFrame &ScratchLocalLevelBinding::frame_for_executor() noexcept {
+  return frame_.frame_;
+}
+
+int ScratchLocalLevelBinding::level_for_executor() const noexcept {
+  return frame_.frame_.level();
+}
+
+void ScratchLocalLevelBinding::claim_for_executor() {
+  if (executor_faulted_.load())
+    throw std::logic_error("scratch binding is faulted");
+  bool expected = false;
+  if (!executor_busy_.compare_exchange_strong(expected, true))
+    throw std::logic_error("scratch binding is busy");
+  if (executor_faulted_.load()) {
+    executor_busy_.store(false);
+    throw std::logic_error("scratch binding is faulted");
+  }
+}
+
+void ScratchLocalLevelBinding::release_for_executor() noexcept {
+  executor_busy_.store(false);
+}
+
+void ScratchLocalLevelBinding::fault_for_executor() noexcept {
+  executor_faulted_.store(true);
+}
+
+} // namespace CarpetX
+
+#ifndef CARPETX_SUBCYCLING_SCRATCH_LOCAL_GH_STANDALONE
+#include "subcycling_scratch_schedule_executor.hxx"
+
+namespace CarpetX {
+
+void ScratchLocalLevelBinding::install_stage_coordinates_for_executor(
+    const ScratchStageCoordinates &coordinates) noexcept {
+  for (auto &context : contexts_) {
+    context->gh.cctk_iteration = coordinates.level_iteration;
+    context->gh.cctk_time = coordinates.stage_time;
+    context->gh.cctk_delta_time = coordinates.base_delta_time;
+    context->gh.cctk_timefac = coordinates.time_refinement_factor;
+  }
+}
+
+} // namespace CarpetX
+#endif

--- a/CarpetX/src/subcycling_scratch_local_gh.hxx
+++ b/CarpetX/src/subcycling_scratch_local_gh.hxx
@@ -1,0 +1,80 @@
+#ifndef CARPETX_SUBCYCLING_SCRATCH_LOCAL_GH_HXX
+#define CARPETX_SUBCYCLING_SCRATCH_LOCAL_GH_HXX
+
+#include "subcycling_scratch_adapter.hxx"
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#if !defined(CARPETX_SUBCYCLING_SCRATCH_LOCAL_GH_STANDALONE) &&              \
+    !defined(CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_STANDALONE)
+#include <cctk.h>
+#else
+struct cGH;
+#endif
+
+namespace CarpetX {
+
+class GHExt;
+class CertifiedScratchStageExecutor;
+class ScratchStateTransaction;
+class ScratchStateTransactionFactory;
+struct ScratchStageCoordinates;
+#ifdef CARPETX_SUBCYCLING_SCRATCH_LOCAL_GH_UNIT
+class ScratchLocalLevelBindingTestAccess;
+#endif
+
+// Owns a certified scratch frame and non-executing local cGH views into it.
+// The object cannot move because every cGH data pointer is tied to frame_.
+class ScratchLocalLevelBinding final {
+public:
+  [[nodiscard]] static std::unique_ptr<ScratchLocalLevelBinding>
+  bind(const GHExt &ghext, CertifiedScratchLevelFrame &&frame);
+
+  ~ScratchLocalLevelBinding();
+  ScratchLocalLevelBinding(const ScratchLocalLevelBinding &) = delete;
+  ScratchLocalLevelBinding &
+  operator=(const ScratchLocalLevelBinding &) = delete;
+  ScratchLocalLevelBinding(ScratchLocalLevelBinding &&) = delete;
+  ScratchLocalLevelBinding &operator=(ScratchLocalLevelBinding &&) = delete;
+
+  int patch() const noexcept;
+  int level() const noexcept;
+  std::int64_t hierarchy_epoch() const noexcept;
+  std::size_t local_context_count() const noexcept;
+
+private:
+  struct Storage;
+  explicit ScratchLocalLevelBinding(CertifiedScratchLevelFrame &&frame);
+  void build_contexts(const GHExt &ghext);
+  cGH *context_for_executor(std::size_t ordinal) noexcept;
+  ScratchLevelFrame &frame_for_executor() noexcept;
+  ScratchLevelFrame &frame_for_transaction() noexcept { return frame_.frame_; }
+  int level_for_executor() const noexcept;
+  void claim_for_executor();
+  void release_for_executor() noexcept;
+  void fault_for_executor() noexcept;
+  void install_stage_coordinates_for_executor(
+      const ScratchStageCoordinates &coordinates) noexcept;
+
+  friend class CertifiedScratchStageExecutor;
+  friend class ScratchStateTransaction;
+  friend class ScratchStateTransactionFactory;
+
+#ifdef CARPETX_SUBCYCLING_SCRATCH_LOCAL_GH_UNIT
+  friend class ScratchLocalLevelBindingTestAccess;
+#endif
+
+  // Contexts are destroyed first, then the frame their pointers address.
+  CertifiedScratchLevelFrame frame_;
+  std::vector<std::unique_ptr<Storage>> contexts_;
+  std::atomic_bool executor_busy_{false};
+  std::atomic_bool executor_faulted_{false};
+};
+
+} // namespace CarpetX
+
+#endif // CARPETX_SUBCYCLING_SCRATCH_LOCAL_GH_HXX

--- a/CarpetX/src/subcycling_scratch_schedule_executor.cxx
+++ b/CarpetX/src/subcycling_scratch_schedule_executor.cxx
@@ -1,0 +1,591 @@
+#include "subcycling_scratch_schedule_executor.hxx"
+
+#include "subcycling_schedule_certification.hxx"
+#include "subcycling_scratch_local_gh.hxx"
+
+#ifndef CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_STANDALONE
+#include <cctk.h>
+#include <cctk_Groups.h>
+#include <cctk_Parameters.h>
+extern "C" CCTK_INT CarpetX_GetEpoch(void);
+#endif
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <exception>
+#include <limits>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+namespace CarpetX {
+
+#ifndef CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_STANDALONE
+void synchronize();
+#endif
+
+#ifdef CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_STANDALONE
+bool subcycling_scratch_executor_poison_enabled_for_test() noexcept;
+void subcycling_scratch_executor_synchronize_for_test();
+void subcycling_scratch_executor_metadata_snapshotted_for_test();
+void subcycling_scratch_executor_after_idle_publish_for_test();
+#endif
+
+struct ResolvedScratchScheduleAccess {
+  std::size_t frame_entry{};
+  std::size_t component{};
+  int read_mask{};
+  int write_mask{};
+  int invalidate_mask{};
+};
+
+struct ResolvedScratchScheduleRoutine {
+  std::vector<ResolvedScratchScheduleAccess> accesses;
+};
+
+namespace {
+
+constexpr int supported_validity_mask =
+    CCTK_VALID_GHOSTS | CCTK_VALID_BOUNDARY | CCTK_VALID_INTERIOR;
+
+struct MetadataSnapshot {
+  cGH *gh{};
+  int iteration{};
+  double time{};
+  double delta_time{};
+  int timefac{};
+  const void *scheduled_function{};
+};
+
+[[nodiscard]] std::size_t phase_index(const ScratchSchedulePhase phase) {
+  return phase == ScratchSchedulePhase::post_step ? 0U : 1U;
+}
+
+[[nodiscard]] SubcyclingScheduleTarget
+target_for_phase(const ScratchSchedulePhase phase) {
+  return phase == ScratchSchedulePhase::post_step
+             ? SubcyclingScheduleTarget::post_step
+             : SubcyclingScheduleTarget::rhs;
+}
+
+[[nodiscard]] bool power_of_two(const int value) noexcept {
+  return value > 0 && (value & (value - 1)) == 0;
+}
+
+[[nodiscard]] double time_tolerance(const double a, const double b,
+                                    const double c = 0.0) noexcept {
+  const double scale =
+      std::max({1.0, std::abs(a), std::abs(b), std::abs(c)});
+  return 16.0 * std::numeric_limits<double>::epsilon() * scale;
+}
+
+[[nodiscard]] bool poison_enabled() noexcept {
+#ifdef CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_STANDALONE
+  return subcycling_scratch_executor_poison_enabled_for_test();
+#else
+  DECLARE_CCTK_PARAMETERS;
+  return poison_undefined_values;
+#endif
+}
+
+void drain_device_work() {
+#ifdef CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_STANDALONE
+  subcycling_scratch_executor_synchronize_for_test();
+#else
+  synchronize();
+#endif
+}
+
+[[nodiscard]] bool validity_bit(const ScratchValidity &validity,
+                                const int bit) noexcept {
+  if (bit == CCTK_VALID_INTERIOR)
+    return validity.interior;
+  if (bit == CCTK_VALID_BOUNDARY)
+    return validity.outer;
+  return validity.ghosts;
+}
+
+void set_validity_bit(ScratchValidity &validity, const int bit,
+                      const bool value) noexcept {
+  if (bit == CCTK_VALID_INTERIOR)
+    validity.interior = value;
+  else if (bit == CCTK_VALID_BOUNDARY)
+    validity.outer = value;
+  else
+    validity.ghosts = value;
+}
+
+template <typename F> void for_each_validity_bit(const int mask, F &&function) {
+  for (const int bit :
+       {CCTK_VALID_GHOSTS, CCTK_VALID_BOUNDARY, CCTK_VALID_INTERIOR})
+    if ((mask & bit) != 0)
+      function(bit);
+}
+
+} // namespace
+
+struct CertifiedScratchStageExecutor::Storage {
+  enum class Lifecycle : std::uint8_t { idle, preflight, started, faulted };
+  std::array<std::vector<ResolvedScratchScheduleRoutine>, 2> routines;
+  std::atomic<Lifecycle> lifecycle{Lifecycle::idle};
+};
+
+#ifdef CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_STANDALONE
+void ScratchLocalLevelBinding::install_stage_coordinates_for_executor(
+    const ScratchStageCoordinates &coordinates) noexcept {
+  for (auto &context : contexts_) {
+    context->gh.cctk_iteration = coordinates.level_iteration;
+    context->gh.cctk_time = coordinates.stage_time;
+    context->gh.cctk_delta_time = coordinates.base_delta_time;
+    context->gh.cctk_timefac = coordinates.time_refinement_factor;
+  }
+}
+#endif
+
+ScratchScheduleExecutionError::ScratchScheduleExecutionError(
+    const ScratchScheduleExecutionErrorCode code,
+    const std::optional<ScratchSchedulePhase> phase,
+    const std::optional<std::size_t> routine_ordinal,
+    const std::optional<std::size_t> context_ordinal,
+    const std::string &message)
+    : std::runtime_error(message), code_(code), phase_(phase),
+      routine_ordinal_(routine_ordinal), context_ordinal_(context_ordinal) {}
+
+ScratchScheduleExecutionErrorCode
+ScratchScheduleExecutionError::code() const noexcept {
+  return code_;
+}
+
+std::optional<ScratchSchedulePhase>
+ScratchScheduleExecutionError::phase() const noexcept {
+  return phase_;
+}
+
+std::optional<std::size_t>
+ScratchScheduleExecutionError::routine_ordinal() const noexcept {
+  return routine_ordinal_;
+}
+
+std::optional<std::size_t>
+ScratchScheduleExecutionError::context_ordinal() const noexcept {
+  return context_ordinal_;
+}
+
+[[noreturn]] void CertifiedScratchStageExecutor::raise(
+    const ScratchScheduleExecutionErrorCode code,
+    const std::optional<ScratchSchedulePhase> phase,
+    const std::optional<std::size_t> routine_ordinal,
+    const std::optional<std::size_t> context_ordinal,
+    const std::string &message) {
+  throw ScratchScheduleExecutionError(code, phase, routine_ordinal,
+                                      context_ordinal, message);
+}
+
+CertifiedScratchStageExecutor::CertifiedScratchStageExecutor(
+    CertifiedLocalScheduleRegistry &registry,
+    ScratchLocalLevelBinding &binding, std::unique_ptr<Storage> storage)
+    : registry_(registry), binding_(binding), storage_(std::move(storage)) {}
+
+CertifiedScratchStageExecutor::~CertifiedScratchStageExecutor() {
+  binding_.release_for_executor();
+}
+
+std::unique_ptr<CertifiedScratchStageExecutor>
+CertifiedScratchStageExecutor::create(CertifiedLocalScheduleRegistry &registry,
+                                      ScratchLocalLevelBinding &binding) {
+  if (binding.executor_faulted_.load())
+    raise(ScratchScheduleExecutionErrorCode::binding_faulted, std::nullopt,
+          std::nullopt, std::nullopt, "scratch binding is faulted");
+  if (binding.executor_busy_.load())
+    raise(ScratchScheduleExecutionErrorCode::binding_busy, std::nullopt,
+          std::nullopt, std::nullopt,
+          "scratch binding already has an executor");
+  try {
+    binding.claim_for_executor();
+  } catch (const std::logic_error &) {
+    const auto code = binding.executor_faulted_.load()
+                          ? ScratchScheduleExecutionErrorCode::binding_faulted
+                          : ScratchScheduleExecutionErrorCode::binding_busy;
+    raise(code, std::nullopt, std::nullopt, std::nullopt,
+          "scratch binding lease could not be acquired");
+  }
+
+  bool published = false;
+  try {
+    auto storage = std::make_unique<Storage>();
+    auto &frame = binding.frame_for_executor();
+    constexpr std::array<ScratchSchedulePhase, 2> phases{
+        ScratchSchedulePhase::post_step, ScratchSchedulePhase::rhs};
+    for (const auto phase : phases) {
+      const auto target = target_for_phase(phase);
+      auto &resolved_phase = storage->routines[phase_index(phase)];
+      resolved_phase.reserve(registry.size(target));
+      for (std::size_t ordinal = 0; ordinal < registry.size(target);
+           ++ordinal) {
+        const auto &record = registry.record_for_executor(target, ordinal);
+        ResolvedScratchScheduleRoutine resolved;
+        resolved.accesses.reserve(record.item.accesses.size());
+        for (const auto &canonical : record.item.accesses) {
+          if (canonical.timelevel != 0 ||
+              ((canonical.read_mask | canonical.write_mask |
+                canonical.invalidate_mask) &
+               ~supported_validity_mask) != 0)
+            raise(ScratchScheduleExecutionErrorCode::unresolved_access, phase,
+                  ordinal, std::nullopt,
+                  "certified access has an unsupported timelevel or mask");
+          const int variable = CCTK_VarIndex(canonical.variable_name.c_str());
+          const char *const roundtrip =
+              variable >= 0 ? CCTK_FullVarName(variable) : nullptr;
+          if (variable < 0 || roundtrip == nullptr ||
+              canonical.variable_name != roundtrip ||
+              CCTK_VarTypeI(variable) != CCTK_VARIABLE_REAL)
+            raise(ScratchScheduleExecutionErrorCode::unresolved_access, phase,
+                  ordinal, std::nullopt,
+                  "certified variable mapping did not round-trip");
+          const int group = CCTK_GroupIndexFromVarI(variable);
+          const int first = group >= 0 ? CCTK_FirstVarIndexI(group) : -1;
+          cGroup group_data{};
+          if (group < 0 || first < 0 ||
+              CCTK_GroupData(group, &group_data) != 0 ||
+              group_data.grouptype != CCTK_GF || group_data.numvars <= 0 ||
+              variable < first || variable >= first + group_data.numvars)
+            raise(ScratchScheduleExecutionErrorCode::unresolved_access, phase,
+                  ordinal, std::nullopt,
+                  "certified variable group mapping is inconsistent");
+
+          std::optional<std::size_t> frame_entry;
+          for (std::size_t entry = 0; entry < frame.entry_count(); ++entry) {
+            if (frame.key(entry).group_index == group) {
+              if (frame_entry.has_value())
+                raise(ScratchScheduleExecutionErrorCode::unresolved_access,
+                      phase, ordinal, std::nullopt,
+                      "scratch frame contains a duplicate group mapping");
+              frame_entry = entry;
+            }
+          }
+          const auto component = static_cast<std::size_t>(variable - first);
+          if (!frame_entry.has_value() ||
+              component >= frame.validity(*frame_entry).size())
+            raise(ScratchScheduleExecutionErrorCode::unresolved_access, phase,
+                  ordinal, std::nullopt,
+                  "scratch frame does not contain the certified variable");
+          resolved.accesses.push_back(
+              ResolvedScratchScheduleAccess{
+                  *frame_entry, component, canonical.read_mask,
+                  canonical.write_mask, canonical.invalidate_mask});
+        }
+        resolved_phase.push_back(std::move(resolved));
+      }
+    }
+    auto result = std::unique_ptr<CertifiedScratchStageExecutor>(
+        new CertifiedScratchStageExecutor(registry, binding,
+                                           std::move(storage)));
+    published = true;
+    return result;
+  } catch (const ScratchScheduleExecutionError &) {
+    if (!published)
+      binding.release_for_executor();
+    throw;
+  } catch (const std::exception &error) {
+    if (!published)
+      binding.release_for_executor();
+    raise(ScratchScheduleExecutionErrorCode::internal_failure, std::nullopt,
+          std::nullopt, std::nullopt,
+          std::string("executor factory failed: ") + error.what());
+  } catch (...) {
+    if (!published)
+      binding.release_for_executor();
+    raise(ScratchScheduleExecutionErrorCode::internal_failure, std::nullopt,
+          std::nullopt, std::nullopt,
+          "executor factory failed with a non-standard exception");
+  }
+}
+
+ScratchScheduleExecutionReceipt CertifiedScratchStageExecutor::execute_post_step(
+    const StepContext &step, const ScratchStageCoordinates &coordinates) {
+  return execute(ScratchSchedulePhase::post_step, step, coordinates);
+}
+
+ScratchScheduleExecutionReceipt CertifiedScratchStageExecutor::execute_rhs(
+    const StepContext &step, const ScratchStageCoordinates &coordinates) {
+  return execute(ScratchSchedulePhase::rhs, step, coordinates);
+}
+
+bool CertifiedScratchStageExecutor::faulted() const noexcept {
+  return storage_->lifecycle.load() == Storage::Lifecycle::faulted;
+}
+
+ScratchScheduleExecutionReceipt CertifiedScratchStageExecutor::execute(
+    const ScratchSchedulePhase phase, const StepContext &step,
+    const ScratchStageCoordinates &coordinates) {
+  using Lifecycle = Storage::Lifecycle;
+  for (;;) {
+    Lifecycle observed = storage_->lifecycle.load();
+    if (observed == Lifecycle::idle) {
+      if (storage_->lifecycle.compare_exchange_weak(observed,
+                                                    Lifecycle::preflight))
+        break;
+      continue;
+    }
+    if (observed == Lifecycle::faulted)
+      raise(ScratchScheduleExecutionErrorCode::already_faulted, phase,
+            std::nullopt, std::nullopt,
+            "scratch executor is already faulted");
+    const Lifecycle active_state = observed;
+    if (storage_->lifecycle.compare_exchange_strong(observed,
+                                                    Lifecycle::faulted)) {
+      if (active_state == Lifecycle::started)
+        binding_.fault_for_executor();
+      raise(ScratchScheduleExecutionErrorCode::reentrant_execution, phase,
+            std::nullopt, std::nullopt,
+            "scratch executor execution is already active");
+    }
+  }
+
+  bool execution_started = false;
+  try {
+
+  const auto preflight_failure =
+      [&](const ScratchScheduleExecutionErrorCode code,
+          const char *const message) -> void {
+    raise(code, phase, std::nullopt, std::nullopt, message);
+  };
+
+  if (current_step_context() != &step || step.level < 0 ||
+      binding_.level_for_executor() != step.level ||
+      !std::isfinite(step.begin_time) || !std::isfinite(step.end_time) ||
+      !(step.begin_time < step.end_time) ||
+      !(step.begin_clock < step.end_clock))
+    preflight_failure(ScratchScheduleExecutionErrorCode::invalid_step_context,
+                      "active StepContext or binding level is invalid");
+  if (coordinates.level_iteration < 0 ||
+      !std::isfinite(coordinates.stage_time) ||
+      !std::isfinite(coordinates.base_delta_time) ||
+      !(coordinates.base_delta_time > 0.0) ||
+      !power_of_two(coordinates.time_refinement_factor) ||
+      !(step_clock_t(0) < coordinates.base_delta_clock))
+    preflight_failure(ScratchScheduleExecutionErrorCode::invalid_coordinates,
+                      "scratch stage coordinates are invalid");
+
+  const double stage_tolerance =
+      time_tolerance(step.begin_time, step.end_time, coordinates.stage_time);
+  if (coordinates.stage_time < step.begin_time - stage_tolerance ||
+      coordinates.stage_time > step.end_time + stage_tolerance)
+    preflight_failure(ScratchScheduleExecutionErrorCode::invalid_coordinates,
+                      "scratch stage time is outside the active step");
+  const auto level_delta_clock = step.end_clock - step.begin_clock;
+  if (level_delta_clock != coordinates.base_delta_clock /
+                               coordinates.time_refinement_factor)
+    preflight_failure(ScratchScheduleExecutionErrorCode::invalid_coordinates,
+                      "base and level clocks do not match exactly");
+  const double expected_level_dt =
+      coordinates.base_delta_time /
+      static_cast<double>(coordinates.time_refinement_factor);
+  const double observed_level_dt = step.end_time - step.begin_time;
+  if (std::abs(observed_level_dt - expected_level_dt) >
+      time_tolerance(observed_level_dt, expected_level_dt,
+                     coordinates.base_delta_time))
+    preflight_failure(ScratchScheduleExecutionErrorCode::invalid_coordinates,
+                      "base and level double time steps do not match");
+  if (binding_.hierarchy_epoch() !=
+      static_cast<std::int64_t>(CarpetX_GetEpoch()))
+    preflight_failure(ScratchScheduleExecutionErrorCode::stale_binding,
+                      "scratch binding hierarchy epoch is stale");
+  if (poison_enabled())
+    preflight_failure(
+        ScratchScheduleExecutionErrorCode::unsupported_configuration,
+        "poison_undefined_values must be disabled for scratch execution");
+
+  std::vector<MetadataSnapshot> metadata;
+  try {
+    metadata.reserve(binding_.local_context_count());
+    for (std::size_t ordinal = 0;
+         ordinal < binding_.local_context_count(); ++ordinal) {
+      cGH *const gh = binding_.context_for_executor(ordinal);
+      if (gh == nullptr)
+        preflight_failure(ScratchScheduleExecutionErrorCode::internal_failure,
+                          "scratch binding returned a null context");
+      metadata.push_back(MetadataSnapshot{
+          gh, gh->cctk_iteration, gh->cctk_time, gh->cctk_delta_time,
+          gh->cctk_timefac,
+          static_cast<const void *>(gh->current_scheduled_function)});
+    }
+  } catch (const ScratchScheduleExecutionError &) {
+    throw;
+  } catch (const std::exception &error) {
+    raise(ScratchScheduleExecutionErrorCode::internal_failure, phase,
+          std::nullopt, std::nullopt,
+          std::string("could not snapshot scratch metadata: ") +
+              error.what());
+  }
+#ifdef CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_STANDALONE
+  subcycling_scratch_executor_metadata_snapshotted_for_test();
+#endif
+
+  std::size_t routine_count = 0;
+  std::size_t local_calls = 0;
+  {
+  const std::size_t context_count = binding_.local_context_count();
+  std::vector<int> results;
+  std::vector<std::exception_ptr> failures;
+  try {
+    results.resize(context_count);
+    failures.resize(context_count);
+  } catch (const std::exception &error) {
+    raise(ScratchScheduleExecutionErrorCode::internal_failure, phase,
+          std::nullopt, std::nullopt,
+          std::string("could not allocate scratch execution state: ") +
+              error.what());
+  }
+
+  struct MetadataGuard {
+    ScratchLocalLevelBinding &binding;
+    std::vector<MetadataSnapshot> &snapshots;
+    ~MetadataGuard() {
+      for (const auto &snapshot : snapshots) {
+        snapshot.gh->cctk_iteration = snapshot.iteration;
+        snapshot.gh->cctk_time = snapshot.time;
+        snapshot.gh->cctk_delta_time = snapshot.delta_time;
+        snapshot.gh->cctk_timefac = snapshot.timefac;
+        snapshot.gh->current_scheduled_function =
+            reinterpret_cast<decltype(snapshot.gh->current_scheduled_function)>(
+                const_cast<void *>(snapshot.scheduled_function));
+      }
+    }
+  } metadata_guard{binding_, metadata};
+  binding_.install_stage_coordinates_for_executor(coordinates);
+
+  auto &frame = binding_.frame_for_executor();
+  const auto &routines = storage_->routines[phase_index(phase)];
+  const auto target = target_for_phase(phase);
+  for (std::size_t routine_ordinal = 0;
+       routine_ordinal < routines.size(); ++routine_ordinal) {
+    if (execution_started &&
+        storage_->lifecycle.load() != Lifecycle::started)
+      raise(ScratchScheduleExecutionErrorCode::reentrant_execution, phase,
+            routine_ordinal, std::nullopt,
+            "scratch executor lifecycle changed during execution");
+    const auto &routine = routines[routine_ordinal];
+    for (const auto &resolved : routine.accesses) {
+      const auto &validity =
+          frame.validity(resolved.frame_entry).at(resolved.component);
+      bool reads_valid = true;
+      for_each_validity_bit(resolved.read_mask, [&](const int bit) {
+        reads_valid = reads_valid && validity_bit(validity, bit);
+      });
+      if (!reads_valid) {
+        raise(ScratchScheduleExecutionErrorCode::invalid_read, phase,
+              routine_ordinal, std::nullopt,
+              "scratch routine read requires invalid data");
+      }
+    }
+
+    if (!execution_started) {
+      Lifecycle expected = Lifecycle::preflight;
+      if (!storage_->lifecycle.compare_exchange_strong(expected,
+                                                       Lifecycle::started))
+        raise(ScratchScheduleExecutionErrorCode::reentrant_execution, phase,
+              routine_ordinal, std::nullopt,
+              "scratch executor lifecycle changed before first call");
+      execution_started = true;
+    }
+
+    std::fill(results.begin(), results.end(), 0);
+    std::fill(failures.begin(), failures.end(), nullptr);
+#pragma omp parallel for schedule(static)
+    for (std::int64_t context_ordinal = 0;
+         context_ordinal < static_cast<std::int64_t>(context_count);
+         ++context_ordinal) {
+      const auto index = static_cast<std::size_t>(context_ordinal);
+      try {
+        cGH *const gh = binding_.context_for_executor(index);
+        if (gh == nullptr)
+          throw std::runtime_error("scratch context disappeared");
+        results[index] =
+            registry_.invoke_for_executor(target, routine_ordinal, gh);
+      } catch (...) {
+        failures[index] = std::current_exception();
+      }
+    }
+
+    std::exception_ptr barrier_failure;
+    try {
+      drain_device_work();
+    } catch (...) {
+      barrier_failure = std::current_exception();
+    }
+    local_calls += context_count;
+
+    std::optional<std::size_t> failed_context;
+    for (std::size_t index = 0; index < context_count; ++index)
+      if (failures[index] != nullptr || results[index] != 0) {
+        failed_context = index;
+        break;
+    }
+    if (failed_context.has_value() || barrier_failure != nullptr) {
+      raise(ScratchScheduleExecutionErrorCode::call_failed, phase,
+            routine_ordinal, failed_context,
+            barrier_failure != nullptr
+                ? "scratch routine device barrier failed"
+                : "scratch routine worker or call bridge failed");
+    }
+    if (storage_->lifecycle.load() != Lifecycle::started)
+      raise(ScratchScheduleExecutionErrorCode::reentrant_execution, phase,
+            routine_ordinal, std::nullopt,
+            "scratch executor lifecycle changed during routine execution");
+
+    for (const auto &resolved : routine.accesses) {
+      auto &validity =
+          frame.mutable_validity(resolved.frame_entry).at(resolved.component);
+      for_each_validity_bit(resolved.write_mask, [&](const int bit) {
+        set_validity_bit(validity, bit, true);
+      });
+    }
+    for (const auto &resolved : routine.accesses) {
+      auto &validity =
+          frame.mutable_validity(resolved.frame_entry).at(resolved.component);
+      for_each_validity_bit(resolved.invalidate_mask, [&](const int bit) {
+        set_validity_bit(validity, bit, false);
+      });
+    }
+  }
+  routine_count = routines.size();
+  }
+
+  Lifecycle expected =
+      execution_started ? Lifecycle::started : Lifecycle::preflight;
+  if (!storage_->lifecycle.compare_exchange_strong(expected, Lifecycle::idle))
+    raise(ScratchScheduleExecutionErrorCode::reentrant_execution, phase,
+          std::nullopt, std::nullopt,
+          "scratch executor lifecycle changed before receipt publication");
+#ifdef CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_STANDALONE
+  subcycling_scratch_executor_after_idle_publish_for_test();
+#endif
+  return ScratchScheduleExecutionReceipt{phase, routine_count, local_calls};
+  } catch (const ScratchScheduleExecutionError &) {
+    const Lifecycle previous =
+        storage_->lifecycle.exchange(Lifecycle::faulted);
+    if (execution_started || previous == Lifecycle::started)
+      binding_.fault_for_executor();
+    throw;
+  } catch (const std::exception &error) {
+    const Lifecycle previous =
+        storage_->lifecycle.exchange(Lifecycle::faulted);
+    if (execution_started || previous == Lifecycle::started)
+      binding_.fault_for_executor();
+    raise(ScratchScheduleExecutionErrorCode::internal_failure, phase,
+          std::nullopt, std::nullopt,
+          std::string("unexpected scratch executor failure: ") + error.what());
+  } catch (...) {
+    const Lifecycle previous =
+        storage_->lifecycle.exchange(Lifecycle::faulted);
+    if (execution_started || previous == Lifecycle::started)
+      binding_.fault_for_executor();
+    raise(ScratchScheduleExecutionErrorCode::internal_failure, phase,
+          std::nullopt, std::nullopt,
+          "unknown scratch executor failure");
+  }
+}
+
+} // namespace CarpetX

--- a/CarpetX/src/subcycling_scratch_schedule_executor.hxx
+++ b/CarpetX/src/subcycling_scratch_schedule_executor.hxx
@@ -1,0 +1,115 @@
+#ifndef CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_HXX
+#define CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_HXX
+
+#include "subcycling_step_context.hxx"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+namespace CarpetX {
+
+enum class ScratchSchedulePhase : std::uint8_t { post_step, rhs };
+
+struct ScratchStageCoordinates {
+  int level_iteration;
+  double stage_time;
+  step_clock_t base_delta_clock;
+  double base_delta_time;
+  int time_refinement_factor;
+};
+
+struct ScratchScheduleExecutionReceipt {
+  ScratchSchedulePhase phase;
+  std::size_t routine_count;
+  std::size_t local_call_count;
+};
+
+enum class ScratchScheduleExecutionErrorCode : std::uint8_t {
+  invalid_step_context,
+  invalid_coordinates,
+  unsupported_configuration,
+  stale_binding,
+  binding_busy,
+  binding_faulted,
+  reentrant_execution,
+  unresolved_access,
+  invalid_read,
+  call_failed,
+  already_faulted,
+  internal_failure,
+};
+
+class ScratchScheduleExecutionError final : public std::runtime_error {
+public:
+  ScratchScheduleExecutionErrorCode code() const noexcept;
+  std::optional<ScratchSchedulePhase> phase() const noexcept;
+  std::optional<std::size_t> routine_ordinal() const noexcept;
+  std::optional<std::size_t> context_ordinal() const noexcept;
+
+private:
+  ScratchScheduleExecutionError(
+      ScratchScheduleExecutionErrorCode code,
+      std::optional<ScratchSchedulePhase> phase,
+      std::optional<std::size_t> routine_ordinal,
+      std::optional<std::size_t> context_ordinal,
+      const std::string &message);
+  ScratchScheduleExecutionErrorCode code_;
+  std::optional<ScratchSchedulePhase> phase_;
+  std::optional<std::size_t> routine_ordinal_;
+  std::optional<std::size_t> context_ordinal_;
+  friend class CertifiedScratchStageExecutor;
+};
+
+class CertifiedLocalScheduleRegistry;
+class ScratchLocalLevelBinding;
+
+class CertifiedScratchStageExecutor final {
+public:
+  [[nodiscard]] static std::unique_ptr<CertifiedScratchStageExecutor>
+  create(CertifiedLocalScheduleRegistry &registry,
+         ScratchLocalLevelBinding &binding);
+
+  ~CertifiedScratchStageExecutor();
+  CertifiedScratchStageExecutor(const CertifiedScratchStageExecutor &) =
+      delete;
+  CertifiedScratchStageExecutor &
+  operator=(const CertifiedScratchStageExecutor &) = delete;
+  CertifiedScratchStageExecutor(CertifiedScratchStageExecutor &&) = delete;
+  CertifiedScratchStageExecutor &
+  operator=(CertifiedScratchStageExecutor &&) = delete;
+
+  ScratchScheduleExecutionReceipt
+  execute_post_step(const StepContext &step,
+                    const ScratchStageCoordinates &coordinates);
+  ScratchScheduleExecutionReceipt
+  execute_rhs(const StepContext &step,
+              const ScratchStageCoordinates &coordinates);
+  bool faulted() const noexcept;
+
+private:
+  struct Storage;
+  CertifiedScratchStageExecutor(CertifiedLocalScheduleRegistry &registry,
+                                ScratchLocalLevelBinding &binding,
+                                std::unique_ptr<Storage> storage);
+  [[noreturn]] static void
+  raise(ScratchScheduleExecutionErrorCode code,
+        std::optional<ScratchSchedulePhase> phase,
+        std::optional<std::size_t> routine_ordinal,
+        std::optional<std::size_t> context_ordinal,
+        const std::string &message);
+  ScratchScheduleExecutionReceipt
+  execute(ScratchSchedulePhase phase, const StepContext &step,
+          const ScratchStageCoordinates &coordinates);
+
+  CertifiedLocalScheduleRegistry &registry_;
+  ScratchLocalLevelBinding &binding_;
+  std::unique_ptr<Storage> storage_;
+};
+
+} // namespace CarpetX
+
+#endif // CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_HXX

--- a/CarpetX/src/subcycling_scratch_state.cxx
+++ b/CarpetX/src/subcycling_scratch_state.cxx
@@ -1,0 +1,323 @@
+#include "subcycling_scratch_state.hxx"
+
+#include <AMReX_MultiFab.H>
+
+#include <memory>
+#include <stdexcept>
+#include <tuple>
+#include <unordered_set>
+#include <utility>
+
+namespace CarpetX {
+namespace {
+
+bool non_negative(const ScratchGFKey &key) noexcept {
+  return key.hierarchy_epoch >= 0 && key.level >= 0 && key.patch >= 0 &&
+         key.group_index >= 0;
+}
+
+auto patch_group(const ScratchGFKey &key) noexcept {
+  return std::tie(key.patch, key.group_index);
+}
+
+bool same_key(const ScratchGFKey &left, const ScratchGFKey &right) noexcept {
+  return left.hierarchy_epoch == right.hierarchy_epoch &&
+         left.level == right.level && left.patch == right.patch &&
+         left.group_index == right.group_index;
+}
+
+#ifndef CARPETX_SUBCYCLING_SCRATCH_LOCAL_GH_UNIT
+bool same_transaction_layout(const amrex::MultiFab &left,
+                             const amrex::MultiFab &right) noexcept {
+  return left.boxArray() == right.boxArray() &&
+         left.DistributionMap() == right.DistributionMap() &&
+         left.nComp() == right.nComp() &&
+         left.nGrowVect() == right.nGrowVect();
+}
+#endif
+
+void validate_manifest(const UncertifiedScratchLevelManifest &manifest) {
+  if (manifest.hierarchy_epoch < 0)
+    throw std::invalid_argument("scratch manifest epoch must be non-negative");
+  if (manifest.level < 0)
+    throw std::invalid_argument("scratch manifest level must be non-negative");
+  if (manifest.entries.empty())
+    throw std::invalid_argument("scratch manifest must not be empty");
+
+  std::unordered_set<const void *> unique_storage;
+  unique_storage.reserve(manifest.entries.size());
+  for (std::size_t index = 0; index < manifest.entries.size(); ++index) {
+    const auto &entry = manifest.entries[index];
+    if (!non_negative(entry.key))
+      throw std::invalid_argument("scratch manifest keys must be non-negative");
+    if (entry.key.hierarchy_epoch != manifest.hierarchy_epoch ||
+        entry.key.level != manifest.level)
+      throw std::invalid_argument(
+          "scratch manifest key epoch and level must match the manifest");
+    if (index != 0 &&
+        !(patch_group(manifest.entries[index - 1].key) <
+          patch_group(entry.key)))
+      throw std::invalid_argument(
+          "scratch manifest keys must be strictly ordered by patch and group");
+    if (entry.source_storage_identity == nullptr)
+      throw std::invalid_argument(
+          "scratch manifest storage identity must not be null");
+    if (!unique_storage.insert(entry.source_storage_identity).second)
+      throw std::invalid_argument(
+          "scratch manifest storage identities must be unique");
+  }
+}
+
+void validate_views(const UncertifiedScratchLevelManifest &manifest,
+                    const std::vector<ScratchGFView> &views) {
+  if (views.size() != manifest.entries.size())
+    throw std::invalid_argument(
+        "scratch view count must exactly match the manifest");
+
+  std::unordered_set<const amrex::MultiFab *> unique_multifabs;
+  std::unordered_set<const std::vector<ScratchValidity> *> unique_validity;
+  unique_multifabs.reserve(views.size());
+  unique_validity.reserve(views.size());
+  for (std::size_t index = 0; index < views.size(); ++index) {
+    const auto &manifest_entry = manifest.entries[index];
+    const auto &view = views[index];
+    if (!same_key(view.key, manifest_entry.key))
+      throw std::invalid_argument(
+          "scratch view key must match the ordered manifest key");
+    if (view.source_storage_identity !=
+        manifest_entry.source_storage_identity)
+      throw std::invalid_argument(
+          "scratch view storage identity must match the ordered manifest");
+    if (view.time_level != 0)
+      throw std::invalid_argument("scratch view must select time level zero");
+    if (view.multifab == nullptr)
+      throw std::invalid_argument("scratch view MultiFab must not be null");
+    if (!unique_multifabs.insert(view.multifab).second)
+      throw std::invalid_argument("scratch view MultiFabs must be unique");
+    if (view.validity == nullptr)
+      throw std::invalid_argument("scratch view validity must not be null");
+    if (!unique_validity.insert(view.validity).second)
+      throw std::invalid_argument("scratch view validity must be unique");
+    if (!view.multifab->isDefined())
+      throw std::invalid_argument("scratch source MultiFab must be defined");
+    if (view.multifab->nComp() <= 0)
+      throw std::invalid_argument(
+          "scratch source MultiFab must have positive components");
+    if (view.validity->size() !=
+        static_cast<std::size_t>(view.multifab->nComp()))
+      throw std::invalid_argument(
+          "scratch validity size must equal the MultiFab component count");
+  }
+}
+
+} // namespace
+
+struct ScratchLevelFrame::Entry {
+  ScratchGFKey key;
+  std::unique_ptr<amrex::MultiFab> multifab;
+  std::vector<ScratchValidity> validity;
+};
+
+ScratchLevelFrame ScratchLevelFrame::copy_tl0(
+    const UncertifiedScratchLevelManifest &manifest,
+    const std::vector<ScratchGFView> &views) {
+  validate_manifest(manifest);
+  validate_views(manifest, views);
+
+  std::vector<Entry> entries;
+  entries.reserve(views.size());
+  for (const auto &view : views) {
+    auto owned =
+        std::make_unique<amrex::MultiFab>(view.multifab->deepCopy());
+    entries.push_back(Entry{view.key, std::move(owned), *view.validity});
+  }
+  return ScratchLevelFrame(manifest.hierarchy_epoch, manifest.level,
+                           std::move(entries));
+}
+
+ScratchLevelFrame::ScratchLevelFrame(const std::int64_t hierarchy_epoch,
+                                     const int level,
+                                     std::vector<Entry> entries)
+    : hierarchy_epoch_(hierarchy_epoch), level_(level),
+      entries_(std::move(entries)) {}
+
+ScratchLevelFrame::~ScratchLevelFrame() = default;
+
+ScratchLevelFrame::ScratchLevelFrame(ScratchLevelFrame &&other) noexcept
+    : hierarchy_epoch_(other.hierarchy_epoch_), level_(other.level_),
+      entries_(std::move(other.entries_)) {
+  other.hierarchy_epoch_ = -1;
+  other.level_ = -1;
+  other.entries_.clear();
+}
+
+ScratchLevelFrame &
+ScratchLevelFrame::operator=(ScratchLevelFrame &&other) noexcept {
+  if (this == &other)
+    return *this;
+  hierarchy_epoch_ = other.hierarchy_epoch_;
+  level_ = other.level_;
+  entries_ = std::move(other.entries_);
+  other.hierarchy_epoch_ = -1;
+  other.level_ = -1;
+  other.entries_.clear();
+  return *this;
+}
+
+std::int64_t ScratchLevelFrame::hierarchy_epoch() const noexcept {
+  return hierarchy_epoch_;
+}
+
+int ScratchLevelFrame::level() const noexcept { return level_; }
+
+std::size_t ScratchLevelFrame::entry_count() const noexcept {
+  return entries_.size();
+}
+
+const ScratchGFKey &ScratchLevelFrame::key(const std::size_t index) const {
+  return entries_.at(index).key;
+}
+
+const amrex::MultiFab &
+ScratchLevelFrame::multifab(const std::size_t index) const {
+  return *entries_.at(index).multifab;
+}
+
+amrex::MultiFab &
+ScratchLevelFrame::mutable_multifab(const std::size_t index) {
+  return *entries_.at(index).multifab;
+}
+
+const std::vector<ScratchValidity> &
+ScratchLevelFrame::validity(const std::size_t index) const {
+  return entries_.at(index).validity;
+}
+
+std::vector<ScratchValidity> &
+ScratchLevelFrame::mutable_validity(const std::size_t index) {
+  return entries_.at(index).validity;
+}
+
+#ifndef CARPETX_SUBCYCLING_SCRATCH_LOCAL_GH_UNIT
+ScratchLevelFrame ScratchLevelFrame::clone_for_transaction() const {
+  std::vector<Entry> cloned;
+  cloned.reserve(entries_.size());
+  for (const auto &entry : entries_) {
+    auto multifab = std::make_unique<amrex::MultiFab>(entry.multifab->deepCopy());
+    cloned.push_back(Entry{entry.key, std::move(multifab), entry.validity});
+  }
+  return ScratchLevelFrame(hierarchy_epoch_, level_, std::move(cloned));
+}
+
+void ScratchLevelFrame::restore_from_transaction(
+    const ScratchLevelFrame &source) {
+  if (hierarchy_epoch_ != source.hierarchy_epoch_ || level_ != source.level_ ||
+      entries_.size() != source.entries_.size())
+    throw std::invalid_argument("scratch transaction frame metadata differs");
+
+  for (std::size_t index = 0; index < entries_.size(); ++index) {
+    auto &destination = entries_[index];
+    const auto &source_entry = source.entries_[index];
+    if (!same_key(destination.key, source_entry.key) ||
+        !same_transaction_layout(*destination.multifab,
+                                 *source_entry.multifab) ||
+        destination.validity.size() != source_entry.validity.size())
+      throw std::invalid_argument("scratch transaction frame schema differs");
+  }
+
+  for (std::size_t index = 0; index < entries_.size(); ++index) {
+    auto &destination = entries_[index];
+    const auto &source_entry = source.entries_[index];
+    amrex::MultiFab::Copy(*destination.multifab, *source_entry.multifab, 0, 0,
+                          destination.multifab->nComp(),
+                          destination.multifab->nGrowVect());
+    for (std::size_t component = 0; component < destination.validity.size();
+         ++component)
+      destination.validity[component] = source_entry.validity[component];
+  }
+}
+
+void ScratchLevelFrame::copy_interior_for_transaction(
+    const std::size_t destination_entry, const ScratchLevelFrame &source,
+    const std::size_t source_entry) {
+  auto &destination = *entries_.at(destination_entry).multifab;
+  const auto &source_multifab = *source.entries_.at(source_entry).multifab;
+  if (!same_transaction_layout(destination, source_multifab))
+    throw std::invalid_argument(
+        "scratch transaction interior copy layout differs");
+  amrex::MultiFab::Copy(destination, source_multifab, 0, 0,
+                        destination.nComp(), 0);
+}
+
+void ScratchLevelFrame::copy_validity_for_transaction(
+    const std::size_t destination_entry, const ScratchLevelFrame &source,
+    const std::size_t source_entry) {
+  auto &destination = entries_.at(destination_entry).validity;
+  const auto &source_validity = source.entries_.at(source_entry).validity;
+  if (destination.size() != source_validity.size())
+    throw std::invalid_argument(
+        "scratch transaction validity component count differs");
+  for (std::size_t component = 0; component < destination.size(); ++component)
+    destination[component] = source_validity[component];
+}
+
+void ScratchLevelFrame::copy_interior_validity_for_transaction(
+    const std::size_t destination_entry, const ScratchLevelFrame &source,
+    const std::size_t source_entry, const bool invalidate_noninterior) {
+  auto &destination = entries_.at(destination_entry).validity;
+  const auto &source_validity = source.entries_.at(source_entry).validity;
+  if (destination.size() != source_validity.size())
+    throw std::invalid_argument(
+        "scratch transaction validity component count differs");
+  for (std::size_t component = 0; component < destination.size(); ++component) {
+    destination[component].interior = source_validity[component].interior;
+    if (invalidate_noninterior) {
+      destination[component].outer = false;
+      destination[component].ghosts = false;
+    }
+  }
+}
+
+void ScratchLevelFrame::linear_combination_interior_for_transaction(
+    const std::size_t destination_entry, const double destination_scale,
+    const std::vector<double> &weights,
+    const std::vector<const ScratchLevelFrame *> &sources,
+    const std::vector<std::size_t> &source_entries) {
+  if (weights.size() != sources.size() ||
+      sources.size() != source_entries.size())
+    throw std::invalid_argument(
+        "scratch transaction combination metadata differs");
+  auto &destination = *entries_.at(destination_entry).multifab;
+  for (std::size_t source = 0; source < sources.size(); ++source) {
+    if (sources[source] == nullptr)
+      throw std::invalid_argument("scratch transaction source is null");
+    const auto &source_multifab =
+        *sources[source]->entries_.at(source_entries[source]).multifab;
+    if (sources[source] == this &&
+        source_entries[source] == destination_entry)
+      throw std::invalid_argument(
+          "scratch transaction combination rejects destination aliasing");
+    if (!same_transaction_layout(destination, source_multifab))
+      throw std::invalid_argument(
+          "scratch transaction combination layout differs");
+  }
+
+  if (destination_scale == 0.0)
+    destination.setVal(0.0, 0, destination.nComp(), 0);
+  else
+    destination.mult(destination_scale, 0, destination.nComp(), 0);
+  for (std::size_t source = 0; source < sources.size(); ++source) {
+    const auto &source_multifab =
+        *sources[source]->entries_.at(source_entries[source]).multifab;
+    amrex::MultiFab::Saxpy(destination, weights[source], source_multifab, 0, 0,
+                          destination.nComp(), 0);
+  }
+}
+
+const void *ScratchLevelFrame::entry_address_for_transaction(
+    const std::size_t entry) const {
+  return entries_.at(entry).multifab.get();
+}
+#endif
+
+} // namespace CarpetX

--- a/CarpetX/src/subcycling_scratch_state.hxx
+++ b/CarpetX/src/subcycling_scratch_state.hxx
@@ -1,0 +1,111 @@
+#ifndef CARPETX_SUBCYCLING_SCRATCH_STATE_HXX
+#define CARPETX_SUBCYCLING_SCRATCH_STATE_HXX
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace amrex {
+class MultiFab;
+}
+
+namespace CarpetX {
+
+class ScratchStateTransaction;
+class ScratchStateTransactionFactory;
+class ScratchStateTransactionCore;
+
+struct ScratchGFKey {
+  std::int64_t hierarchy_epoch;
+  int level;
+  int patch;
+  int group_index;
+};
+
+struct ScratchValidity {
+  bool interior;
+  bool outer;
+  bool ghosts;
+};
+
+struct ScratchGFView {
+  ScratchGFKey key;
+  int time_level;
+  const void *source_storage_identity;
+  const amrex::MultiFab *multifab;
+  const std::vector<ScratchValidity> *validity;
+};
+
+struct ScratchGFManifestEntry {
+  ScratchGFKey key;
+  const void *source_storage_identity;
+};
+
+// This manifest is agreement supplied by a caller, not a certified inventory
+// of the runtime GridFunction set. The identity token is opaque and is only
+// compared; it is never dereferenced by this primitive.
+struct UncertifiedScratchLevelManifest {
+  std::int64_t hierarchy_epoch;
+  int level;
+  std::vector<ScratchGFManifestEntry> entries;
+};
+
+class ScratchLevelFrame {
+public:
+  // A defined source whose storage was created with allocation disabled is a
+  // caller-contract violation in Phase 8A. Collective source certification is
+  // deliberately deferred to Phase 8B.
+  static ScratchLevelFrame
+  copy_tl0(const UncertifiedScratchLevelManifest &manifest,
+           const std::vector<ScratchGFView> &views);
+
+  ~ScratchLevelFrame();
+  ScratchLevelFrame(const ScratchLevelFrame &) = delete;
+  ScratchLevelFrame &operator=(const ScratchLevelFrame &) = delete;
+  ScratchLevelFrame(ScratchLevelFrame &&) noexcept;
+  ScratchLevelFrame &operator=(ScratchLevelFrame &&) noexcept;
+
+  std::int64_t hierarchy_epoch() const noexcept;
+  int level() const noexcept;
+  std::size_t entry_count() const noexcept;
+  const ScratchGFKey &key(std::size_t index) const;
+  const amrex::MultiFab &multifab(std::size_t index) const;
+  amrex::MultiFab &mutable_multifab(std::size_t index);
+  const std::vector<ScratchValidity> &validity(std::size_t index) const;
+  std::vector<ScratchValidity> &mutable_validity(std::size_t index);
+
+private:
+  struct Entry;
+  ScratchLevelFrame(std::int64_t hierarchy_epoch, int level,
+                    std::vector<Entry> entries);
+
+  ScratchLevelFrame clone_for_transaction() const;
+  void restore_from_transaction(const ScratchLevelFrame &source);
+  void copy_interior_for_transaction(std::size_t destination_entry,
+                                     const ScratchLevelFrame &source,
+                                     std::size_t source_entry);
+  void copy_validity_for_transaction(std::size_t destination_entry,
+                                     const ScratchLevelFrame &source,
+                                     std::size_t source_entry);
+  void copy_interior_validity_for_transaction(
+      std::size_t destination_entry, const ScratchLevelFrame &source,
+      std::size_t source_entry, bool invalidate_noninterior);
+  void linear_combination_interior_for_transaction(
+      std::size_t destination_entry, double destination_scale,
+      const std::vector<double> &weights,
+      const std::vector<const ScratchLevelFrame *> &sources,
+      const std::vector<std::size_t> &source_entries);
+  const void *entry_address_for_transaction(std::size_t entry) const;
+
+  friend class ScratchStateTransaction;
+  friend class ScratchStateTransactionFactory;
+  friend class ScratchStateTransactionCore;
+
+  std::int64_t hierarchy_epoch_;
+  int level_;
+  std::vector<Entry> entries_;
+};
+
+} // namespace CarpetX
+
+#endif // CARPETX_SUBCYCLING_SCRATCH_STATE_HXX

--- a/CarpetX/src/subcycling_scratch_state_transaction.cxx
+++ b/CarpetX/src/subcycling_scratch_state_transaction.cxx
@@ -162,6 +162,7 @@ struct ScratchStateTransaction::Storage {
   bool discarded{false};
   bool dense_committed_once{false};
   std::shared_ptr<const DenseInterval> committed_dense;
+  std::optional<ScratchLevelFrame> armed_live_evolved_rollback;
 
   // Declaration order is intentional: executor is destroyed before the
   // binding whose lease it owns.
@@ -191,6 +192,8 @@ struct ScratchStateTransaction::Storage {
     states.clear();
     committed_dense.reset();
     release_execution_storage();
+    // The session rollback snapshot is independent of disposable execution
+    // state and remains armed until commit disarms or rollback consumes it.
   }
 };
 
@@ -208,6 +211,9 @@ public:
                                          ScratchLevelFrame);
   static std::vector<ScratchLiveEntrySnapshot>
   read_and_validate_live(ScratchStateTransaction::Storage &);
+  static std::vector<ScratchLiveEntrySnapshot>
+  read_and_validate_live_against(ScratchStateTransaction::Storage &,
+                                 const ScratchLevelFrame &);
   static ScratchLevelFrame capture_live_frame(
       ScratchStateTransaction::Storage &, ScratchStateKind);
   static ScratchLevelFrame capture_working_frame(
@@ -279,13 +285,14 @@ ScratchStateToken ScratchStateTransactionCore::publish_state(
 }
 
 std::vector<ScratchLiveEntrySnapshot>
-ScratchStateTransactionCore::read_and_validate_live(
-    ScratchStateTransaction::Storage &storage) {
-  require_available(storage);
+ScratchStateTransactionCore::read_and_validate_live_against(
+    ScratchStateTransaction::Storage &storage,
+    const ScratchLevelFrame &reference) {
   if (!storage.epoch_reader ||
       storage.epoch_reader() != storage.hierarchy_epoch)
     throw std::runtime_error("scratch live hierarchy epoch changed");
-  if (storage.live_readers.size() != storage.expected_live.size())
+  if (storage.live_readers.size() != storage.expected_live.size() ||
+      reference.entry_count() != storage.expected_live.size())
     throw std::runtime_error("scratch live reader schema changed");
 
   std::vector<ScratchLiveEntrySnapshot> snapshots;
@@ -306,14 +313,19 @@ ScratchStateTransactionCore::read_and_validate_live(
         !observed.grid_function_real || !observed.restore ||
         observed.multifab == nullptr ||
         !observed.multifab->isDefined() ||
-        !same_layout(*observed.multifab,
-                     storage.working_frame->multifab(entry)) ||
-        observed.validity.size() !=
-            storage.working_frame->validity(entry).size())
+        !same_layout(*observed.multifab, reference.multifab(entry)) ||
+        observed.validity.size() != reference.validity(entry).size())
       throw std::runtime_error("scratch live identity or schema changed");
     snapshots.push_back(observed);
   }
   return snapshots;
+}
+
+std::vector<ScratchLiveEntrySnapshot>
+ScratchStateTransactionCore::read_and_validate_live(
+    ScratchStateTransaction::Storage &storage) {
+  require_available(storage);
+  return read_and_validate_live_against(storage, *storage.working_frame);
 }
 
 ScratchLevelFrame ScratchStateTransactionCore::capture_live_frame(
@@ -645,6 +657,60 @@ void ScratchStateTransaction::set_state_valid(
   }
 }
 
+void ScratchStateTransaction::arm_live_evolved_rollback() {
+  ScratchStateTransactionCore::require_available(*storage_);
+  if (storage_->armed_live_evolved_rollback.has_value())
+    throw std::logic_error("live evolved rollback is already armed");
+  try {
+    storage_->armed_live_evolved_rollback.emplace(
+        ScratchStateTransactionCore::capture_live_frame(
+            *storage_, ScratchStateKind::evolved));
+  } catch (...) {
+    storage_->fault_and_discard();
+    throw;
+  }
+}
+
+void ScratchStateTransaction::disarm_live_evolved_rollback() noexcept {
+  storage_->armed_live_evolved_rollback.reset();
+}
+
+void ScratchStateTransaction::rollback_live_evolved() {
+  if (!storage_->armed_live_evolved_rollback.has_value())
+    throw std::logic_error("live evolved rollback is not armed");
+  try {
+    const auto &frame = *storage_->armed_live_evolved_rollback;
+
+    // This path deliberately does not require disposable execution storage.
+    // Validate the epoch, every live identity, and every layout before the
+    // first restore callback can write live TL0.
+    const auto snapshots =
+        ScratchStateTransactionCore::read_and_validate_live_against(*storage_,
+                                                                     frame);
+    if (frame.entry_count() != snapshots.size())
+      throw std::runtime_error("armed live rollback state schema changed");
+    for (std::size_t entry = 0; entry < snapshots.size(); ++entry) {
+      const auto &snapshot = snapshots[entry];
+      if (!snapshot.restore || !same_key(frame.key(entry), snapshot.key) ||
+          !same_layout(frame.multifab(entry), *snapshot.multifab) ||
+          frame.validity(entry).size() != snapshot.validity.size())
+        throw std::runtime_error("armed live rollback state layout changed");
+    }
+
+    for (std::size_t entry = 0; entry < snapshots.size(); ++entry)
+      snapshots[entry].restore(frame.multifab(entry), frame.validity(entry));
+
+    storage_->armed_live_evolved_rollback.reset();
+    discard();
+  } catch (...) {
+    // A rollback attempt is terminal even when its preflight fails. Retrying
+    // after epoch or identity drift must never revive the private snapshot.
+    storage_->armed_live_evolved_rollback.reset();
+    storage_->fault_and_discard();
+    throw;
+  }
+}
+
 void ScratchStateTransaction::rollback_live_evolved(
     const ScratchStateToken &state) {
   // Preserve the distinction between a pre-existing terminal state and a
@@ -680,6 +746,7 @@ void ScratchStateTransaction::rollback_live_evolved(
 
     // Rollback is terminal for this attempted primary step. In particular,
     // no PostStep or RHS schedule is rerun after live TL0 is restored.
+    storage_->armed_live_evolved_rollback.reset();
     discard();
   } catch (...) {
     storage_->fault_and_discard();
@@ -957,6 +1024,32 @@ void ScratchStateTransaction::discard() noexcept {
   storage_->states.clear();
   storage_->committed_dense.reset();
   storage_->release_execution_storage();
+  // An armed session rollback is retained deliberately. Successful session
+  // commit disarms it before calling discard().
+}
+
+ScratchStateTransactionFactory::StageSpatialAccess
+ScratchStateTransactionFactory::stage_spatial_access(
+    ScratchStateTransaction &transaction) {
+  try {
+    auto &storage = *transaction.storage_;
+    ScratchStateTransactionCore::require_available(storage);
+    auto live_entries =
+        ScratchStateTransactionCore::read_and_validate_live(storage);
+    return StageSpatialAccess{storage.working_frame, std::move(live_entries),
+                              storage.hierarchy_epoch, storage.level,
+                              storage.time_refinement_factor};
+  } catch (...) {
+    if (transaction.storage_ != nullptr)
+      transaction.storage_->fault_and_discard();
+    throw;
+  }
+}
+
+void ScratchStateTransactionFactory::fault_stage_spatial_preparation(
+    ScratchStateTransaction &transaction) noexcept {
+  if (transaction.storage_ != nullptr)
+    transaction.storage_->fault_and_discard();
 }
 
 #ifndef CARPETX_SUBCYCLING_SCRATCH_STATE_TRANSACTION_UNIT

--- a/CarpetX/src/subcycling_scratch_state_transaction.cxx
+++ b/CarpetX/src/subcycling_scratch_state_transaction.cxx
@@ -1,0 +1,1231 @@
+#include "subcycling_scratch_state_transaction.hxx"
+
+#include "subcycling_dense_control_builder.hxx"
+#include "subcycling_dense_mfab_state.hxx"
+#include "subcycling_dense_output.hxx"
+#include "subcycling_dense_stencil.hxx"
+#ifdef CARPETX_SUBCYCLING_SCRATCH_STATE_TRANSACTION_UNIT
+#define CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_STANDALONE
+#endif
+#include "subcycling_scratch_local_gh.hxx"
+#include "subcycling_scratch_schedule_executor.hxx"
+#include "subcycling_scratch_state_transaction_factory.hxx"
+
+#ifndef CARPETX_SUBCYCLING_SCRATCH_STATE_TRANSACTION_UNIT
+#include "driver.hxx"
+#include <cctk_Parameters.h>
+extern "C" CCTK_INT CarpetX_GetEpoch(void);
+#endif
+
+#include <AMReX_MultiFab.H>
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+#include <tuple>
+#include <unordered_set>
+#include <utility>
+
+namespace CarpetX {
+namespace {
+
+std::atomic<std::uint64_t> next_transaction_owner{1};
+
+bool same_key(const ScratchGFKey &left, const ScratchGFKey &right) noexcept {
+  return std::tie(left.hierarchy_epoch, left.level, left.patch,
+                  left.group_index) ==
+         std::tie(right.hierarchy_epoch, right.level, right.patch,
+                  right.group_index);
+}
+
+bool same_layout(const amrex::MultiFab &left,
+                 const amrex::MultiFab &right) noexcept {
+  return left.boxArray() == right.boxArray() &&
+         left.DistributionMap() == right.DistributionMap() &&
+         left.nComp() == right.nComp() &&
+         left.nGrowVect() == right.nGrowVect();
+}
+
+bool finite_positive(const double value) noexcept {
+  return std::isfinite(value) && value > 0.0;
+}
+
+bool close_time(const double left, const double right,
+                const double begin, const double end) noexcept {
+  const auto scale =
+      std::max({1.0, std::abs(left), std::abs(right), std::abs(begin),
+                std::abs(end)});
+  const auto tolerance =
+      16.0 * std::numeric_limits<double>::epsilon() * scale;
+  return std::abs(left - right) <= tolerance;
+}
+
+std::size_t find_group(const ScratchLevelFrame &frame, const int group) {
+  for (std::size_t entry = 0; entry < frame.entry_count(); ++entry)
+    if (frame.key(entry).group_index == group)
+      return entry;
+  throw std::invalid_argument("scratch transaction group is absent");
+}
+
+DenseSampleConstraint sample_constraint(const ScratchDenseSampleRef &sample) {
+  return {sample.theta,
+          sample.kind == ScratchDenseSampleKind::value
+              ? DenseSampleKind::value
+              : DenseSampleKind::scaled_derivative};
+}
+
+bool same_constraint(const DenseSampleConstraint &left,
+                     const DenseSampleConstraint &right) noexcept {
+  return left.theta == right.theta && left.kind == right.kind;
+}
+
+} // namespace
+
+ScratchStateToken::ScratchStateToken() noexcept = default;
+
+ScratchStateToken::ScratchStateToken(const std::uint64_t owner,
+                                     const std::uint64_t state,
+                                     const std::int64_t epoch,
+                                     const std::uint64_t schema,
+                                     const ScratchStateKind kind) noexcept
+    : owner_(owner), state_(state), epoch_(epoch), schema_(schema),
+      kind_(kind) {}
+
+ScratchStateToken::ScratchStateToken(ScratchStateToken &&other) noexcept
+    : owner_(other.owner_), state_(other.state_), epoch_(other.epoch_),
+      schema_(other.schema_), kind_(other.kind_) {
+  other.reset();
+}
+
+ScratchStateToken &
+ScratchStateToken::operator=(ScratchStateToken &&other) noexcept {
+  if (this == &other)
+    return *this;
+  owner_ = other.owner_;
+  state_ = other.state_;
+  epoch_ = other.epoch_;
+  schema_ = other.schema_;
+  kind_ = other.kind_;
+  other.reset();
+  return *this;
+}
+
+bool ScratchStateToken::valid() const noexcept {
+  return owner_ != 0 && state_ != 0 && epoch_ >= 0 && schema_ != 0;
+}
+
+void ScratchStateToken::reset() noexcept {
+  owner_ = 0;
+  state_ = 0;
+  epoch_ = -1;
+  schema_ = 0;
+  kind_ = ScratchStateKind::evolved;
+}
+
+struct ScratchStateTransaction::Storage {
+  struct PairIndex {
+    ScratchGroupPair groups;
+    std::size_t evolved_entry;
+    std::size_t rhs_entry;
+  };
+
+  struct StateRecord {
+    ScratchStateKind kind;
+    ScratchLevelFrame frame;
+  };
+
+  struct ExpectedLiveEntry {
+    ScratchLiveEntrySnapshot snapshot;
+  };
+
+  std::uint64_t owner{next_transaction_owner.fetch_add(1)};
+  std::uint64_t schema{1};
+  std::int64_t hierarchy_epoch{-1};
+  std::vector<ScratchGroupPair> group_pairs;
+  std::vector<int> dependent_groups;
+  std::vector<PairIndex> pair_indices;
+  std::vector<std::size_t> invalidated_entries;
+  int level{-1};
+  int level_iteration{-1};
+  step_clock_t base_delta_clock{};
+  double base_delta_time{0.0};
+  int time_refinement_factor{0};
+  std::function<std::int64_t()> epoch_reader;
+  std::vector<ScratchLiveEntryReader> live_readers;
+  std::vector<ExpectedLiveEntry> expected_live;
+  std::vector<std::unique_ptr<StateRecord>> states;
+  std::size_t rhs_evaluations{0};
+  bool faulted{false};
+  bool discarded{false};
+  bool dense_committed_once{false};
+  std::shared_ptr<const DenseInterval> committed_dense;
+
+  // Declaration order is intentional: executor is destroyed before the
+  // binding whose lease it owns.
+#ifndef CARPETX_SUBCYCLING_SCRATCH_STATE_TRANSACTION_UNIT
+  std::unique_ptr<ScratchLocalLevelBinding> binding;
+  std::unique_ptr<CertifiedScratchStageExecutor> executor;
+#else
+  std::optional<ScratchLevelFrame> test_frame;
+  ScratchStateTransactionFactory::TestScheduleExecutor test_executor;
+#endif
+  ScratchLevelFrame *working_frame{nullptr};
+
+  void release_execution_storage() noexcept {
+#ifndef CARPETX_SUBCYCLING_SCRATCH_STATE_TRANSACTION_UNIT
+    executor.reset();
+    binding.reset();
+#else
+    test_executor = {};
+    test_frame.reset();
+#endif
+    working_frame = nullptr;
+  }
+
+  void fault_and_discard() noexcept {
+    faulted = true;
+    discarded = true;
+    states.clear();
+    committed_dense.reset();
+    release_execution_storage();
+  }
+};
+
+class ScratchStateTransactionCore final {
+public:
+  static void require_available(ScratchStateTransaction::Storage &);
+  static ScratchStateTransaction::Storage::StateRecord &
+  require_state(ScratchStateTransaction::Storage &,
+                const ScratchStateToken &);
+  static const ScratchStateTransaction::Storage::StateRecord &
+  require_state(const ScratchStateTransaction::Storage &,
+                const ScratchStateToken &);
+  static ScratchStateToken publish_state(ScratchStateTransaction::Storage &,
+                                         ScratchStateKind,
+                                         ScratchLevelFrame);
+  static std::vector<ScratchLiveEntrySnapshot>
+  read_and_validate_live(ScratchStateTransaction::Storage &);
+  static ScratchLevelFrame capture_live_frame(
+      ScratchStateTransaction::Storage &, ScratchStateKind);
+  static ScratchLevelFrame capture_working_frame(
+      ScratchStateTransaction::Storage &, ScratchStateKind);
+  static ScratchStageCoordinates stage_coordinates(
+      ScratchStateTransaction::Storage &, const StepContext &,
+      const StagePoint &);
+  static void validate_factory_metadata(
+      const ScratchLevelFrame &,
+      const ScratchStateTransactionFactoryMetadata &,
+      std::vector<ScratchStateTransaction::Storage::PairIndex> &,
+      std::vector<std::size_t> &,
+      std::vector<ScratchStateTransaction::Storage::ExpectedLiveEntry> &);
+};
+
+namespace {
+
+} // namespace
+
+void ScratchStateTransactionCore::require_available(
+    ScratchStateTransaction::Storage &storage) {
+  if (storage.discarded || storage.working_frame == nullptr)
+    throw std::logic_error("scratch transaction is discarded");
+  if (storage.faulted)
+    throw std::logic_error("scratch transaction is faulted");
+  try {
+    if (!storage.epoch_reader ||
+        storage.epoch_reader() != storage.hierarchy_epoch) {
+      storage.fault_and_discard();
+      throw std::runtime_error("scratch transaction hierarchy epoch changed");
+    }
+  } catch (...) {
+    storage.fault_and_discard();
+    throw;
+  }
+}
+
+ScratchStateTransaction::Storage::StateRecord &
+ScratchStateTransactionCore::require_state(
+    ScratchStateTransaction::Storage &storage,
+    const ScratchStateToken &token) {
+  require_available(storage);
+  if (!token.valid() || token.owner_ != storage.owner ||
+      token.epoch_ != storage.hierarchy_epoch ||
+      token.schema_ != storage.schema || token.state_ > storage.states.size())
+    throw std::invalid_argument("scratch state token does not belong here");
+  auto *const record = storage.states[token.state_ - 1].get();
+  if (record == nullptr || record->kind != token.kind_)
+    throw std::invalid_argument("scratch state token metadata is stale");
+  return *record;
+}
+
+const ScratchStateTransaction::Storage::StateRecord &
+ScratchStateTransactionCore::require_state(
+    const ScratchStateTransaction::Storage &storage,
+    const ScratchStateToken &token) {
+  return ScratchStateTransactionCore::require_state(
+      const_cast<ScratchStateTransaction::Storage &>(storage), token);
+}
+
+ScratchStateToken ScratchStateTransactionCore::publish_state(
+    ScratchStateTransaction::Storage &storage, const ScratchStateKind kind,
+    ScratchLevelFrame frame) {
+  auto record = std::make_unique<ScratchStateTransaction::Storage::StateRecord>(
+      ScratchStateTransaction::Storage::StateRecord{kind, std::move(frame)});
+  storage.states.push_back(std::move(record));
+  return ScratchStateToken(storage.owner, storage.states.size(),
+                           storage.hierarchy_epoch, storage.schema, kind);
+}
+
+std::vector<ScratchLiveEntrySnapshot>
+ScratchStateTransactionCore::read_and_validate_live(
+    ScratchStateTransaction::Storage &storage) {
+  require_available(storage);
+  if (!storage.epoch_reader ||
+      storage.epoch_reader() != storage.hierarchy_epoch)
+    throw std::runtime_error("scratch live hierarchy epoch changed");
+  if (storage.live_readers.size() != storage.expected_live.size())
+    throw std::runtime_error("scratch live reader schema changed");
+
+  std::vector<ScratchLiveEntrySnapshot> snapshots;
+  snapshots.reserve(storage.live_readers.size());
+  for (std::size_t entry = 0; entry < storage.live_readers.size(); ++entry) {
+    if (!storage.live_readers[entry])
+      throw std::runtime_error("scratch live reader is unavailable");
+    const auto observed = storage.live_readers[entry]();
+    const auto &expected = storage.expected_live[entry].snapshot;
+    if (!same_key(observed.key, expected.key) ||
+        observed.level_identity != expected.level_identity ||
+        observed.group_identity != expected.group_identity ||
+        observed.tl0_identity != expected.tl0_identity ||
+        observed.storage_identity != expected.storage_identity ||
+        observed.validity_identity != expected.validity_identity ||
+        observed.multifab != expected.multifab ||
+        observed.grid_function_real != expected.grid_function_real ||
+        !observed.grid_function_real || !observed.restore ||
+        observed.multifab == nullptr ||
+        !observed.multifab->isDefined() ||
+        !same_layout(*observed.multifab,
+                     storage.working_frame->multifab(entry)) ||
+        observed.validity.size() !=
+            storage.working_frame->validity(entry).size())
+      throw std::runtime_error("scratch live identity or schema changed");
+    snapshots.push_back(observed);
+  }
+  return snapshots;
+}
+
+ScratchLevelFrame ScratchStateTransactionCore::capture_live_frame(
+    ScratchStateTransaction::Storage &storage,
+    const ScratchStateKind kind) {
+  const auto snapshots = read_and_validate_live(storage);
+  UncertifiedScratchLevelManifest manifest{storage.hierarchy_epoch,
+                                           storage.level, {}};
+  std::vector<ScratchGFView> views;
+  manifest.entries.reserve(snapshots.size());
+  views.reserve(snapshots.size());
+  for (const auto &snapshot : snapshots) {
+    manifest.entries.push_back({snapshot.key, snapshot.storage_identity});
+    views.push_back({snapshot.key, 0, snapshot.storage_identity,
+                     snapshot.multifab, &snapshot.validity});
+  }
+  auto frame = ScratchLevelFrame::copy_tl0(manifest, views);
+  if (kind == ScratchStateKind::raw_rhs) {
+    for (const auto &pair : storage.pair_indices) {
+      frame.copy_interior_for_transaction(pair.evolved_entry, frame,
+                                          pair.rhs_entry);
+      frame.copy_interior_validity_for_transaction(
+          pair.evolved_entry, frame, pair.rhs_entry, true);
+    }
+  }
+  return frame;
+}
+
+ScratchLevelFrame ScratchStateTransactionCore::capture_working_frame(
+    ScratchStateTransaction::Storage &storage,
+    const ScratchStateKind kind) {
+  require_available(storage);
+  auto frame = storage.working_frame->clone_for_transaction();
+  if (kind == ScratchStateKind::raw_rhs) {
+    for (const auto &pair : storage.pair_indices) {
+      frame.copy_interior_for_transaction(pair.evolved_entry, frame,
+                                          pair.rhs_entry);
+      frame.copy_interior_validity_for_transaction(
+          pair.evolved_entry, frame, pair.rhs_entry, true);
+    }
+  }
+  return frame;
+}
+
+ScratchStageCoordinates ScratchStateTransactionCore::stage_coordinates(
+    ScratchStateTransaction::Storage &storage,
+    const StepContext &context, const StagePoint &stage_point) {
+  require_available(storage);
+  if (current_step_context() != &context ||
+      current_scratch_state_transaction() == nullptr)
+    throw std::logic_error(
+        "scratch schedule requires its active StepContext scope");
+  if (context.level != storage.level)
+    throw std::invalid_argument(
+        "scratch transaction StepContext level differs");
+  if (stage_point.stage_index <= 0 || stage_point.stage_count <= 0 ||
+      stage_point.stage_index > stage_point.stage_count)
+    throw std::invalid_argument("scratch stage index/count are invalid");
+  switch (stage_point.kind) {
+  case StageKind::primary:
+  case StageKind::fractional:
+    break;
+  case StageKind::endpoint_probe:
+    if (stage_point.stage_index != 1 || stage_point.stage_count != 1)
+      throw std::invalid_argument(
+          "scratch endpoint probe must use the singleton stage index");
+    break;
+  default:
+    throw std::invalid_argument("scratch stage kind is invalid");
+  }
+  if (stage_point.stage_fraction < step_clock_t(0) ||
+      stage_point.stage_fraction > step_clock_t(1))
+    throw std::out_of_range(
+        "scratch exact stage fraction is outside [0,1]");
+  if (!std::isfinite(stage_point.stage_time))
+    throw std::invalid_argument("scratch stage time must be finite");
+  const auto level_delta_clock =
+      storage.base_delta_clock / storage.time_refinement_factor;
+  if (context.end_clock - context.begin_clock != level_delta_clock)
+    throw std::invalid_argument("scratch stage exact clock differs");
+  const auto level_delta_time =
+      storage.base_delta_time /
+      static_cast<double>(storage.time_refinement_factor);
+  if (!close_time(context.end_time - context.begin_time, level_delta_time,
+                  context.begin_time, context.end_time))
+    throw std::invalid_argument("scratch stage floating clock differs");
+  const auto scale =
+      std::max({1.0, std::abs(context.begin_time),
+                std::abs(context.end_time)});
+  const auto tolerance =
+      16.0 * std::numeric_limits<double>::epsilon() * scale;
+  if (stage_point.stage_time < context.begin_time - tolerance ||
+      stage_point.stage_time > context.end_time + tolerance)
+    throw std::out_of_range("scratch stage time is outside the step");
+  const auto exact_stage_clock =
+      context.begin_clock +
+      stage_point.stage_fraction * (context.end_clock - context.begin_clock);
+  if (exact_stage_clock < context.begin_clock ||
+      exact_stage_clock > context.end_clock)
+    throw std::out_of_range("scratch exact stage clock is outside the step");
+  const auto exact_fraction = static_cast<double>(stage_point.stage_fraction);
+  const auto expected_stage_time =
+      context.begin_time +
+      exact_fraction * (context.end_time - context.begin_time);
+  if (!std::isfinite(expected_stage_time) ||
+      std::abs(stage_point.stage_time - expected_stage_time) > tolerance)
+    throw std::invalid_argument(
+        "scratch stage time differs from its exact stage fraction");
+  return {storage.level_iteration, stage_point.stage_time,
+          storage.base_delta_clock,
+          storage.base_delta_time, storage.time_refinement_factor};
+}
+
+void ScratchStateTransactionCore::validate_factory_metadata(
+    const ScratchLevelFrame &frame,
+    const ScratchStateTransactionFactoryMetadata &metadata,
+    std::vector<ScratchStateTransaction::Storage::PairIndex> &pair_indices,
+    std::vector<std::size_t> &invalidated_entries,
+    std::vector<ScratchStateTransaction::Storage::ExpectedLiveEntry>
+        &expected_live) {
+  if (metadata.hierarchy_epoch < 0 ||
+      frame.hierarchy_epoch() != metadata.hierarchy_epoch)
+    throw std::invalid_argument("scratch transaction epoch differs");
+  if (metadata.patch_count != 1 || metadata.level_count < 1 ||
+      metadata.level_count > 2 || frame.level() < 0 || frame.level() > 1 ||
+      frame.level() >= metadata.level_count)
+    throw std::invalid_argument(
+        "scratch transaction requires patch zero and level zero or one");
+  const int expected_time_refinement_factor = 1 << frame.level();
+  if (metadata.level_iteration < 0 ||
+      !(step_clock_t(0) < metadata.base_delta_clock) ||
+      !finite_positive(metadata.base_delta_time) ||
+      metadata.time_refinement_factor != expected_time_refinement_factor ||
+      metadata.poison_undefined_values)
+    throw std::invalid_argument(
+        "scratch transaction time or configuration is unsupported");
+  if (!metadata.epoch_reader ||
+      metadata.epoch_reader() != metadata.hierarchy_epoch)
+    throw std::invalid_argument("scratch transaction epoch reader differs");
+  if (metadata.group_pairs.empty() ||
+      metadata.live_entry_readers.size() != frame.entry_count())
+    throw std::invalid_argument("scratch transaction schema is incomplete");
+
+  std::unordered_set<int> evolved_groups;
+  std::unordered_set<int> rhs_groups;
+  pair_indices.reserve(metadata.group_pairs.size());
+  for (std::size_t pair_ordinal = 0;
+       pair_ordinal < metadata.group_pairs.size(); ++pair_ordinal) {
+    const auto &pair = metadata.group_pairs[pair_ordinal];
+    if (pair.evolved_group < 0 || pair.rhs_group < 0 ||
+        pair.evolved_group == pair.rhs_group ||
+        (pair_ordinal != 0 &&
+         metadata.group_pairs[pair_ordinal - 1].evolved_group >=
+             pair.evolved_group) ||
+        !evolved_groups.insert(pair.evolved_group).second ||
+        !rhs_groups.insert(pair.rhs_group).second)
+      throw std::invalid_argument("scratch transaction group pairs overlap");
+    const auto evolved = find_group(frame, pair.evolved_group);
+    const auto rhs = find_group(frame, pair.rhs_group);
+    if (!same_layout(frame.multifab(evolved), frame.multifab(rhs)) ||
+        frame.validity(evolved).size() != frame.validity(rhs).size())
+      throw std::invalid_argument("scratch transaction pair layouts differ");
+    pair_indices.push_back({pair, evolved, rhs});
+  }
+  for (const auto evolved : evolved_groups)
+    if (rhs_groups.count(evolved) != 0)
+      throw std::invalid_argument(
+          "scratch transaction evolved and RHS sets overlap");
+
+  std::unordered_set<int> invalidation_groups;
+  for (const auto group : metadata.dependent_groups) {
+    if (group < 0 || !invalidation_groups.insert(group).second)
+      throw std::invalid_argument(
+          "scratch transaction invalidation groups overlap");
+    if (evolved_groups.count(group) != 0)
+      throw std::invalid_argument(
+          "scratch transaction cannot invalidate an evolved group");
+    invalidated_entries.push_back(find_group(frame, group));
+  }
+  for (const auto rhs : rhs_groups)
+    if (invalidation_groups.count(rhs) == 0)
+      throw std::invalid_argument(
+          "scratch transaction RHS lacks invalidation coverage");
+
+  std::unordered_set<const void *> level_identities;
+  std::unordered_set<const void *> group_identities;
+  std::unordered_set<const void *> tl0_identities;
+  std::unordered_set<const void *> storage_identities;
+  std::unordered_set<const void *> validity_identities;
+  std::unordered_set<const amrex::MultiFab *> multifabs;
+  expected_live.reserve(frame.entry_count());
+  for (std::size_t entry = 0; entry < frame.entry_count(); ++entry) {
+    if (frame.key(entry).patch != 0 ||
+        frame.key(entry).level != frame.level())
+      throw std::invalid_argument(
+          "scratch transaction frame key differs from requested level");
+    if (!metadata.live_entry_readers[entry])
+      throw std::invalid_argument("scratch transaction live reader is empty");
+    const auto snapshot = metadata.live_entry_readers[entry]();
+    if (!same_key(snapshot.key, frame.key(entry)) ||
+        snapshot.key.patch != 0 || snapshot.key.level != frame.level() ||
+        snapshot.level_identity == nullptr ||
+        snapshot.group_identity == nullptr || snapshot.tl0_identity == nullptr ||
+        snapshot.storage_identity == nullptr ||
+        snapshot.validity_identity == nullptr ||
+        snapshot.multifab == nullptr ||
+        !snapshot.grid_function_real || !snapshot.restore ||
+        !snapshot.multifab->isDefined() ||
+        !same_layout(*snapshot.multifab, frame.multifab(entry)) ||
+        snapshot.validity.size() != frame.validity(entry).size())
+      throw std::invalid_argument("scratch transaction live schema differs");
+    level_identities.insert(snapshot.level_identity);
+    if (!group_identities.insert(snapshot.group_identity).second ||
+        !tl0_identities.insert(snapshot.tl0_identity).second ||
+        !storage_identities.insert(snapshot.storage_identity).second ||
+        !validity_identities.insert(snapshot.validity_identity).second ||
+        !multifabs.insert(snapshot.multifab).second)
+      throw std::invalid_argument("scratch transaction live identities overlap");
+    expected_live.push_back({snapshot});
+  }
+  if (level_identities.size() != 1)
+    throw std::invalid_argument(
+        "scratch transaction live entries span multiple levels");
+}
+
+ScratchStateTransaction::ScratchStateTransaction(
+    std::unique_ptr<Storage> storage)
+    : storage_(std::move(storage)) {
+  if (storage_ == nullptr)
+    throw std::invalid_argument("scratch transaction storage is missing");
+}
+
+ScratchStateTransaction::~ScratchStateTransaction() = default;
+
+const std::vector<ScratchGroupPair> &
+ScratchStateTransaction::group_pairs() const noexcept {
+  return storage_->group_pairs;
+}
+
+const std::vector<int> &
+ScratchStateTransaction::dependent_groups() const noexcept {
+  return storage_->dependent_groups;
+}
+
+ScratchStateToken ScratchStateTransaction::capture_live_evolved() {
+  try {
+    return ScratchStateTransactionCore::publish_state(
+        *storage_, ScratchStateKind::evolved,
+        ScratchStateTransactionCore::capture_live_frame(
+            *storage_, ScratchStateKind::evolved));
+  } catch (...) {
+    storage_->fault_and_discard();
+    throw;
+  }
+}
+
+ScratchStateToken ScratchStateTransaction::capture_live_rhs() {
+  try {
+    return ScratchStateTransactionCore::publish_state(
+        *storage_, ScratchStateKind::raw_rhs,
+        ScratchStateTransactionCore::capture_live_frame(
+            *storage_, ScratchStateKind::raw_rhs));
+  } catch (...) {
+    storage_->fault_and_discard();
+    throw;
+  }
+}
+
+ScratchStateToken ScratchStateTransaction::capture_scratch_evolved() {
+  return ScratchStateTransactionCore::publish_state(
+      *storage_, ScratchStateKind::evolved,
+      ScratchStateTransactionCore::capture_working_frame(
+          *storage_, ScratchStateKind::evolved));
+}
+
+ScratchStateToken ScratchStateTransaction::capture_scratch_rhs() {
+  return ScratchStateTransactionCore::publish_state(
+      *storage_, ScratchStateKind::raw_rhs,
+      ScratchStateTransactionCore::capture_working_frame(
+          *storage_, ScratchStateKind::raw_rhs));
+}
+
+ScratchStateToken
+ScratchStateTransaction::clone_state(const ScratchStateToken &state) {
+  const auto &source = ScratchStateTransactionCore::require_state(*storage_, state);
+  return ScratchStateTransactionCore::publish_state(
+      *storage_, source.kind, source.frame.clone_for_transaction());
+}
+
+ScratchStateKind
+ScratchStateTransaction::state_kind(const ScratchStateToken &state) const {
+  return ScratchStateTransactionCore::require_state(std::as_const(*storage_),
+                                                     state)
+      .kind;
+}
+
+bool ScratchStateTransaction::state_valid(
+    const ScratchStateToken &state, const ScratchStateRegion region) const {
+  const auto &record = ScratchStateTransactionCore::require_state(
+      std::as_const(*storage_), state);
+  for (const auto &pair : storage_->pair_indices) {
+    for (const auto &component : record.frame.validity(pair.evolved_entry)) {
+      const bool valid = region == ScratchStateRegion::interior
+                             ? component.interior
+                         : region == ScratchStateRegion::outer
+                             ? component.outer
+                             : component.ghosts;
+      if (!valid)
+        return false;
+    }
+  }
+  return true;
+}
+
+void ScratchStateTransaction::set_state_valid(
+    ScratchStateToken &state, const ScratchStateRegion region,
+    const bool valid) {
+  auto &record = ScratchStateTransactionCore::require_state(*storage_, state);
+  for (const auto &pair : storage_->pair_indices) {
+    auto &components = record.frame.mutable_validity(pair.evolved_entry);
+    for (auto &component : components) {
+      if (region == ScratchStateRegion::interior)
+        component.interior = valid;
+      else if (region == ScratchStateRegion::outer)
+        component.outer = valid;
+      else
+        component.ghosts = valid;
+    }
+  }
+}
+
+void ScratchStateTransaction::rollback_live_evolved(
+    const ScratchStateToken &state) {
+  // Preserve the distinction between a pre-existing terminal state and a
+  // rollback failure: discarded/faulted transactions are rejected without
+  // reviving or otherwise changing them.
+  ScratchStateTransactionCore::require_available(*storage_);
+  try {
+    const auto &record =
+        ScratchStateTransactionCore::require_state(*storage_, state);
+    if (record.kind != ScratchStateKind::evolved)
+      throw std::invalid_argument(
+          "live rollback requires an evolved state token");
+
+    // Validate every live identity and every source layout before the first
+    // in-place write. The callbacks remain factory-owned, so the public API
+    // exposes no driver representation.
+    const auto snapshots =
+        ScratchStateTransactionCore::read_and_validate_live(*storage_);
+    if (record.frame.entry_count() != snapshots.size())
+      throw std::runtime_error("live rollback state schema changed");
+    for (std::size_t entry = 0; entry < snapshots.size(); ++entry) {
+      const auto &snapshot = snapshots[entry];
+      if (!snapshot.restore ||
+          !same_key(record.frame.key(entry), snapshot.key) ||
+          !same_layout(record.frame.multifab(entry), *snapshot.multifab) ||
+          record.frame.validity(entry).size() != snapshot.validity.size())
+        throw std::runtime_error("live rollback state layout changed");
+    }
+
+    for (std::size_t entry = 0; entry < snapshots.size(); ++entry)
+      snapshots[entry].restore(record.frame.multifab(entry),
+                               record.frame.validity(entry));
+
+    // Rollback is terminal for this attempted primary step. In particular,
+    // no PostStep or RHS schedule is rerun after live TL0 is restored.
+    discard();
+  } catch (...) {
+    storage_->fault_and_discard();
+    throw;
+  }
+}
+
+void ScratchStateTransaction::restore_state(const ScratchStateToken &state) {
+  const auto &record =
+      ScratchStateTransactionCore::require_state(*storage_, state);
+  if (record.kind != ScratchStateKind::evolved)
+    throw std::invalid_argument("only evolved state has a full-frame restore");
+  storage_->working_frame->restore_from_transaction(record.frame);
+}
+
+void ScratchStateTransaction::restore_left(
+    const ScratchStateToken &evolved, const ScratchStateToken &raw_rhs) {
+  const auto &evolved_record =
+      ScratchStateTransactionCore::require_state(*storage_, evolved);
+  const auto &rhs_record =
+      ScratchStateTransactionCore::require_state(*storage_, raw_rhs);
+  if (evolved_record.kind != ScratchStateKind::evolved ||
+      rhs_record.kind != ScratchStateKind::raw_rhs)
+    throw std::invalid_argument("scratch left restore state kinds differ");
+  storage_->working_frame->restore_from_transaction(evolved_record.frame);
+  for (const auto &pair : storage_->pair_indices) {
+    storage_->working_frame->copy_interior_for_transaction(
+        pair.rhs_entry, rhs_record.frame, pair.evolved_entry);
+    storage_->working_frame->copy_interior_validity_for_transaction(
+        pair.rhs_entry, rhs_record.frame, pair.evolved_entry, false);
+  }
+}
+
+void ScratchStateTransaction::linear_combination(
+    ScratchStateToken &destination, double destination_scale,
+    const std::vector<ScratchLinearTerm> &terms) {
+  auto &destination_record =
+      ScratchStateTransactionCore::require_state(*storage_, destination);
+  if (!std::isfinite(destination_scale))
+    throw std::invalid_argument(
+        "scratch combination destination scale is not finite");
+
+  std::vector<double> weights;
+  std::vector<const ScratchLevelFrame *> sources;
+  weights.reserve(terms.size());
+  sources.reserve(terms.size());
+  for (const auto &term : terms) {
+    if (!std::isfinite(term.coefficient) || term.state == nullptr)
+      throw std::invalid_argument("scratch combination term is invalid");
+    const auto &source =
+        ScratchStateTransactionCore::require_state(*storage_, *term.state);
+    if (destination_record.kind == ScratchStateKind::raw_rhs &&
+        source.kind != ScratchStateKind::raw_rhs)
+      throw std::invalid_argument(
+          "raw RHS combination requires raw RHS sources");
+    if (term.coefficient == 0.0)
+      continue;
+    if (term.state->state_ == destination.state_) {
+      destination_scale += term.coefficient;
+      if (!std::isfinite(destination_scale))
+        throw std::invalid_argument(
+            "scratch combination alias scale is not finite");
+      continue;
+    }
+    weights.push_back(term.coefficient);
+    sources.push_back(&source.frame);
+  }
+
+  std::vector<std::size_t> source_entries(sources.size());
+  for (const auto &pair : storage_->pair_indices) {
+    std::fill(source_entries.begin(), source_entries.end(),
+              pair.evolved_entry);
+    destination_record.frame.linear_combination_interior_for_transaction(
+        pair.evolved_entry, destination_scale, weights, sources,
+        source_entries);
+    auto &destination_validity =
+        destination_record.frame.mutable_validity(pair.evolved_entry);
+    for (std::size_t component = 0;
+         component < destination_validity.size(); ++component) {
+      bool interior_valid =
+          destination_scale == 0.0
+              ? true
+              : destination_validity[component].interior;
+      for (std::size_t source = 0; source < sources.size(); ++source)
+        if (weights[source] != 0.0)
+          interior_valid =
+              interior_valid &&
+              sources[source]
+                  ->validity(pair.evolved_entry)[component]
+                  .interior;
+      destination_validity[component].interior = interior_valid;
+    }
+  }
+}
+
+void ScratchStateTransaction::post_step_after_update(
+    const StepContext &context, const StagePoint &stage_point) {
+  try {
+    const auto coordinates = ScratchStateTransactionCore::stage_coordinates(
+        *storage_, context, stage_point);
+    if (current_scratch_state_transaction() != this)
+      throw std::logic_error(
+          "active StepContext belongs to another scratch transaction");
+    for (const auto entry : storage_->invalidated_entries) {
+      auto &components = storage_->working_frame->mutable_validity(entry);
+      for (auto &component : components)
+        component = {false, false, false};
+    }
+#ifdef CARPETX_SUBCYCLING_SCRATCH_STATE_TRANSACTION_UNIT
+    if (!storage_->test_executor)
+      throw std::logic_error("scratch test executor is missing");
+    const auto receipt = storage_->test_executor(
+        ScratchSchedulePhase::post_step, context, coordinates);
+#else
+    const auto receipt = storage_->executor->execute_post_step(context,
+                                                                coordinates);
+#endif
+    if (receipt.phase != ScratchSchedulePhase::post_step)
+      throw std::runtime_error("scratch PostStep receipt phase differs");
+  } catch (...) {
+    storage_->fault_and_discard();
+    throw;
+  }
+}
+
+void ScratchStateTransaction::evaluate_rhs(const StepContext &context,
+                                           const StagePoint &stage_point) {
+  try {
+    const auto coordinates = ScratchStateTransactionCore::stage_coordinates(
+        *storage_, context, stage_point);
+    if (current_scratch_state_transaction() != this)
+      throw std::logic_error(
+          "active StepContext belongs to another scratch transaction");
+#ifdef CARPETX_SUBCYCLING_SCRATCH_STATE_TRANSACTION_UNIT
+    if (!storage_->test_executor)
+      throw std::logic_error("scratch test executor is missing");
+    const auto receipt = storage_->test_executor(ScratchSchedulePhase::rhs,
+                                                  context, coordinates);
+#else
+    const auto receipt = storage_->executor->execute_rhs(context, coordinates);
+#endif
+    if (receipt.phase != ScratchSchedulePhase::rhs)
+      throw std::runtime_error("scratch RHS receipt phase differs");
+    ++storage_->rhs_evaluations;
+  } catch (...) {
+    storage_->fault_and_discard();
+    throw;
+  }
+}
+
+std::size_t ScratchStateTransaction::rhs_evaluation_count() const noexcept {
+  return storage_->rhs_evaluations;
+}
+
+void ScratchStateTransaction::commit_dense(
+    const StepContext &context, const DenseOutputProvider &provider,
+    const DenseIntervalId &interval,
+    const std::vector<ScratchDenseSampleRef> &samples) {
+  ScratchStateTransactionCore::require_available(*storage_);
+  if (storage_->dense_committed_once || storage_->committed_dense != nullptr)
+    throw std::logic_error("scratch dense interval is already committed");
+  try {
+    if (current_step_context() != &context ||
+        current_scratch_state_transaction() != this)
+      throw std::logic_error(
+          "scratch dense commit requires its active StepContext scope");
+    const auto &provider_capability = provider.capability();
+    const auto level_delta_clock =
+        storage_->base_delta_clock / storage_->time_refinement_factor;
+    const auto level_delta_time =
+        storage_->base_delta_time /
+        static_cast<double>(storage_->time_refinement_factor);
+    if (context.level != storage_->level ||
+        interval.level != context.level ||
+        interval.begin_clock != context.begin_clock ||
+        interval.end_clock != context.end_clock ||
+        interval.begin_time != context.begin_time ||
+        interval.end_time != context.end_time ||
+        interval.method != context.method ||
+        provider_capability.method != context.method ||
+        interval.tableau_fingerprint !=
+            provider_capability.tableau_fingerprint ||
+        interval.end_clock - interval.begin_clock != level_delta_clock ||
+        !close_time(interval.end_time - interval.begin_time, level_delta_time,
+                    interval.begin_time, interval.end_time))
+      throw std::invalid_argument("scratch dense interval clock differs");
+    const auto &constraints =
+        reference_dense_stencil(interval.method).specification().constraints;
+    if (samples.size() != constraints.size())
+      throw std::invalid_argument("scratch dense sample count differs");
+
+    std::unordered_set<std::uint64_t> unique_states;
+    std::vector<std::unique_ptr<OwnedMultiFabDenseState>> owned_samples;
+    std::vector<DenseMFabRawSampleView> sample_views;
+    owned_samples.reserve(samples.size());
+    sample_views.reserve(samples.size());
+    for (std::size_t sample = 0; sample < samples.size(); ++sample) {
+      const auto &reference = samples[sample];
+      if (reference.state == nullptr ||
+          !same_constraint(sample_constraint(reference), constraints[sample]))
+        throw std::invalid_argument("scratch dense sample metadata differs");
+      const auto &record = ScratchStateTransactionCore::require_state(
+          *storage_, *reference.state);
+      const auto required_kind =
+          reference.kind == ScratchDenseSampleKind::value
+              ? ScratchStateKind::evolved
+              : ScratchStateKind::raw_rhs;
+      if (record.kind != required_kind ||
+          !unique_states.insert(reference.state->state_).second)
+        throw std::invalid_argument("scratch dense sample token differs");
+      for (const auto &pair : storage_->pair_indices)
+        for (const auto &component :
+             record.frame.validity(pair.evolved_entry))
+          if (!component.interior)
+            throw std::invalid_argument(
+                "scratch dense sample interior is invalid");
+
+      std::vector<DenseMFabView> views;
+      views.reserve(storage_->pair_indices.size());
+      for (const auto &pair : storage_->pair_indices) {
+        const auto &key = record.frame.key(pair.evolved_entry);
+        views.push_back({{key.hierarchy_epoch, key.patch, key.level,
+                          pair.groups.evolved_group},
+                         &record.frame.multifab(pair.evolved_entry)});
+      }
+      owned_samples.push_back(OwnedMultiFabDenseState::copy_of(views));
+      sample_views.push_back({constraints[sample], owned_samples.back().get()});
+    }
+
+    auto controls = build_reference_dense_controls(
+        interval.method, level_delta_time, sample_views);
+    auto builder = provider.begin_interval(interval);
+    for (auto &control : std::move(controls).release_controls())
+      builder->add_control(std::move(control));
+    auto sealed = builder->seal();
+    storage_->committed_dense = sealed;
+    storage_->dense_committed_once = true;
+  } catch (...) {
+    storage_->fault_and_discard();
+    throw;
+  }
+}
+
+std::shared_ptr<const DenseInterval>
+ScratchStateTransaction::take_committed_dense() noexcept {
+  try {
+    if (storage_->discarded || storage_->faulted)
+      return nullptr;
+    if (!storage_->epoch_reader ||
+        storage_->epoch_reader() != storage_->hierarchy_epoch) {
+      storage_->fault_and_discard();
+      return nullptr;
+    }
+    auto result = std::move(storage_->committed_dense);
+    storage_->committed_dense.reset();
+    return result;
+  } catch (...) {
+    storage_->fault_and_discard();
+    return nullptr;
+  }
+}
+
+bool ScratchStateTransaction::faulted() const noexcept {
+  return storage_->faulted;
+}
+
+bool ScratchStateTransaction::discarded() const noexcept {
+  return storage_->discarded;
+}
+
+void ScratchStateTransaction::discard() noexcept {
+  if (storage_->discarded)
+    return;
+  storage_->discarded = true;
+  storage_->states.clear();
+  storage_->committed_dense.reset();
+  storage_->release_execution_storage();
+}
+
+#ifndef CARPETX_SUBCYCLING_SCRATCH_STATE_TRANSACTION_UNIT
+std::unique_ptr<ScratchStateTransaction>
+ScratchStateTransactionFactory::create_native(
+    const GHExt &ghext, CertifiedLocalScheduleRegistry &registry,
+    CertifiedScratchLevelFrame &&frame,
+    ScratchStateTransactionFactoryMetadata metadata) {
+  DECLARE_CCTK_PARAMETERS;
+  const int patch = frame.patch();
+  const int level = frame.frame().level();
+  if (ghext.patchdata.size() != 1 || patch != 0 ||
+      ghext.patchdata.front().leveldata.empty() ||
+      ghext.patchdata.front().leveldata.size() > 2 || level < 0 ||
+      level > 1 ||
+      static_cast<std::size_t>(level) >=
+          ghext.patchdata.front().leveldata.size())
+    throw std::invalid_argument(
+        "native scratch transaction requires patch zero and level zero or one");
+  if (!metadata.live_entry_readers.empty())
+    throw std::invalid_argument(
+        "native scratch transaction constructs its own live readers");
+  const auto &coarse_level = ghext.patchdata.front().leveldata.front();
+  const auto &native_level = ghext.patchdata.front().leveldata.at(
+      static_cast<std::size_t>(level));
+  const auto *const native_gh = native_level.get_patch_cctkGH();
+  const int expected_time_refinement_factor = 1 << level;
+  const auto coarse_delta_clock =
+      step_clock_t(coarse_level.delta_iteration.num,
+                   coarse_level.delta_iteration.den);
+  const auto native_delta_clock =
+      step_clock_t(native_level.delta_iteration.num,
+                   native_level.delta_iteration.den);
+  if (native_gh == nullptr || native_level.patch != patch ||
+      native_level.level != level || native_gh->cctk_iteration < 0 ||
+      native_gh->cctk_timefac != expected_time_refinement_factor ||
+      !(step_clock_t(0) < coarse_delta_clock) ||
+      native_delta_clock !=
+          coarse_delta_clock / expected_time_refinement_factor ||
+      !finite_positive(native_gh->cctk_delta_time))
+    throw std::invalid_argument(
+        "native scratch transaction time envelope is unsupported");
+  metadata.hierarchy_epoch =
+      static_cast<std::int64_t>(CarpetX_GetEpoch());
+  metadata.patch_count = static_cast<int>(ghext.patchdata.size());
+  metadata.level_count =
+      static_cast<int>(ghext.patchdata.front().leveldata.size());
+  metadata.level_iteration = native_gh->cctk_iteration;
+  metadata.base_delta_clock = coarse_delta_clock;
+  metadata.base_delta_time = native_gh->cctk_delta_time;
+  metadata.time_refinement_factor = native_gh->cctk_timefac;
+  metadata.poison_undefined_values = poison_undefined_values;
+  metadata.epoch_reader = [] {
+    return static_cast<std::int64_t>(CarpetX_GetEpoch());
+  };
+  metadata.live_entry_readers.reserve(frame.frame().entry_count());
+  for (std::size_t entry = 0; entry < frame.frame().entry_count(); ++entry) {
+    const int group_index = frame.frame().key(entry).group_index;
+    const auto epoch = metadata.hierarchy_epoch;
+    metadata.live_entry_readers.push_back(
+        [&ghext, group_index, epoch, level] {
+          const auto &leveldata = ghext.patchdata.at(0).leveldata.at(
+              static_cast<std::size_t>(level));
+          if (group_index < 0 ||
+              static_cast<std::size_t>(group_index) >=
+                  leveldata.groupdata.size() ||
+              leveldata.groupdata[static_cast<std::size_t>(group_index)] ==
+                  nullptr)
+            throw std::runtime_error(
+                "native scratch live group identity disappeared");
+          const auto &groupdata = *leveldata.groupdata[
+              static_cast<std::size_t>(group_index)];
+          if (groupdata.mfab.empty() || groupdata.valid.empty())
+            throw std::runtime_error(
+                "native scratch live TL0 identity disappeared");
+          const auto *const multifab = groupdata.mfab.at(0).get();
+          const auto &why_valid = groupdata.valid.at(0);
+          const auto *const level_identity = &leveldata;
+          const auto *const group_identity = &groupdata;
+          const auto *const tl0_identity = &groupdata.mfab.at(0);
+          const auto *const validity_identity = &why_valid;
+          std::vector<ScratchValidity> validity;
+          validity.reserve(why_valid.size());
+          for (const auto &why : why_valid) {
+            const auto &bits = why.get();
+            validity.push_back({bits.valid_int, bits.valid_outer,
+                                bits.valid_ghosts});
+          }
+          cGroup cactus_group{};
+          const bool grid_function_real =
+              CCTK_GroupData(group_index, &cactus_group) == 0 &&
+              cactus_group.grouptype == CCTK_GF &&
+              cactus_group.vartype == CCTK_VARIABLE_REAL;
+          ScratchLiveEntryRestorer restore =
+              [&ghext, group_index, epoch, level, level_identity,
+               group_identity, tl0_identity, multifab, validity_identity](
+                  const amrex::MultiFab &state,
+                  const std::vector<ScratchValidity> &restored_validity) {
+                if (static_cast<std::int64_t>(CarpetX_GetEpoch()) != epoch)
+                  throw std::runtime_error(
+                      "native live rollback hierarchy epoch changed");
+                auto &mutable_ghext = const_cast<GHExt &>(ghext);
+                auto &current_level =
+                    mutable_ghext.patchdata.at(0).leveldata.at(
+                        static_cast<std::size_t>(level));
+                if (group_index < 0 ||
+                    static_cast<std::size_t>(group_index) >=
+                        current_level.groupdata.size() ||
+                    current_level.groupdata[
+                        static_cast<std::size_t>(group_index)] == nullptr)
+                  throw std::runtime_error(
+                      "native live rollback group identity disappeared");
+                auto &current_group = *current_level.groupdata[
+                    static_cast<std::size_t>(group_index)];
+                if (current_group.mfab.empty() ||
+                    current_group.valid.empty())
+                  throw std::runtime_error(
+                      "native live rollback TL0 identity disappeared");
+                auto *const destination = current_group.mfab.at(0).get();
+                auto &current_validity = current_group.valid.at(0);
+                if (&current_level != level_identity ||
+                    &current_group != group_identity ||
+                    &current_group.mfab.at(0) != tl0_identity ||
+                    destination != multifab ||
+                    &current_validity != validity_identity ||
+                    destination == nullptr || !destination->isDefined() ||
+                    !same_layout(*destination, state) ||
+                    current_validity.size() != restored_validity.size())
+                  throw std::runtime_error(
+                      "native live rollback identity or layout changed");
+
+                amrex::MultiFab::Copy(*destination, state, 0, 0,
+                                      state.nComp(), state.nGrowVect());
+                for (std::size_t component = 0;
+                     component < restored_validity.size(); ++component) {
+                  valid_t bits;
+                  bits.valid_int = restored_validity[component].interior;
+                  bits.valid_outer = restored_validity[component].outer;
+                  bits.valid_ghosts = restored_validity[component].ghosts;
+                  current_validity[component].set_all(bits, [] {
+                    return "ScratchStateTransaction primary rollback";
+                  });
+                }
+              };
+          return ScratchLiveEntrySnapshot{
+              {epoch, level, 0, group_index},
+              level_identity,
+              group_identity,
+              tl0_identity,
+              multifab,
+              validity_identity,
+              multifab,
+              std::move(validity),
+              grid_function_real,
+              std::move(restore)};
+        });
+  }
+  auto storage = std::make_unique<ScratchStateTransaction::Storage>();
+  ScratchStateTransactionCore::validate_factory_metadata(
+      frame.frame(), metadata, storage->pair_indices,
+      storage->invalidated_entries, storage->expected_live);
+  storage->hierarchy_epoch = metadata.hierarchy_epoch;
+  storage->group_pairs = metadata.group_pairs;
+  storage->dependent_groups = metadata.dependent_groups;
+  std::sort(storage->dependent_groups.begin(),
+            storage->dependent_groups.end());
+  storage->level = level;
+  storage->level_iteration = metadata.level_iteration;
+  storage->base_delta_clock = metadata.base_delta_clock;
+  storage->base_delta_time = metadata.base_delta_time;
+  storage->time_refinement_factor = metadata.time_refinement_factor;
+  storage->epoch_reader = std::move(metadata.epoch_reader);
+  storage->live_readers = std::move(metadata.live_entry_readers);
+  storage->binding = ScratchLocalLevelBinding::bind(ghext, std::move(frame));
+  storage->working_frame = &storage->binding->frame_for_transaction();
+  storage->executor =
+      CertifiedScratchStageExecutor::create(registry, *storage->binding);
+  return std::unique_ptr<ScratchStateTransaction>(
+      new ScratchStateTransaction(std::move(storage)));
+}
+#else
+std::unique_ptr<ScratchStateTransaction>
+ScratchStateTransactionFactory::create_native(
+    const GHExt &, CertifiedLocalScheduleRegistry &,
+    CertifiedScratchLevelFrame &&,
+    ScratchStateTransactionFactoryMetadata) {
+  throw std::logic_error("native scratch transaction is not in the unit gate");
+}
+
+std::unique_ptr<ScratchStateTransaction>
+ScratchStateTransactionFactory::create_for_test(
+    ScratchLevelFrame working_frame,
+    ScratchStateTransactionFactoryMetadata metadata,
+    TestScheduleExecutor executor) {
+  if (!executor)
+    throw std::invalid_argument("scratch test executor is missing");
+  auto storage = std::make_unique<ScratchStateTransaction::Storage>();
+  ScratchStateTransactionCore::validate_factory_metadata(
+      working_frame, metadata, storage->pair_indices,
+      storage->invalidated_entries, storage->expected_live);
+  storage->hierarchy_epoch = metadata.hierarchy_epoch;
+  storage->group_pairs = metadata.group_pairs;
+  storage->dependent_groups = metadata.dependent_groups;
+  std::sort(storage->dependent_groups.begin(),
+            storage->dependent_groups.end());
+  storage->level = working_frame.level();
+  storage->level_iteration = metadata.level_iteration;
+  storage->base_delta_clock = metadata.base_delta_clock;
+  storage->base_delta_time = metadata.base_delta_time;
+  storage->time_refinement_factor = metadata.time_refinement_factor;
+  storage->epoch_reader = std::move(metadata.epoch_reader);
+  storage->live_readers = std::move(metadata.live_entry_readers);
+  storage->test_executor = std::move(executor);
+  storage->test_frame.emplace(std::move(working_frame));
+  storage->working_frame = &*storage->test_frame;
+  return std::unique_ptr<ScratchStateTransaction>(
+      new ScratchStateTransaction(std::move(storage)));
+}
+
+const void *ScratchStateTransactionFactory::working_entry_address_for_test(
+    const ScratchStateTransaction &transaction, const std::size_t entry) {
+  ScratchStateTransactionCore::require_available(*transaction.storage_);
+  return transaction.storage_->working_frame->entry_address_for_transaction(
+      entry);
+}
+
+const amrex::MultiFab &
+ScratchStateTransactionFactory::working_multifab_for_test(
+    const ScratchStateTransaction &transaction, const std::size_t entry) {
+  ScratchStateTransactionCore::require_available(*transaction.storage_);
+  return transaction.storage_->working_frame->multifab(entry);
+}
+
+amrex::MultiFab &ScratchStateTransactionFactory::mutable_working_multifab_for_test(
+    ScratchStateTransaction &transaction, const std::size_t entry) {
+  ScratchStateTransactionCore::require_available(*transaction.storage_);
+  return transaction.storage_->working_frame->mutable_multifab(entry);
+}
+
+const std::vector<ScratchValidity> &
+ScratchStateTransactionFactory::working_validity_for_test(
+    const ScratchStateTransaction &transaction, const std::size_t entry) {
+  ScratchStateTransactionCore::require_available(*transaction.storage_);
+  return transaction.storage_->working_frame->validity(entry);
+}
+
+std::vector<ScratchValidity> &
+ScratchStateTransactionFactory::mutable_working_validity_for_test(
+    ScratchStateTransaction &transaction, const std::size_t entry) {
+  ScratchStateTransactionCore::require_available(*transaction.storage_);
+  return transaction.storage_->working_frame->mutable_validity(entry);
+}
+
+ScratchStateToken ScratchStateTransactionFactory::stale_epoch_token_for_test(
+    const ScratchStateTransaction &transaction,
+    const ScratchStateToken &source) {
+  auto token = ScratchStateToken(source.owner_, source.state_, source.epoch_ + 1,
+                                 source.schema_, source.kind_);
+  if (token.epoch_ == transaction.storage_->hierarchy_epoch)
+    ++token.epoch_;
+  return token;
+}
+
+ScratchStateToken
+ScratchStateTransactionFactory::incompatible_schema_token_for_test(
+    const ScratchStateTransaction &, const ScratchStateToken &source) {
+  return ScratchStateToken(source.owner_, source.state_, source.epoch_,
+                           source.schema_ + 1, source.kind_);
+}
+#endif
+
+} // namespace CarpetX

--- a/CarpetX/src/subcycling_scratch_state_transaction.hxx
+++ b/CarpetX/src/subcycling_scratch_state_transaction.hxx
@@ -1,0 +1,133 @@
+#ifndef CARPETX_SUBCYCLING_SCRATCH_STATE_TRANSACTION_HXX
+#define CARPETX_SUBCYCLING_SCRATCH_STATE_TRANSACTION_HXX
+
+#include "subcycling_step_context.hxx"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace CarpetX {
+
+class DenseInterval;
+struct DenseIntervalId;
+class DenseOutputProvider;
+class ScratchStateTransactionFactory;
+class ScratchStateTransactionCore;
+
+enum class ScratchStateKind : std::uint8_t { evolved, raw_rhs };
+enum class ScratchStateRegion : std::uint8_t { interior, outer, ghosts };
+
+// A token names transaction-owned storage. It intentionally exposes neither
+// the storage representation nor any driver object.
+class ScratchStateToken final {
+public:
+  ScratchStateToken() noexcept;
+  ~ScratchStateToken() = default;
+  ScratchStateToken(const ScratchStateToken &) = delete;
+  ScratchStateToken &operator=(const ScratchStateToken &) = delete;
+  ScratchStateToken(ScratchStateToken &&other) noexcept;
+  ScratchStateToken &operator=(ScratchStateToken &&other) noexcept;
+
+  bool valid() const noexcept;
+
+private:
+  ScratchStateToken(std::uint64_t owner, std::uint64_t state,
+                    std::int64_t epoch, std::uint64_t schema,
+                    ScratchStateKind kind) noexcept;
+  void reset() noexcept;
+
+  std::uint64_t owner_{0};
+  std::uint64_t state_{0};
+  std::int64_t epoch_{-1};
+  std::uint64_t schema_{0};
+  ScratchStateKind kind_{ScratchStateKind::evolved};
+
+  friend class ScratchStateTransaction;
+  friend class ScratchStateTransactionFactory;
+  friend class ScratchStateTransactionCore;
+};
+
+struct ScratchGroupPair {
+  int evolved_group;
+  int rhs_group;
+};
+
+struct ScratchLinearTerm {
+  double coefficient;
+  const ScratchStateToken *state;
+};
+
+enum class ScratchDenseSampleKind : std::uint8_t {
+  value,
+  raw_derivative,
+};
+
+struct ScratchDenseSampleRef {
+  double theta;
+  ScratchDenseSampleKind kind;
+  const ScratchStateToken *state;
+};
+
+class ScratchStateTransaction final {
+public:
+  ~ScratchStateTransaction();
+  ScratchStateTransaction(const ScratchStateTransaction &) = delete;
+  ScratchStateTransaction &operator=(const ScratchStateTransaction &) =
+      delete;
+  ScratchStateTransaction(ScratchStateTransaction &&) = delete;
+  ScratchStateTransaction &operator=(ScratchStateTransaction &&) = delete;
+
+  const std::vector<ScratchGroupPair> &group_pairs() const noexcept;
+  const std::vector<int> &dependent_groups() const noexcept;
+
+  ScratchStateToken capture_live_evolved();
+  ScratchStateToken capture_live_rhs();
+  ScratchStateToken capture_scratch_evolved();
+  ScratchStateToken capture_scratch_rhs();
+  ScratchStateToken clone_state(const ScratchStateToken &state);
+
+  ScratchStateKind state_kind(const ScratchStateToken &state) const;
+  bool state_valid(const ScratchStateToken &state,
+                   ScratchStateRegion region) const;
+  void set_state_valid(ScratchStateToken &state, ScratchStateRegion region,
+                       bool valid);
+  // Terminal failure recovery for a captured primary-step left state. This
+  // restores live TL0 in place and never executes PostStep or RHS schedules.
+  void rollback_live_evolved(const ScratchStateToken &state);
+  void restore_state(const ScratchStateToken &state);
+  void restore_left(const ScratchStateToken &evolved,
+                    const ScratchStateToken &raw_rhs);
+  void linear_combination(ScratchStateToken &destination,
+                          double destination_scale,
+                          const std::vector<ScratchLinearTerm> &terms);
+
+  void post_step_after_update(const StepContext &context,
+                              const StagePoint &stage_point);
+  void evaluate_rhs(const StepContext &context,
+                    const StagePoint &stage_point);
+  std::size_t rhs_evaluation_count() const noexcept;
+
+  void commit_dense(const StepContext &context,
+                    const DenseOutputProvider &provider,
+                    const DenseIntervalId &interval,
+                    const std::vector<ScratchDenseSampleRef> &samples);
+  std::shared_ptr<const DenseInterval> take_committed_dense() noexcept;
+
+  bool faulted() const noexcept;
+  bool discarded() const noexcept;
+  void discard() noexcept;
+
+private:
+  struct Storage;
+  explicit ScratchStateTransaction(std::unique_ptr<Storage> storage);
+  std::unique_ptr<Storage> storage_;
+
+  friend class ScratchStateTransactionFactory;
+  friend class ScratchStateTransactionCore;
+};
+
+} // namespace CarpetX
+
+#endif // CARPETX_SUBCYCLING_SCRATCH_STATE_TRANSACTION_HXX

--- a/CarpetX/src/subcycling_scratch_state_transaction.hxx
+++ b/CarpetX/src/subcycling_scratch_state_transaction.hxx
@@ -93,6 +93,13 @@ public:
                    ScratchStateRegion region) const;
   void set_state_valid(ScratchStateToken &state, ScratchStateRegion region,
                        bool valid);
+  // A level-step session arms one private pre-primary snapshot. Fault/discard
+  // keeps it alive; successful commit must disarm it explicitly.
+  void arm_live_evolved_rollback();
+  void disarm_live_evolved_rollback() noexcept;
+  // Terminally restores the armed snapshot without executing any schedule.
+  // This remains available after transaction fault/discard.
+  void rollback_live_evolved();
   // Terminal failure recovery for a captured primary-step left state. This
   // restores live TL0 in place and never executes PostStep or RHS schedules.
   void rollback_live_evolved(const ScratchStateToken &state);

--- a/CarpetX/src/subcycling_scratch_state_transaction_factory.hxx
+++ b/CarpetX/src/subcycling_scratch_state_transaction_factory.hxx
@@ -1,0 +1,92 @@
+#ifndef CARPETX_SUBCYCLING_SCRATCH_STATE_TRANSACTION_FACTORY_HXX
+#define CARPETX_SUBCYCLING_SCRATCH_STATE_TRANSACTION_FACTORY_HXX
+
+#include "subcycling_scratch_adapter.hxx"
+#include "subcycling_scratch_schedule_executor.hxx"
+#include "subcycling_scratch_state_transaction.hxx"
+
+#include <AMReX_MultiFab.H>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace CarpetX {
+
+class CertifiedLocalScheduleRegistry;
+class GHExt;
+
+using ScratchLiveEntryRestorer = std::function<void(
+    const amrex::MultiFab &, const std::vector<ScratchValidity> &)>;
+
+struct ScratchLiveEntrySnapshot {
+  ScratchGFKey key;
+  const void *level_identity;
+  const void *group_identity;
+  const void *tl0_identity;
+  const void *storage_identity;
+  const void *validity_identity;
+  const amrex::MultiFab *multifab;
+  std::vector<ScratchValidity> validity;
+  bool grid_function_real;
+  ScratchLiveEntryRestorer restore;
+};
+
+using ScratchLiveEntryReader =
+    std::function<ScratchLiveEntrySnapshot()>;
+
+struct ScratchStateTransactionFactoryMetadata {
+  std::int64_t hierarchy_epoch;
+  int patch_count;
+  int level_count;
+  int level_iteration;
+  step_clock_t base_delta_clock;
+  double base_delta_time;
+  int time_refinement_factor;
+  bool poison_undefined_values;
+  std::vector<ScratchGroupPair> group_pairs;
+  std::vector<int> dependent_groups;
+  std::function<std::int64_t()> epoch_reader;
+  std::vector<ScratchLiveEntryReader> live_entry_readers;
+};
+
+class ScratchStateTransactionFactory final {
+public:
+  static std::unique_ptr<ScratchStateTransaction> create_native(
+      const GHExt &ghext, CertifiedLocalScheduleRegistry &registry,
+      CertifiedScratchLevelFrame &&frame,
+      ScratchStateTransactionFactoryMetadata metadata);
+
+#ifdef CARPETX_SUBCYCLING_SCRATCH_STATE_TRANSACTION_UNIT
+  using TestScheduleExecutor = std::function<ScratchScheduleExecutionReceipt(
+      ScratchSchedulePhase, const StepContext &,
+      const ScratchStageCoordinates &)>;
+
+  static std::unique_ptr<ScratchStateTransaction> create_for_test(
+      ScratchLevelFrame working_frame,
+      ScratchStateTransactionFactoryMetadata metadata,
+      TestScheduleExecutor executor);
+
+  static const void *working_entry_address_for_test(
+      const ScratchStateTransaction &transaction, std::size_t entry);
+  static const amrex::MultiFab &working_multifab_for_test(
+      const ScratchStateTransaction &transaction, std::size_t entry);
+  static amrex::MultiFab &mutable_working_multifab_for_test(
+      ScratchStateTransaction &transaction, std::size_t entry);
+  static const std::vector<ScratchValidity> &working_validity_for_test(
+      const ScratchStateTransaction &transaction, std::size_t entry);
+  static std::vector<ScratchValidity> &mutable_working_validity_for_test(
+      ScratchStateTransaction &transaction, std::size_t entry);
+  static ScratchStateToken stale_epoch_token_for_test(
+      const ScratchStateTransaction &transaction,
+      const ScratchStateToken &source);
+  static ScratchStateToken incompatible_schema_token_for_test(
+      const ScratchStateTransaction &transaction,
+      const ScratchStateToken &source);
+#endif
+};
+
+} // namespace CarpetX
+
+#endif // CARPETX_SUBCYCLING_SCRATCH_STATE_TRANSACTION_FACTORY_HXX

--- a/CarpetX/src/subcycling_scratch_state_transaction_factory.hxx
+++ b/CarpetX/src/subcycling_scratch_state_transaction_factory.hxx
@@ -16,6 +16,7 @@ namespace CarpetX {
 
 class CertifiedLocalScheduleRegistry;
 class GHExt;
+class TwoLevelStageSpatialNativeBackend;
 
 using ScratchLiveEntryRestorer = std::function<void(
     const amrex::MultiFab &, const std::vector<ScratchValidity> &)>;
@@ -85,6 +86,24 @@ public:
       const ScratchStateTransaction &transaction,
       const ScratchStateToken &source);
 #endif
+
+private:
+  // Raw transaction storage is deliberately available only to the native
+  // driver-owned stage-spatial backend. It is never part of the public
+  // ScratchStateTransaction API.
+  struct StageSpatialAccess {
+    ScratchLevelFrame *working_frame;
+    std::vector<ScratchLiveEntrySnapshot> live_entries;
+    std::int64_t hierarchy_epoch;
+    int level;
+    int time_refinement_factor;
+  };
+
+  static StageSpatialAccess
+  stage_spatial_access(ScratchStateTransaction &transaction);
+  static void fault_stage_spatial_preparation(
+      ScratchStateTransaction &transaction) noexcept;
+  friend class TwoLevelStageSpatialNativeBackend;
 };
 
 } // namespace CarpetX

--- a/CarpetX/src/subcycling_stage_spatial_preparer.cxx
+++ b/CarpetX/src/subcycling_stage_spatial_preparer.cxx
@@ -1,0 +1,261 @@
+#include "subcycling_stage_spatial_preparer.hxx"
+#include "subcycling_stage_spatial_preparer_internal.hxx"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace CarpetX {
+namespace {
+
+double fraction_as_double(const step_clock_t value) {
+  return static_cast<double>(value);
+}
+
+bool close_stage_time(const double actual, const double expected) {
+  const double scale = std::max({1.0, std::abs(actual), std::abs(expected)});
+  return std::abs(actual - expected) <=
+         32.0 * std::numeric_limits<double>::epsilon() * scale;
+}
+
+StageSpatialTarget target_for(const StageKind kind) {
+  switch (kind) {
+  case StageKind::primary:
+    return StageSpatialTarget::primary_live_tl0;
+  case StageKind::fractional:
+  case StageKind::endpoint_probe:
+    return StageSpatialTarget::transaction_scratch;
+  }
+  throw std::invalid_argument("unknown subcycling stage kind");
+}
+
+std::string target_name(const StageSpatialTarget target) {
+  switch (target) {
+  case StageSpatialTarget::primary_live_tl0:
+    return "live";
+  case StageSpatialTarget::transaction_scratch:
+    return "scratch";
+  }
+  throw std::logic_error("unknown stage spatial target");
+}
+
+void validate_stage(const StepContext &context,
+                    const StagePoint &stage_point,
+                    const step_clock_t stage_clock) {
+  if (context.level < 0 || !(context.begin_clock < context.end_clock))
+    throw std::invalid_argument("stage spatial context is invalid");
+  if (!std::isfinite(context.begin_time) ||
+      !std::isfinite(context.end_time) ||
+      !(context.begin_time < context.end_time))
+    throw std::invalid_argument(
+        "stage spatial physical interval is invalid");
+  if (stage_point.stage_index <= 0 || stage_point.stage_count <= 0 ||
+      stage_point.stage_index > stage_point.stage_count)
+    throw std::invalid_argument("stage spatial index/count is invalid");
+  if (stage_point.kind == StageKind::endpoint_probe &&
+      (stage_point.stage_index != 1 || stage_point.stage_count != 1))
+    throw std::invalid_argument(
+        "endpoint probe must be a singleton stage");
+  if (stage_point.stage_fraction.den <= 0 ||
+      stage_point.stage_fraction < 0 || stage_point.stage_fraction > 1)
+    throw std::invalid_argument(
+        "stage spatial fraction must be exact and in [0,1]");
+  if (stage_clock < context.begin_clock || stage_clock > context.end_clock)
+    throw std::invalid_argument("stage spatial clock escaped its step");
+  if (!std::isfinite(stage_point.stage_time))
+    throw std::invalid_argument("stage spatial time must be finite");
+  const double expected_time =
+      context.begin_time + fraction_as_double(stage_point.stage_fraction) *
+                               (context.end_time - context.begin_time);
+  if (!close_stage_time(stage_point.stage_time, expected_time))
+    throw std::invalid_argument(
+        "stage spatial exact clock and physical time disagree");
+}
+
+void validate_metadata(const StageSpatialMetadata &metadata,
+                       const StepContext &context) {
+  if (metadata.patch_count != 1)
+    throw std::invalid_argument(
+        "stage spatial preparation supports exactly one patch");
+  if (metadata.level_count <= 0 || metadata.level_count > 2)
+    throw std::invalid_argument(
+        "stage spatial preparation supports one or two levels");
+  if (metadata.level < 0 || metadata.level >= metadata.level_count ||
+      metadata.level != context.level)
+    throw std::invalid_argument(
+        "stage spatial transaction level changed");
+  if (metadata.level_count == 2 &&
+      metadata.spatial_refinement_ratio != 2)
+    throw std::invalid_argument(
+        "stage spatial preparation requires refinement ratio two");
+  if (metadata.transaction_epoch < 0 ||
+      metadata.transaction_epoch != metadata.observed_epoch)
+    throw std::runtime_error("stage spatial hierarchy epoch changed");
+  if (metadata.global_sync_ownership_conflict)
+    throw std::logic_error(
+        "global SYNC conflicts with driver-owned stage spatial fill");
+  if (metadata.evolved_group_count == 0)
+    throw std::invalid_argument(
+        "stage spatial preparation has no evolved groups");
+}
+
+std::optional<step_clock_t>
+validate_parent(const StageSpatialMetadata &metadata,
+                const StepContext &context, const step_clock_t stage_clock,
+                const DenseInterval *parent_dense) {
+  if (metadata.level == 0) {
+    if (parent_dense != nullptr)
+      throw std::invalid_argument(
+          "coarsest stage must not receive a parent dense interval");
+    return std::nullopt;
+  }
+  if (parent_dense == nullptr)
+    throw std::invalid_argument(
+        "fine stage requires its covering parent dense interval");
+  const auto &id = parent_dense->id();
+  if (id.level != metadata.level - 1 || id.method != context.method ||
+      parent_dense->capability().method != context.method)
+    throw std::invalid_argument(
+        "fine stage parent dense interval metadata differs");
+  if (!(id.begin_clock < id.end_clock) || stage_clock < id.begin_clock ||
+      stage_clock > id.end_clock)
+    throw std::out_of_range(
+        "fine stage is outside its parent dense interval");
+  const auto theta =
+      (stage_clock - id.begin_clock) / (id.end_clock - id.begin_clock);
+  if (theta.den <= 0 || theta < 0 || theta > 1)
+    throw std::out_of_range(
+        "fine stage parent theta is outside [0,1]");
+  return theta;
+}
+
+} // namespace
+
+TwoLevelStageSpatialPreparer::TwoLevelStageSpatialPreparer(
+    std::unique_ptr<detail::StageSpatialPreparerBackend> backend)
+    : backend_(std::move(backend)) {
+  if (backend_ == nullptr)
+    throw std::invalid_argument("stage spatial backend is missing");
+}
+
+TwoLevelStageSpatialPreparer::~TwoLevelStageSpatialPreparer() = default;
+TwoLevelStageSpatialPreparer::TwoLevelStageSpatialPreparer(
+    TwoLevelStageSpatialPreparer &&) noexcept = default;
+TwoLevelStageSpatialPreparer &TwoLevelStageSpatialPreparer::operator=(
+    TwoLevelStageSpatialPreparer &&) noexcept = default;
+
+StageSpatialPreparationReceipt TwoLevelStageSpatialPreparer::prepare_impl(
+    ScratchStateTransaction *transaction, const StepContext &context,
+    const StagePoint &stage_point, const DenseInterval *parent_dense) {
+  try {
+    const auto metadata = backend_->inspect(transaction);
+    validate_metadata(metadata, context);
+    const auto target = target_for(stage_point.kind);
+    const auto stage_clock =
+        context.begin_clock +
+        (context.end_clock - context.begin_clock) *
+            stage_point.stage_fraction;
+    validate_stage(context, stage_point, stage_clock);
+    const auto parent_theta =
+        validate_parent(metadata, context, stage_clock, parent_dense);
+
+    if (metadata.level == 0) {
+      backend_->prepare_level_zero(transaction, target, stage_clock);
+    } else {
+      backend_->prepare_level_one(transaction, target, stage_clock,
+                                  *parent_theta, *parent_dense);
+    }
+    // Spatial validity is promoted only after every exchange, boundary fill,
+    // dense sample, and prolongation has returned successfully.
+    backend_->promote(transaction, target);
+    return StageSpatialPreparationReceipt{
+        target, 0, metadata.level, stage_clock, parent_theta,
+        metadata.evolved_group_count};
+  } catch (...) {
+    backend_->fault(transaction);
+    throw;
+  }
+}
+
+#ifdef CARPETX_SUBCYCLING_STAGE_SPATIAL_PREPARER_UNIT
+namespace {
+
+class TestStageSpatialBackend final
+    : public detail::StageSpatialPreparerBackend {
+public:
+  explicit TestStageSpatialBackend(
+      TwoLevelStageSpatialPreparer::TestBackend &test)
+      : test_(test) {}
+
+  StageSpatialMetadata inspect(ScratchStateTransaction *) override {
+    const auto &m = test_.metadata;
+    return {m.patch_count,
+            m.level_count,
+            m.spatial_refinement_ratio,
+            m.level,
+            m.transaction_epoch,
+            m.observed_epoch,
+            m.global_sync_ownership_conflict,
+            m.evolved_group_count};
+  }
+
+  void prepare_level_zero(ScratchStateTransaction *,
+                          const StageSpatialTarget target,
+                          step_clock_t) override {
+    ++test_.prepare_calls;
+    test_.events.push_back("prepare L0 " + target_name(target));
+    if (test_.throw_during_prepare)
+      throw std::runtime_error("injected stage spatial fill failure");
+  }
+
+  void prepare_level_one(ScratchStateTransaction *,
+                         const StageSpatialTarget target, step_clock_t,
+                         const step_clock_t parent_theta,
+                         const DenseInterval &) override {
+    ++test_.prepare_calls;
+    test_.observed_parent_theta = parent_theta;
+    test_.events.push_back(
+        "prepare L1 " + target_name(target) + " theta=" +
+        std::to_string(parent_theta.num) + "/" +
+        std::to_string(parent_theta.den));
+    if (test_.throw_during_prepare)
+      throw std::runtime_error("injected stage spatial fill failure");
+  }
+
+  void promote(ScratchStateTransaction *,
+               const StageSpatialTarget target) override {
+    ++test_.promote_calls;
+    test_.events.push_back("promote " + target_name(target));
+    if (test_.throw_during_promote)
+      throw std::runtime_error("injected stage spatial promotion failure");
+  }
+
+  void fault(ScratchStateTransaction *) noexcept override {
+    ++test_.fault_calls;
+    test_.events.push_back("fault");
+  }
+
+private:
+  TwoLevelStageSpatialPreparer::TestBackend &test_;
+};
+
+} // namespace
+
+TwoLevelStageSpatialPreparer
+TwoLevelStageSpatialPreparer::create_for_test(TestBackend &backend) {
+  return TwoLevelStageSpatialPreparer(
+      std::make_unique<TestStageSpatialBackend>(backend));
+}
+
+StageSpatialPreparationReceipt
+TwoLevelStageSpatialPreparer::prepare_for_test(
+    const StepContext &context, const StagePoint &stage_point,
+    const DenseInterval *parent_dense) {
+  return prepare_impl(nullptr, context, stage_point, parent_dense);
+}
+#endif
+
+} // namespace CarpetX

--- a/CarpetX/src/subcycling_stage_spatial_preparer.hxx
+++ b/CarpetX/src/subcycling_stage_spatial_preparer.hxx
@@ -1,0 +1,103 @@
+#ifndef CARPETX_SUBCYCLING_STAGE_SPATIAL_PREPARER_HXX
+#define CARPETX_SUBCYCLING_STAGE_SPATIAL_PREPARER_HXX
+
+#include "subcycling_dense_output.hxx"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+#ifdef CARPETX_SUBCYCLING_STAGE_SPATIAL_PREPARER_UNIT
+#include <string>
+#include <vector>
+#endif
+
+namespace CarpetX {
+
+class GHExt;
+class ScratchStateTransaction;
+namespace detail {
+class StageSpatialPreparerBackend;
+}
+
+enum class StageSpatialScheduleOwnership : std::uint8_t {
+  certified_local_no_global_sync,
+  conflicting_global_sync,
+};
+
+enum class StageSpatialTarget : std::uint8_t {
+  primary_live_tl0,
+  transaction_scratch,
+};
+
+struct StageSpatialPreparationReceipt {
+  StageSpatialTarget target;
+  int patch;
+  int level;
+  step_clock_t stage_clock;
+  std::optional<step_clock_t> parent_theta;
+  std::size_t evolved_group_count;
+};
+
+class TwoLevelStageSpatialPreparer final {
+public:
+  TwoLevelStageSpatialPreparer(
+      GHExt &ghext, StageSpatialScheduleOwnership schedule_ownership);
+  ~TwoLevelStageSpatialPreparer();
+
+  TwoLevelStageSpatialPreparer(const TwoLevelStageSpatialPreparer &) = delete;
+  TwoLevelStageSpatialPreparer &
+  operator=(const TwoLevelStageSpatialPreparer &) = delete;
+  TwoLevelStageSpatialPreparer(TwoLevelStageSpatialPreparer &&) noexcept;
+  TwoLevelStageSpatialPreparer &
+  operator=(TwoLevelStageSpatialPreparer &&) noexcept;
+
+  StageSpatialPreparationReceipt
+  prepare(ScratchStateTransaction &transaction, const StepContext &context,
+          const StagePoint &stage_point, const DenseInterval *parent_dense);
+
+#ifdef CARPETX_SUBCYCLING_STAGE_SPATIAL_PREPARER_UNIT
+  struct TestMetadata {
+    int patch_count{1};
+    int level_count{1};
+    int spatial_refinement_ratio{2};
+    int level{0};
+    std::int64_t transaction_epoch{7};
+    std::int64_t observed_epoch{7};
+    bool global_sync_ownership_conflict{false};
+    std::size_t evolved_group_count{1};
+  };
+
+  struct TestBackend {
+    TestMetadata metadata;
+    bool throw_during_prepare{false};
+    bool throw_during_promote{false};
+    int prepare_calls{0};
+    int promote_calls{0};
+    int fault_calls{0};
+    std::optional<step_clock_t> observed_parent_theta;
+    std::vector<std::string> events;
+  };
+
+  static TwoLevelStageSpatialPreparer create_for_test(TestBackend &backend);
+  StageSpatialPreparationReceipt
+  prepare_for_test(const StepContext &context, const StagePoint &stage_point,
+                   const DenseInterval *parent_dense);
+#endif
+
+private:
+  explicit TwoLevelStageSpatialPreparer(
+      std::unique_ptr<detail::StageSpatialPreparerBackend> backend);
+
+  StageSpatialPreparationReceipt
+  prepare_impl(ScratchStateTransaction *transaction,
+               const StepContext &context, const StagePoint &stage_point,
+               const DenseInterval *parent_dense);
+
+  std::unique_ptr<detail::StageSpatialPreparerBackend> backend_;
+};
+
+} // namespace CarpetX
+
+#endif // CARPETX_SUBCYCLING_STAGE_SPATIAL_PREPARER_HXX

--- a/CarpetX/src/subcycling_stage_spatial_preparer_internal.hxx
+++ b/CarpetX/src/subcycling_stage_spatial_preparer_internal.hxx
@@ -1,0 +1,45 @@
+#ifndef CARPETX_SUBCYCLING_STAGE_SPATIAL_PREPARER_INTERNAL_HXX
+#define CARPETX_SUBCYCLING_STAGE_SPATIAL_PREPARER_INTERNAL_HXX
+
+#include "subcycling_stage_spatial_preparer.hxx"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace CarpetX {
+
+struct StageSpatialMetadata {
+  int patch_count;
+  int level_count;
+  int spatial_refinement_ratio;
+  int level;
+  std::int64_t transaction_epoch;
+  std::int64_t observed_epoch;
+  bool global_sync_ownership_conflict;
+  std::size_t evolved_group_count;
+};
+
+namespace detail {
+
+class StageSpatialPreparerBackend {
+public:
+  virtual ~StageSpatialPreparerBackend() = default;
+  virtual StageSpatialMetadata
+  inspect(ScratchStateTransaction *transaction) = 0;
+  virtual void prepare_level_zero(ScratchStateTransaction *transaction,
+                                  StageSpatialTarget target,
+                                  step_clock_t stage_clock) = 0;
+  virtual void prepare_level_one(ScratchStateTransaction *transaction,
+                                 StageSpatialTarget target,
+                                 step_clock_t stage_clock,
+                                 step_clock_t parent_theta,
+                                 const DenseInterval &parent_dense) = 0;
+  virtual void promote(ScratchStateTransaction *transaction,
+                       StageSpatialTarget target) = 0;
+  virtual void fault(ScratchStateTransaction *transaction) noexcept = 0;
+};
+
+} // namespace detail
+} // namespace CarpetX
+
+#endif // CARPETX_SUBCYCLING_STAGE_SPATIAL_PREPARER_INTERNAL_HXX

--- a/CarpetX/src/subcycling_stage_spatial_preparer_native.cxx
+++ b/CarpetX/src/subcycling_stage_spatial_preparer_native.cxx
@@ -1,0 +1,437 @@
+#include "subcycling_stage_spatial_preparer.hxx"
+#include "subcycling_stage_spatial_preparer_internal.hxx"
+
+#include "driver.hxx"
+#include "fillpatch.hxx"
+#include "subcycling_dense_mfab_state.hxx"
+#include "subcycling_scratch_state_transaction_factory.hxx"
+#include "task_manager.hxx"
+
+#include <AMReX_IntVect.H>
+#include <AMReX_MultiFab.H>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace CarpetX {
+
+// The driver-wide synchronization primitive is defined in schedule.cxx.
+void synchronize();
+
+namespace {
+
+bool same_layout(const amrex::MultiFab &left,
+                 const amrex::MultiFab &right) {
+  return left.isDefined() && right.isDefined() &&
+         left.boxArray() == right.boxArray() &&
+         left.DistributionMap() == right.DistributionMap() &&
+         left.nComp() == right.nComp() &&
+         left.nGrowVect() == right.nGrowVect();
+}
+
+bool ratio_is_two(const amrex::IntVect &ratio) {
+  for (int direction = 0; direction < AMREX_SPACEDIM; ++direction)
+    if (ratio[direction] != 2)
+      return false;
+  return true;
+}
+
+} // namespace
+
+class TwoLevelStageSpatialNativeBackend final
+    : public detail::StageSpatialPreparerBackend {
+  using GroupData = GHExt::PatchData::LevelData::GroupData;
+  using StageAccess = ScratchStateTransactionFactory::StageSpatialAccess;
+
+  struct Binding {
+    int group_index;
+    std::size_t frame_entry;
+    GroupData *groupdata;
+    amrex::MultiFab *target;
+    std::vector<why_valid_t> *live_validity;
+    std::vector<ScratchValidity> *scratch_validity;
+  };
+
+  struct Pending {
+    StageSpatialTarget target;
+    int level;
+    step_clock_t stage_clock;
+    std::vector<int> evolved_groups;
+  };
+
+public:
+  TwoLevelStageSpatialNativeBackend(
+      GHExt &ghext, const StageSpatialScheduleOwnership ownership)
+      : ghext_(ghext), ownership_(ownership) {}
+
+  StageSpatialMetadata
+  inspect(ScratchStateTransaction *transaction) override {
+    auto &native_transaction = require_transaction(transaction);
+    const auto access = ScratchStateTransactionFactory::stage_spatial_access(
+        native_transaction);
+    const int patch_count = static_cast<int>(ghext_.patchdata.size());
+    const int level_count =
+        patch_count == 1
+            ? static_cast<int>(ghext_.patchdata.front().leveldata.size())
+            : 0;
+    int spatial_ratio = 2;
+    if (patch_count == 1 && level_count == 2) {
+      const auto &patchdata = ghext_.patchdata.front();
+      spatial_ratio =
+          patchdata.amrcore != nullptr &&
+                  ratio_is_two(patchdata.amrcore->refRatio(0))
+              ? 2
+              : -1;
+    }
+    return StageSpatialMetadata{
+        patch_count,
+        level_count,
+        spatial_ratio,
+        access.level,
+        access.hierarchy_epoch,
+        static_cast<std::int64_t>(CarpetX_GetEpoch()),
+        ownership_ == StageSpatialScheduleOwnership::conflicting_global_sync,
+        native_transaction.group_pairs().size()};
+  }
+
+  void prepare_level_zero(ScratchStateTransaction *transaction,
+                          const StageSpatialTarget target,
+                          const step_clock_t stage_clock) override {
+    auto &native_transaction = require_transaction(transaction);
+    require_no_pending();
+    auto access = ScratchStateTransactionFactory::stage_spatial_access(
+        native_transaction);
+    if (access.level != 0)
+      throw std::invalid_argument(
+          "level-zero spatial preparation received another level");
+    auto bindings = collect_bindings(access, native_transaction, target);
+    invalidate_spatial(bindings);
+    pending_ = Pending{target, 0, stage_clock, group_indices(bindings)};
+
+    task_manager tasks2;
+    const auto &patchdata = ghext_.patchdata.at(0);
+    if (patchdata.amrcore == nullptr)
+      throw std::runtime_error("stage spatial AMR core disappeared");
+    const auto &geometry = patchdata.amrcore->Geom(0);
+    for (auto &binding : bindings)
+      FillPatch_Sync(tasks2, *binding.groupdata, *binding.target, geometry);
+    synchronize();
+    tasks2.run_tasks_serially();
+    synchronize();
+  }
+
+  void prepare_level_one(ScratchStateTransaction *transaction,
+                         const StageSpatialTarget target,
+                         const step_clock_t stage_clock,
+                         const step_clock_t parent_theta,
+                         const DenseInterval &parent_dense) override {
+    auto &native_transaction = require_transaction(transaction);
+    require_no_pending();
+    auto access = ScratchStateTransactionFactory::stage_spatial_access(
+        native_transaction);
+    if (access.level != 1)
+      throw std::invalid_argument(
+          "level-one spatial preparation received another level");
+    auto bindings = collect_bindings(access, native_transaction, target);
+
+    // The parent sample is fully materialized and compatibility-checked before
+    // any fine target validity is invalidated.
+    auto parent_state = evaluate_parent(access, bindings, parent_theta,
+                                        parent_dense);
+    validate_level_one_fill(bindings, *parent_state);
+    invalidate_spatial(bindings);
+    pending_ = Pending{target, 1, stage_clock, group_indices(bindings)};
+
+    auto &patchdata = ghext_.patchdata.at(0);
+    const auto &fine_geometry = patchdata.amrcore->Geom(1);
+    const auto &coarse_geometry = patchdata.amrcore->Geom(0);
+    task_manager tasks2;
+    task_manager tasks3;
+    for (std::size_t index = 0; index < bindings.size(); ++index) {
+      auto &binding = bindings[index];
+      auto &coarse_group = require_group(0, binding.group_index);
+      FillPatch_ProlongateGhosts(
+          tasks2, tasks3, *binding.groupdata, coarse_group, *binding.target,
+          parent_state->multifab(index), fine_geometry, coarse_geometry,
+          binding.groupdata->interpolator, binding.groupdata->bcrecs);
+    }
+    synchronize();
+    tasks2.run_tasks_serially();
+    synchronize();
+    tasks3.run_tasks_serially();
+    synchronize();
+  }
+
+  void promote(ScratchStateTransaction *transaction,
+               const StageSpatialTarget target) override {
+    auto &native_transaction = require_transaction(transaction);
+    if (!pending_.has_value() || pending_->target != target)
+      throw std::logic_error(
+          "stage spatial validity promotion lacks its preparation");
+    auto access = ScratchStateTransactionFactory::stage_spatial_access(
+        native_transaction);
+    if (access.level != pending_->level)
+      throw std::runtime_error(
+          "stage spatial level changed before validity promotion");
+    auto bindings = collect_bindings(access, native_transaction, target);
+    if (group_indices(bindings) != pending_->evolved_groups)
+      throw std::runtime_error(
+          "stage spatial group schema changed before validity promotion");
+
+    promote_spatial(bindings);
+    pending_.reset();
+  }
+
+  void fault(ScratchStateTransaction *transaction) noexcept override {
+    pending_.reset();
+    if (transaction != nullptr)
+      ScratchStateTransactionFactory::fault_stage_spatial_preparation(
+          *transaction);
+  }
+
+private:
+  static ScratchStateTransaction &
+  require_transaction(ScratchStateTransaction *transaction) {
+    if (transaction == nullptr)
+      throw std::invalid_argument(
+          "native stage spatial preparation requires a transaction");
+    return *transaction;
+  }
+
+  void require_no_pending() const {
+    if (pending_.has_value())
+      throw std::logic_error(
+          "prior stage spatial validity has not been promoted");
+  }
+
+  GroupData &require_group(const int level, const int group_index) {
+    if (ghext_.patchdata.size() != 1 || level < 0 || level > 1 ||
+        static_cast<std::size_t>(level) >=
+            ghext_.patchdata.front().leveldata.size())
+      throw std::runtime_error("stage spatial hierarchy layout changed");
+    auto &leveldata = ghext_.patchdata.front().leveldata.at(
+        static_cast<std::size_t>(level));
+    if (group_index < 0 ||
+        static_cast<std::size_t>(group_index) >=
+            leveldata.groupdata.size() ||
+        leveldata.groupdata[static_cast<std::size_t>(group_index)] == nullptr)
+      throw std::runtime_error("stage spatial group disappeared");
+    return *leveldata.groupdata[static_cast<std::size_t>(group_index)];
+  }
+
+  static std::size_t find_frame_entry(const ScratchLevelFrame &frame,
+                                      const int group_index) {
+    for (std::size_t entry = 0; entry < frame.entry_count(); ++entry)
+      if (frame.key(entry).group_index == group_index)
+        return entry;
+    throw std::runtime_error("stage spatial scratch group disappeared");
+  }
+
+  static const ScratchLiveEntrySnapshot &
+  find_live_entry(const StageAccess &access, const int group_index) {
+    const auto found = std::find_if(
+        access.live_entries.begin(), access.live_entries.end(),
+        [group_index](const ScratchLiveEntrySnapshot &entry) {
+          return entry.key.group_index == group_index;
+        });
+    if (found == access.live_entries.end())
+      throw std::runtime_error("stage spatial live group disappeared");
+    return *found;
+  }
+
+  std::vector<Binding>
+  collect_bindings(StageAccess &access,
+                   const ScratchStateTransaction &transaction,
+                   const StageSpatialTarget target) {
+    if (access.working_frame == nullptr ||
+        access.working_frame->hierarchy_epoch() != access.hierarchy_epoch ||
+        access.working_frame->level() != access.level)
+      throw std::runtime_error("stage spatial scratch frame changed");
+    std::vector<Binding> bindings;
+    bindings.reserve(transaction.group_pairs().size());
+    for (const auto &pair : transaction.group_pairs()) {
+      const int group_index = pair.evolved_group;
+      auto &groupdata = require_group(access.level, group_index);
+      if (groupdata.groupindex != group_index || groupdata.mfab.empty() ||
+          groupdata.valid.empty() || groupdata.mfab.at(0) == nullptr)
+        throw std::runtime_error(
+            "stage spatial live TL0 schema changed");
+      auto *const live = groupdata.mfab.at(0).get();
+      auto &live_validity = groupdata.valid.at(0);
+      const auto &snapshot = find_live_entry(access, group_index);
+      const auto frame_entry =
+          find_frame_entry(*access.working_frame, group_index);
+      const auto &frame_key = access.working_frame->key(frame_entry);
+      if (snapshot.key.hierarchy_epoch != access.hierarchy_epoch ||
+          snapshot.key.patch != 0 || snapshot.key.level != access.level ||
+          frame_key.hierarchy_epoch != access.hierarchy_epoch ||
+          frame_key.patch != 0 || frame_key.level != access.level ||
+          snapshot.group_identity != &groupdata ||
+          snapshot.tl0_identity != &groupdata.mfab.at(0) ||
+          snapshot.storage_identity != live || snapshot.multifab != live ||
+          snapshot.validity_identity != &live_validity ||
+          !snapshot.grid_function_real || live == nullptr ||
+          !live->isDefined())
+        throw std::runtime_error(
+            "stage spatial live identity or key changed");
+
+      amrex::MultiFab *target_mfab = nullptr;
+      std::vector<why_valid_t> *target_live_validity = nullptr;
+      std::vector<ScratchValidity> *target_scratch_validity = nullptr;
+      if (target == StageSpatialTarget::primary_live_tl0) {
+        target_mfab = live;
+        target_live_validity = &live_validity;
+      } else {
+        target_mfab =
+            &access.working_frame->mutable_multifab(frame_entry);
+        target_scratch_validity =
+            &access.working_frame->mutable_validity(frame_entry);
+      }
+      if (target_mfab == nullptr || !same_layout(*target_mfab, *live) ||
+          target_mfab->nComp() != groupdata.numvars ||
+          live_validity.size() !=
+              static_cast<std::size_t>(groupdata.numvars) ||
+          snapshot.validity.size() != live_validity.size() ||
+          (target_scratch_validity != nullptr &&
+           target_scratch_validity->size() != live_validity.size()))
+        throw std::runtime_error(
+            "stage spatial target layout or schema changed");
+
+      for (std::size_t component = 0; component < live_validity.size();
+           ++component) {
+        const bool interior =
+            target_live_validity != nullptr
+                ? target_live_validity->at(component).get().valid_int
+                : target_scratch_validity->at(component).interior;
+        if (!interior)
+          throw std::runtime_error(
+              "stage spatial target interior is invalid");
+      }
+      bindings.push_back(Binding{group_index, frame_entry, &groupdata,
+                                 target_mfab, target_live_validity,
+                                 target_scratch_validity});
+    }
+    return bindings;
+  }
+
+  std::unique_ptr<OwnedMultiFabDenseState>
+  evaluate_parent(const StageAccess &access,
+                  const std::vector<Binding> &bindings,
+                  const step_clock_t parent_theta,
+                  const DenseInterval &parent_dense) {
+    std::vector<DenseMFabView> views;
+    views.reserve(bindings.size());
+    for (const auto &binding : bindings) {
+      auto &coarse_group = require_group(0, binding.group_index);
+      if (coarse_group.mfab.empty() || coarse_group.mfab.at(0) == nullptr ||
+          !coarse_group.mfab.at(0)->isDefined())
+        throw std::runtime_error(
+            "stage spatial parent live group disappeared");
+      views.push_back(
+          DenseMFabView{{access.hierarchy_epoch, 0, 0,
+                         binding.group_index},
+                        coarse_group.mfab.at(0).get()});
+    }
+    auto state = OwnedMultiFabDenseState::allocate_like(views);
+    parent_dense.evaluate(parent_theta, *state);
+    return state;
+  }
+
+  void validate_level_one_fill(
+      const std::vector<Binding> &bindings,
+      const OwnedMultiFabDenseState &parent_state) {
+    if (ghext_.patchdata.size() != 1 ||
+        ghext_.patchdata.front().leveldata.size() != 2 ||
+        ghext_.patchdata.front().amrcore == nullptr ||
+        !ratio_is_two(ghext_.patchdata.front().amrcore->refRatio(0)) ||
+        parent_state.entry_count() != bindings.size())
+      throw std::runtime_error(
+          "stage spatial level-one hierarchy changed");
+    for (std::size_t index = 0; index < bindings.size(); ++index) {
+      const auto &binding = bindings[index];
+      auto &coarse_group = require_group(0, binding.group_index);
+      const auto &key = parent_state.key(index);
+      if (key.patch != 0 || key.level != 0 ||
+          key.group_index != binding.group_index ||
+          coarse_group.numvars != binding.groupdata->numvars ||
+          binding.groupdata->interpolator == nullptr ||
+          !same_layout(parent_state.multifab(index),
+                       *coarse_group.mfab.at(0)))
+        throw std::runtime_error(
+            "stage spatial parent sample or prolongation schema changed");
+    }
+  }
+
+  static std::vector<int>
+  group_indices(const std::vector<Binding> &bindings) {
+    std::vector<int> result;
+    result.reserve(bindings.size());
+    for (const auto &binding : bindings)
+      result.push_back(binding.group_index);
+    return result;
+  }
+
+  static void invalidate_spatial(std::vector<Binding> &bindings) {
+    for (auto &binding : bindings) {
+      if (binding.live_validity != nullptr) {
+        for (auto &validity : *binding.live_validity) {
+          validity.set_outer(false, [] {
+            return "TwoLevelStageSpatialPreparer fill pending";
+          });
+          validity.set_ghosts(false, [] {
+            return "TwoLevelStageSpatialPreparer fill pending";
+          });
+        }
+      } else {
+        for (auto &validity : *binding.scratch_validity) {
+          validity.outer = false;
+          validity.ghosts = false;
+        }
+      }
+    }
+  }
+
+  static void promote_spatial(std::vector<Binding> &bindings) {
+    for (auto &binding : bindings) {
+      if (binding.live_validity != nullptr) {
+        for (auto &validity : *binding.live_validity) {
+          validity.set_outer(true, [] {
+            return "TwoLevelStageSpatialPreparer fill completed";
+          });
+          validity.set_ghosts(true, [] {
+            return "TwoLevelStageSpatialPreparer fill completed";
+          });
+        }
+      } else {
+        for (auto &validity : *binding.scratch_validity) {
+          validity.outer = true;
+          validity.ghosts = true;
+        }
+      }
+    }
+  }
+
+  GHExt &ghext_;
+  StageSpatialScheduleOwnership ownership_;
+  std::optional<Pending> pending_;
+};
+
+TwoLevelStageSpatialPreparer::TwoLevelStageSpatialPreparer(
+    GHExt &ghext, const StageSpatialScheduleOwnership schedule_ownership)
+    : TwoLevelStageSpatialPreparer(
+          std::make_unique<TwoLevelStageSpatialNativeBackend>(
+              ghext, schedule_ownership)) {}
+
+StageSpatialPreparationReceipt TwoLevelStageSpatialPreparer::prepare(
+    ScratchStateTransaction &transaction, const StepContext &context,
+    const StagePoint &stage_point, const DenseInterval *parent_dense) {
+  return prepare_impl(&transaction, context, stage_point, parent_dense);
+}
+
+} // namespace CarpetX

--- a/CarpetX/src/subcycling_static_v1_contract.hxx
+++ b/CarpetX/src/subcycling_static_v1_contract.hxx
@@ -18,6 +18,47 @@ select_static_v1_evolve_path(const bool use_subcycling_wip) noexcept {
                            : StaticV1EvolvePath::legacy;
 }
 
+struct StaticV1LevelOneCreationEnvelope {
+  bool subcycling_enabled;
+  int configured_patch_count;
+  int callback_patch;
+  int callback_level;
+  int configured_level_count;
+  int existing_level_count;
+  int regrid_every;
+  int coarse_patch;
+  int coarse_level;
+  int coarse_iteration;
+  int coarse_delta_iteration;
+  bool coarse_is_subcycling_level;
+  std::array<int, 3> spatial_refinement_ratio;
+  double callback_time;
+};
+
+constexpr bool permits_static_v1_level_one_creation(
+    const StaticV1LevelOneCreationEnvelope &envelope) noexcept {
+  return envelope.subcycling_enabled &&
+         envelope.configured_patch_count == 1 &&
+         envelope.callback_patch == 0 && envelope.callback_level == 1 &&
+         envelope.configured_level_count == 2 &&
+         envelope.existing_level_count == 1 && envelope.regrid_every == 0 &&
+         envelope.coarse_patch == 0 && envelope.coarse_level == 0 &&
+         envelope.coarse_iteration == 0 &&
+         envelope.coarse_delta_iteration == 1 &&
+         !envelope.coarse_is_subcycling_level &&
+         envelope.spatial_refinement_ratio[0] == 2 &&
+         envelope.spatial_refinement_ratio[1] == 2 &&
+         envelope.spatial_refinement_ratio[2] == 2 &&
+         envelope.callback_time == 0.0;
+}
+
+constexpr bool should_stop_static_v1_initial_regrid_loop(
+    const bool subcycling_enabled, const int configured_patch_count,
+    const int configured_level_count, const int existing_level_count) noexcept {
+  return subcycling_enabled && configured_patch_count == 1 &&
+         configured_level_count == 2 && existing_level_count == 2;
+}
+
 struct StaticV1PolicyEnvelope {
   int patch_count;
   int level_count;

--- a/CarpetX/src/subcycling_static_v1_contract.hxx
+++ b/CarpetX/src/subcycling_static_v1_contract.hxx
@@ -1,0 +1,135 @@
+#ifndef CARPETX_SUBCYCLING_STATIC_V1_CONTRACT_HXX
+#define CARPETX_SUBCYCLING_STATIC_V1_CONTRACT_HXX
+
+#include <algorithm>
+#include <array>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace CarpetX {
+
+enum class StaticV1EvolvePath { legacy, static_v1 };
+
+constexpr StaticV1EvolvePath
+select_static_v1_evolve_path(const bool use_subcycling_wip) noexcept {
+  return use_subcycling_wip ? StaticV1EvolvePath::static_v1
+                           : StaticV1EvolvePath::legacy;
+}
+
+struct StaticV1PolicyEnvelope {
+  int patch_count;
+  int level_count;
+  int spatial_refinement_ratio;
+  int regrid_every;
+  bool recovering;
+  bool do_reflux;
+  bool do_restrict;
+  bool restrict_during_sync;
+  bool poison_undefined_values;
+  bool level_one_subcycles;
+  bool root_iteration_zero;
+  bool level_clocks_zero;
+  bool complete_method_schema;
+  bool evolved_schema_supported;
+  bool bounded_test_odesolvers2_configuration;
+};
+
+inline void
+validate_static_v1_policy_envelope(const StaticV1PolicyEnvelope &policy) {
+  if (policy.patch_count != 1)
+    throw std::invalid_argument(
+        "static-v1 requires exactly one CarpetX patch");
+  if (policy.level_count != 2)
+    throw std::invalid_argument(
+        "static-v1 requires exactly two CarpetX levels");
+  if (policy.spatial_refinement_ratio != 2)
+    throw std::invalid_argument(
+        "static-v1 requires factor-two spatial refinement");
+  if (policy.recovering)
+    throw std::invalid_argument(
+        "static-v1 supports new starts only; recovery is disabled");
+  if (policy.regrid_every != 0)
+    throw std::invalid_argument(
+        "static-v1 requires CarpetX::regrid_every=0");
+  if (policy.do_reflux)
+    throw std::invalid_argument(
+        "static-v1 requires CarpetX::do_reflux=no");
+  if (!policy.do_restrict)
+    throw std::invalid_argument(
+        "static-v1 requires CarpetX::do_restrict=yes");
+  if (policy.restrict_during_sync)
+    throw std::invalid_argument(
+        "static-v1 requires CarpetX::restrict_during_sync=no");
+  if (policy.poison_undefined_values)
+    throw std::invalid_argument(
+        "static-v1 requires CarpetX::poison_undefined_values=no");
+  if (!policy.level_one_subcycles)
+    throw std::invalid_argument(
+        "static-v1 requires level one to be marked for subcycling");
+  if (!policy.root_iteration_zero || !policy.level_clocks_zero)
+    throw std::invalid_argument(
+        "static-v1 requires zero root and level clocks at a new start");
+  if (!policy.complete_method_schema)
+    throw std::invalid_argument(
+        "static-v1 requires a frozen complete ODE method/group schema");
+  if (!policy.evolved_schema_supported)
+    throw std::invalid_argument(
+        "static-v1 requires GF REAL evolved, RHS, and dependent groups with "
+        "one evolved timelevel");
+  if (!policy.bounded_test_odesolvers2_configuration)
+    throw std::invalid_argument(
+        "static-v1 outer PRESTEP/EVOL schedule certification is not yet "
+        "implemented; only the exact two-level TestODESolvers2 "
+        "state/RHS/dependent schema is supported, and BBH or general thorn "
+        "configurations are not supported");
+}
+
+inline bool has_exact_static_v1_test_odesolvers2_active_thorns(
+    std::vector<std::string> active_thorns) {
+  static const std::array<const char *, 14> expected{
+      "AMReX",          "Arith", "BoxInBox",    "Cactus", "CarpetX",
+      "CarpetXRegrid",  "IOUtil", "Loop",        "MPI",    "NSIMD",
+      "ODESolvers",     "TestODESolvers2", "yaml_cpp", "zlib"};
+  std::sort(active_thorns.begin(), active_thorns.end());
+  return active_thorns.size() == expected.size() &&
+         std::equal(active_thorns.begin(), active_thorns.end(),
+                    expected.begin(), [](const std::string &active,
+                                         const char *const required) {
+                      return active == required;
+                    });
+}
+
+// Accepted active-level GF history must rotate before the canonical TL0
+// snapshot is copied. Keeping this sequencing helper Cactus-free makes the
+// exact once-and-before contract directly regression-testable.
+template <class Cycle, class Capture>
+decltype(auto)
+cycle_then_capture_static_v1_level_state(Cycle &&cycle, Capture &&capture) {
+  std::forward<Cycle>(cycle)();
+  return std::forward<Capture>(capture)();
+}
+
+enum class StaticV1SyncObserverAction {
+  cycle_synchronized_globals,
+  postrestrict,
+  poststep,
+  analysis,
+  output,
+  checkpoint,
+};
+
+constexpr std::array<StaticV1SyncObserverAction, 6>
+static_v1_sync_observer_order() noexcept {
+  return {StaticV1SyncObserverAction::cycle_synchronized_globals,
+          StaticV1SyncObserverAction::postrestrict,
+          StaticV1SyncObserverAction::poststep,
+          StaticV1SyncObserverAction::analysis,
+          StaticV1SyncObserverAction::output,
+          StaticV1SyncObserverAction::checkpoint};
+}
+
+} // namespace CarpetX
+
+#endif // CARPETX_SUBCYCLING_STATIC_V1_CONTRACT_HXX

--- a/CarpetX/src/subcycling_static_v1_contract.hxx
+++ b/CarpetX/src/subcycling_static_v1_contract.hxx
@@ -102,9 +102,6 @@ validate_static_v1_policy_envelope(const StaticV1PolicyEnvelope &policy) {
   if (policy.spatial_refinement_ratio != 2)
     throw std::invalid_argument(
         "static-v1 requires factor-two spatial refinement");
-  if (policy.recovering)
-    throw std::invalid_argument(
-        "static-v1 supports new starts only; recovery is disabled");
   if (policy.regrid_every != 0)
     throw std::invalid_argument(
         "static-v1 requires CarpetX::regrid_every=0");
@@ -123,9 +120,14 @@ validate_static_v1_policy_envelope(const StaticV1PolicyEnvelope &policy) {
   if (!policy.level_one_subcycles)
     throw std::invalid_argument(
         "static-v1 requires level one to be marked for subcycling");
-  if (!policy.root_iteration_zero || !policy.level_clocks_zero)
+  if (policy.recovering) {
+    if (!policy.level_clocks_zero)
+      throw std::invalid_argument(
+          "static-v1 recovery requires freshly rebuilt zero level clocks");
+  } else if (!policy.root_iteration_zero || !policy.level_clocks_zero) {
     throw std::invalid_argument(
         "static-v1 requires zero root and level clocks at a new start");
+  }
   if (!policy.complete_method_schema)
     throw std::invalid_argument(
         "static-v1 requires a frozen complete ODE method/group schema");
@@ -143,17 +145,25 @@ validate_static_v1_policy_envelope(const StaticV1PolicyEnvelope &policy) {
 
 inline bool has_exact_static_v1_test_odesolvers2_active_thorns(
     std::vector<std::string> active_thorns) {
-  static const std::array<const char *, 14> expected{
+  static const std::array<const char *, 14> p1_expected{
       "AMReX",          "Arith", "BoxInBox",    "Cactus", "CarpetX",
       "CarpetXRegrid",  "IOUtil", "Loop",        "MPI",    "NSIMD",
       "ODESolvers",     "TestODESolvers2", "yaml_cpp", "zlib"};
+  static const std::array<const char *, 16> p2_checkpoint_expected{
+      "AMReX",         "Arith",       "BoxInBox", "Cactus",
+      "CarpetX",       "CarpetXRegrid", "HDF5",   "IOUtil",
+      "Loop",          "MPI",         "NSIMD",    "ODESolvers",
+      "Silo",          "TestODESolvers2", "yaml_cpp", "zlib"};
   std::sort(active_thorns.begin(), active_thorns.end());
-  return active_thorns.size() == expected.size() &&
-         std::equal(active_thorns.begin(), active_thorns.end(),
-                    expected.begin(), [](const std::string &active,
-                                         const char *const required) {
-                      return active == required;
-                    });
+  const auto matches = [&](const auto &expected) {
+    return active_thorns.size() == expected.size() &&
+           std::equal(active_thorns.begin(), active_thorns.end(),
+                      expected.begin(), [](const std::string &active,
+                                           const char *const required) {
+                        return active == required;
+                      });
+  };
+  return matches(p1_expected) || matches(p2_checkpoint_expected);
 }
 
 // Accepted active-level GF history must rotate before the canonical TL0

--- a/CarpetX/src/subcycling_static_v1_contract.hxx
+++ b/CarpetX/src/subcycling_static_v1_contract.hxx
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -28,8 +29,12 @@ struct StaticV1LevelOneCreationEnvelope {
   int regrid_every;
   int coarse_patch;
   int coarse_level;
-  int coarse_iteration;
-  int coarse_delta_iteration;
+  struct StaticV1Rational {
+    std::int64_t numerator;
+    std::int64_t denominator;
+  };
+  StaticV1Rational coarse_iteration;
+  StaticV1Rational coarse_delta_iteration;
   bool coarse_is_subcycling_level;
   std::array<int, 3> spatial_refinement_ratio;
   double callback_time;
@@ -43,13 +48,22 @@ constexpr bool permits_static_v1_level_one_creation(
          envelope.configured_level_count == 2 &&
          envelope.existing_level_count == 1 && envelope.regrid_every == 0 &&
          envelope.coarse_patch == 0 && envelope.coarse_level == 0 &&
-         envelope.coarse_iteration == 0 &&
-         envelope.coarse_delta_iteration == 1 &&
+         envelope.coarse_iteration.numerator == 0 &&
+         envelope.coarse_iteration.denominator == 1 &&
+         envelope.coarse_delta_iteration.numerator == 1 &&
+         envelope.coarse_delta_iteration.denominator == 1 &&
          !envelope.coarse_is_subcycling_level &&
          envelope.spatial_refinement_ratio[0] == 2 &&
          envelope.spatial_refinement_ratio[1] == 2 &&
          envelope.spatial_refinement_ratio[2] == 2 &&
          envelope.callback_time == 0.0;
+}
+
+using StaticV1Rational = StaticV1LevelOneCreationEnvelope::StaticV1Rational;
+
+constexpr int
+static_v1_parent_refinement_ratio_index(const int callback_level) noexcept {
+  return callback_level - 1;
 }
 
 constexpr bool should_stop_static_v1_initial_regrid_loop(

--- a/CarpetX/src/subcycling_static_v1_top_adapter.cxx
+++ b/CarpetX/src/subcycling_static_v1_top_adapter.cxx
@@ -1,0 +1,796 @@
+#include "subcycling_static_v1_top_adapter.hxx"
+
+#include "driver.hxx"
+#include "hierarchy_stepper.hxx"
+#include "schedule.hxx"
+#include "subcycling_native_gate.hxx"
+#include "subcycling_runtime_clock.hxx"
+#include "subcycling_schedule_certification.hxx"
+#include "subcycling_schedule_state.hxx"
+#include "subcycling_scratch_adapter.hxx"
+#include "subcycling_scratch_state_transaction_factory.hxx"
+#include "subcycling_stage_spatial_preparer.hxx"
+#include "subcycling_step_context.hxx"
+#include "transaction_level_step_session.hxx"
+
+#include <cctk.h>
+#include <cctk_ActiveThorns.h>
+#include <cctk_Groups.h>
+#include <cctk_Parameters.h>
+#include <cctk_Schedule.h>
+
+#include <AMReX_IntVect.H>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace CarpetX {
+namespace {
+
+using LevelData = GHExt::PatchData::LevelData;
+using GroupData = GHExt::PatchData::LevelData::GroupData;
+
+step_clock_t exact_clock(const rat64 value) {
+  return step_clock_t(value.num, value.den);
+}
+
+rat64 level_clock(const step_clock_t value) {
+  return rat64(value.num, value.den);
+}
+
+bool ratio_is_two(const amrex::IntVect &ratio) noexcept {
+  for (int direction = 0; direction < AMREX_SPACEDIM; ++direction)
+    if (ratio[direction] != 2)
+      return false;
+  return true;
+}
+
+bool same_step_context(const StepContext &left,
+                       const StepContext &right) noexcept {
+  return left.level == right.level &&
+         left.begin_clock == right.begin_clock &&
+         left.end_clock == right.end_clock &&
+         left.begin_time == right.begin_time &&
+         left.end_time == right.end_time && left.method == right.method &&
+         left.require_dense_output == right.require_dense_output &&
+         left.endpoint_accepted_step == right.endpoint_accepted_step;
+}
+
+std::vector<int>
+contract_groups(const SubcyclingGroupSchema &group_schema) {
+  std::vector<int> groups;
+  groups.reserve(2 * group_schema.ordered_group_pairs.size() +
+                 group_schema.dependent_groups.size());
+  for (const auto &pair : group_schema.ordered_group_pairs) {
+    groups.push_back(pair.evolved_group);
+    groups.push_back(pair.rhs_group);
+  }
+  groups.insert(groups.end(), group_schema.dependent_groups.begin(),
+                group_schema.dependent_groups.end());
+  std::sort(groups.begin(), groups.end());
+  groups.erase(std::unique(groups.begin(), groups.end()), groups.end());
+  return groups;
+}
+
+bool bounded_test_odesolvers2_schema(
+    const SubcyclingGroupSchema &group_schema) {
+  const int state = CCTK_GroupIndex("TestODESolvers2::state");
+  const int rhs = CCTK_GroupIndex("TestODESolvers2::rhs");
+  const int dependent =
+      CCTK_GroupIndex("TestODESolvers2::gate_dependent");
+  std::vector<int> expected_dependents{rhs, dependent};
+  std::sort(expected_dependents.begin(), expected_dependents.end());
+  const auto *const native_gate = static_cast<const CCTK_INT *>(
+      CCTK_ParameterGet("native_subcycling_gate", "TestODESolvers2",
+                        nullptr));
+  return state >= 0 && rhs >= 0 && dependent >= 0 && native_gate != nullptr &&
+         *native_gate == 0 &&
+         group_schema.ordered_group_pairs.size() == 1 &&
+         group_schema.ordered_group_pairs.front().evolved_group == state &&
+         group_schema.ordered_group_pairs.front().rhs_group == rhs &&
+         group_schema.dependent_groups == expected_dependents;
+}
+
+bool bounded_test_odesolvers2_active_thorns() {
+  const int compiled_count = CCTK_NumCompiledThorns();
+  if (compiled_count < 0)
+    return false;
+  std::vector<std::string> active_thorns;
+  active_thorns.reserve(static_cast<std::size_t>(compiled_count));
+  for (int index = 0; index < compiled_count; ++index) {
+    const char *const thorn = CCTK_CompiledThorn(index);
+    if (thorn == nullptr)
+      return false;
+    const int active = CCTK_IsThornActive(thorn);
+    if (active < 0)
+      return false;
+    if (active != 0)
+      active_thorns.emplace_back(thorn);
+  }
+  return has_exact_static_v1_test_odesolvers2_active_thorns(
+      std::move(active_thorns));
+}
+
+bool cactus_group_is_gf_real(const int group_index) {
+  cGroup group{};
+  return group_index >= 0 && group_index < CCTK_NumGroups() &&
+         CCTK_GroupData(group_index, &group) == 0 &&
+         group.grouptype == CCTK_GF &&
+         group.vartype == CCTK_VARIABLE_REAL && group.numvars > 0;
+}
+
+bool schema_is_supported(const GHExt &driver,
+                         const SubcyclingGroupSchema &group_schema) {
+  if (group_schema.ordered_group_pairs.empty())
+    return false;
+
+  const auto groups = contract_groups(group_schema);
+  for (const int group : groups)
+    if (!cactus_group_is_gf_real(group))
+      return false;
+
+  for (const auto &pair : group_schema.ordered_group_pairs) {
+    cGroup evolved{};
+    cGroup rhs{};
+    if (pair.evolved_group == pair.rhs_group ||
+        CCTK_GroupData(pair.evolved_group, &evolved) != 0 ||
+        CCTK_GroupData(pair.rhs_group, &rhs) != 0 ||
+        evolved.numvars != rhs.numvars || evolved.numtimelevels != 1)
+      return false;
+  }
+
+  if (driver.patchdata.size() != 1 ||
+      driver.patchdata.front().leveldata.size() != 2)
+    return false;
+  for (const auto &level : driver.patchdata.front().leveldata) {
+    for (const int group : groups) {
+      if (group < 0 ||
+          static_cast<std::size_t>(group) >= level.groupdata.size() ||
+          level.groupdata[static_cast<std::size_t>(group)] == nullptr)
+        return false;
+      const auto &data =
+          *level.groupdata[static_cast<std::size_t>(group)];
+      if (data.groupindex != group || data.mfab.empty() ||
+          data.valid.empty() || data.mfab.size() != data.valid.size() ||
+          data.numvars <= 0)
+        return false;
+      for (std::size_t tl = 0; tl < data.mfab.size(); ++tl)
+        if (data.mfab[tl] == nullptr || !data.mfab[tl]->isDefined() ||
+            data.mfab[tl]->nComp() != data.numvars ||
+            data.valid[tl].size() !=
+                static_cast<std::size_t>(data.numvars) ||
+            !data.mfab[tl]->boxArray().ok())
+          return false;
+    }
+    for (const auto &pair : group_schema.ordered_group_pairs) {
+      const auto &evolved = *level.groupdata.at(
+          static_cast<std::size_t>(pair.evolved_group));
+      if (evolved.mfab.size() != 1 || evolved.valid.size() != 1 ||
+          evolved.valid.front().size() !=
+              static_cast<std::size_t>(evolved.numvars))
+        return false;
+    }
+  }
+  return true;
+}
+
+struct GroupContractIdentity {
+  int group_index;
+  const GroupData *group_identity;
+  int numvars;
+  bool do_restrict;
+  std::size_t timelevel_count;
+  std::size_t validity_timelevel_count;
+  std::vector<const void *> storage_identities;
+  std::vector<const void *> validity_identities;
+};
+
+struct LevelContractIdentity {
+  const LevelData *level_identity;
+  const cGH *patch_gh_identity;
+  const amrex::FabArrayBase *fab_identity;
+  rat64 delta_iteration;
+  bool is_subcycling_level;
+  std::vector<GroupContractIdentity> groups;
+};
+
+LevelContractIdentity
+capture_level_contract(const LevelData &level,
+                       const std::vector<int> &groups) {
+  LevelContractIdentity result{&level, level.get_patch_cctkGH(), level.fab.get(),
+                               level.delta_iteration,
+                               level.is_subcycling_level, {}};
+  result.groups.reserve(groups.size());
+  for (const int group : groups) {
+    const auto &data =
+        *level.groupdata.at(static_cast<std::size_t>(group));
+    std::vector<const void *> storage_identities;
+    std::vector<const void *> validity_identities;
+    storage_identities.reserve(data.mfab.size());
+    validity_identities.reserve(data.valid.size());
+    for (const auto &storage : data.mfab)
+      storage_identities.push_back(storage.get());
+    for (const auto &validity : data.valid)
+      validity_identities.push_back(validity.data());
+    const auto canonicalize = [](auto &identities) {
+      std::sort(identities.begin(), identities.end(),
+                std::less<const void *>{});
+    };
+    canonicalize(storage_identities);
+    canonicalize(validity_identities);
+    result.groups.push_back({group,
+                             &data,
+                             data.numvars,
+                             data.do_restrict,
+                             data.mfab.size(),
+                             data.valid.size(),
+                             std::move(storage_identities),
+                             std::move(validity_identities)});
+  }
+  return result;
+}
+
+struct StaticV1Preflight {
+  GHExt *driver;
+  SubcyclingMethodContractSnapshot method_snapshot;
+  std::int64_t hierarchy_epoch;
+  double initial_physical_time;
+  double base_delta_time;
+  std::vector<int> restricted_evolved_groups;
+  std::array<LevelContractIdentity, 2> level_contracts;
+};
+
+StaticV1Preflight preflight_static_v1(cGH &root,
+                                      const bool recovering) {
+  DECLARE_CCTK_PARAMETERS;
+
+  if (!ghext)
+    throw std::invalid_argument("static-v1 requires an active CarpetX GHExt");
+  if (!in_global_mode(&root))
+    throw std::invalid_argument(
+        "static-v1 requires the root GH to be in global mode");
+
+  auto method_snapshot =
+      require_complete_registered_subcycling_method_contract();
+  validate_registered_subcycling_method_contract(method_snapshot);
+  if (!method_snapshot.group_schema)
+    throw std::logic_error(
+        "static-v1 complete method snapshot lost its group schema");
+
+  const int patch_count = static_cast<int>(ghext->patchdata.size());
+  const int level_count =
+      patch_count == 1
+          ? static_cast<int>(ghext->patchdata.front().leveldata.size())
+          : 0;
+  int spatial_refinement_ratio = -1;
+  if (patch_count == 1 && level_count == 2 &&
+      ghext->patchdata.front().amrcore != nullptr &&
+      ratio_is_two(ghext->patchdata.front().amrcore->refRatio(0)))
+    spatial_refinement_ratio = 2;
+
+  bool level_clocks_zero = level_count == 2;
+  bool level_one_subcycles = false;
+  if (level_count == 2) {
+    const auto &levels = ghext->patchdata.front().leveldata;
+    level_clocks_zero =
+        exact_clock(levels[0].iteration) == step_clock_t(0) &&
+        exact_clock(levels[1].iteration) == step_clock_t(0);
+    level_one_subcycles = levels[1].is_subcycling_level;
+  }
+  const bool supported_schema =
+      schema_is_supported(*ghext, *method_snapshot.group_schema);
+  const bool bounded_configuration =
+      method_snapshot.contract.provider_id == "ODESolvers::method" &&
+      bounded_test_odesolvers2_schema(*method_snapshot.group_schema) &&
+      bounded_test_odesolvers2_active_thorns();
+
+  validate_static_v1_policy_envelope(StaticV1PolicyEnvelope{
+      patch_count,
+      level_count,
+      spatial_refinement_ratio,
+      regrid_every,
+      recovering,
+      bool(do_reflux),
+      bool(do_restrict),
+      bool(restrict_during_sync),
+      bool(poison_undefined_values),
+      level_one_subcycles,
+      root.cctk_iteration == 0,
+      level_clocks_zero,
+      true,
+      supported_schema,
+      bounded_configuration});
+
+  const auto &levels = ghext->patchdata.front().leveldata;
+  for (std::size_t level = 0; level < levels.size(); ++level) {
+    const auto &data = levels[level];
+    if (data.patch != 0 || data.level != static_cast<int>(level) ||
+        data.fab == nullptr || data.get_patch_cctkGH() == nullptr ||
+        data.fab->boxArray().d_numPts() <= 0)
+      throw std::invalid_argument(
+          "static-v1 requires initialized, non-empty level and patch-GH "
+          "storage for levels zero and one");
+  }
+  validate_static_v1_clock_envelope(StaticV1ClockEnvelope{
+      2,
+      2,
+      recovering,
+      regrid_every != 0,
+      step_clock_t(0),
+      {exact_clock(levels[0].iteration),
+       exact_clock(levels[1].iteration)},
+      {exact_clock(levels[0].delta_iteration),
+       exact_clock(levels[1].delta_iteration)},
+      0,
+      {0, 0}});
+
+  if (!std::isfinite(root.cctk_time))
+    throw std::invalid_argument(
+        "static-v1 initial physical time must be finite");
+  const double base_delta_time =
+      static_v1_base_delta_time(root.cctk_delta_time, level_count);
+  const auto groups = contract_groups(*method_snapshot.group_schema);
+  std::vector<int> restricted_evolved_groups;
+  restricted_evolved_groups.reserve(
+      method_snapshot.group_schema->ordered_group_pairs.size());
+  for (const auto &pair :
+       method_snapshot.group_schema->ordered_group_pairs) {
+    const auto &coarse_evolved = *levels[0].groupdata.at(
+        static_cast<std::size_t>(pair.evolved_group));
+    const auto &fine_evolved = *levels[1].groupdata.at(
+        static_cast<std::size_t>(pair.evolved_group));
+    if (!coarse_evolved.do_restrict || !fine_evolved.do_restrict)
+      throw std::invalid_argument(
+          "static-v1 requires restriction enabled for every evolved group");
+    if (std::find(restricted_evolved_groups.begin(),
+                  restricted_evolved_groups.end(),
+                  pair.evolved_group) != restricted_evolved_groups.end())
+      throw std::invalid_argument(
+          "static-v1 evolved group schema contains a duplicate group");
+    restricted_evolved_groups.push_back(pair.evolved_group);
+  }
+
+  const auto hierarchy_epoch =
+      static_cast<std::int64_t>(CarpetX_GetEpoch());
+  if (hierarchy_epoch < 0)
+    throw std::invalid_argument(
+        "static-v1 hierarchy epoch must be non-negative");
+
+  return StaticV1Preflight{
+      ghext.get(),
+      std::move(method_snapshot),
+      hierarchy_epoch,
+      root.cctk_time,
+      base_delta_time,
+      std::move(restricted_evolved_groups),
+      {capture_level_contract(levels[0], groups),
+       capture_level_contract(levels[1], groups)}};
+}
+
+struct BeginLevelSnapshot {
+  std::array<rat64, 2> clocks;
+  rat64 endpoint_clock;
+};
+
+class StaticV1EvolutionAdapter final : public HierarchyEvolutionAdapter {
+public:
+  StaticV1EvolutionAdapter(cGH &root, StaticV1Preflight preflight)
+      : root_(root), driver_(preflight.driver),
+        method_snapshot_(std::move(preflight.method_snapshot)),
+        hierarchy_epoch_(preflight.hierarchy_epoch),
+        initial_physical_time_(preflight.initial_physical_time),
+        base_delta_time_(preflight.base_delta_time),
+        restricted_evolved_groups_(
+            std::move(preflight.restricted_evolved_groups)),
+        level_contracts_(std::move(preflight.level_contracts)) {
+    schedule_registry_ = load_certified_local_schedule_registry();
+    dense_provider_ = std::make_shared<const DenseOutputProvider>(
+        method_snapshot_.contract.dense);
+    dense_registry_.register_provider(dense_provider_);
+    stage_preparer_ = std::make_unique<TwoLevelStageSpatialPreparer>(
+        *driver_,
+        StageSpatialScheduleOwnership::certified_local_no_global_sync);
+
+    const LevelAdvanceConfig method{
+        method_snapshot_.contract.dense.method,
+        method_snapshot_.contract.dense.tableau_fingerprint};
+    HierarchyStepperConfig config{
+        {method, method}, step_clock_t(0), initial_physical_time_,
+        base_delta_time_, 2, 0, {0, 0}};
+    stepper_ =
+        std::make_unique<HierarchyStepper>(std::move(config), dense_registry_);
+
+    // Everything above is preflight/read-only. This is the single transition
+    // from the legacy finest physical delta to the static-v1 coarse base delta.
+    const auto initial_metadata = full_sync_root_runtime_clock(
+        0, initial_physical_time_, base_delta_time_);
+    apply_persistent_metadata(initial_metadata);
+  }
+
+  HierarchyAdvanceResult advance_one_epoch() {
+    return stepper_->advance_one_epoch(*this);
+  }
+
+  double weighted_cells_per_epoch() const {
+    validate_immutable_contract();
+    const auto &levels = driver_->patchdata.front().leveldata;
+    return levels[0].fab->boxArray().d_numPts() +
+           2.0 * levels[1].fab->boxArray().d_numPts();
+  }
+
+  std::unique_ptr<LevelStepSession>
+  begin_level_step(const StepContext &context,
+                   const bool require_dense) override {
+    const auto begin = validate_begin_context(context, require_dense);
+    return with_candidate_scope(context, [&]() {
+      const auto &schema = *method_snapshot_.group_schema;
+      auto frame = cycle_then_capture_static_v1_level_state(
+          [&] {
+            ScheduleInternal::cycle_active_level_grid_function_timelevels(
+                &root_);
+          },
+          [&] {
+            return copy_canonical_tl0_collective(*driver_, 0,
+                                                 context.level);
+          });
+      ScratchStateTransactionFactoryMetadata metadata{
+          hierarchy_epoch_,
+          1,
+          2,
+          static_cast<int>(context.endpoint_accepted_step),
+          step_clock_t(1),
+          base_delta_time_,
+          context.level == 0 ? 1 : 2,
+          false,
+          schema.ordered_group_pairs,
+          schema.dependent_groups,
+          {},
+          {}};
+      auto transaction = ScratchStateTransactionFactory::create_native(
+          *driver_, *schedule_registry_, std::move(frame),
+          std::move(metadata));
+
+      TransactionLevelEvolution evolution =
+          [this, context](ScratchStateTransaction &transaction) {
+            with_candidate_scope(context, [&] {
+              const auto *const active_context = current_step_context();
+              if (active_context == nullptr ||
+                  !same_step_context(*active_context, context) ||
+                  current_scratch_state_transaction() != &transaction)
+                throw std::logic_error(
+                    "static-v1 evolution lost its active step transaction");
+              CCTK_Traverse(&root_, "CCTK_PRESTEP");
+              CCTK_Traverse(&root_, "CCTK_EVOL");
+            });
+          };
+      ValidatedLevelCommit commit = [this, context, begin] {
+        auto &target = validate_commit_target(context, begin);
+        // All throwing work is complete. This is the callback's only mutation
+        // and there is deliberately no operation after it.
+        target.iteration = begin.endpoint_clock;
+      };
+      return std::make_unique<TransactionLevelStepSession>(
+          std::move(transaction), require_dense, std::move(evolution),
+          std::move(commit));
+    });
+  }
+
+  void prepare_stage(const StepContext &context,
+                     const StagePoint &stage_point,
+                     const DenseInterval *parent_dense) override {
+    const auto *const active_context = current_step_context();
+    auto *const transaction = current_scratch_state_transaction();
+    if (active_context == nullptr ||
+        !same_step_context(*active_context, context) || transaction == nullptr)
+      throw std::logic_error(
+          "static-v1 stage preparation has no active transaction");
+    stage_preparer_->prepare(*transaction, context, stage_point, parent_dense);
+  }
+
+  void begin_synchronization(const int coarse_level, const int fine_level,
+                             const hierarchy_time_t time) override {
+    if (synchronization_active_ || coarse_level != 0 || fine_level != 1)
+      throw std::logic_error(
+          "static-v1 received an invalid synchronization pair");
+    validate_immutable_contract();
+    const auto &levels = driver_->patchdata.front().leveldata;
+    if (exact_clock(levels[0].iteration) != time ||
+        exact_clock(levels[1].iteration) != time)
+      throw std::logic_error(
+          "static-v1 levels are not aligned before synchronization");
+    synchronization_active_ = true;
+  }
+
+  void synchronize_levels(const int coarse_level, const int fine_level,
+                          const hierarchy_time_t time) override {
+    if (!synchronization_active_ || coarse_level != 0 || fine_level != 1)
+      throw std::logic_error(
+          "static-v1 synchronization scope is not active");
+    if (time.den != 1 || time.num < 0)
+      throw std::logic_error(
+          "static-v1 synchronization clock is not a coarse endpoint");
+    const double physical_time =
+        initial_physical_time_ + static_cast<double>(time) * base_delta_time_;
+    const auto runtime = full_sync_root_runtime_clock(
+        static_cast<std::uint64_t>(time.num), physical_time,
+        base_delta_time_);
+    const ScheduleInternal::LevelTimeMetadata<CCTK_REAL> metadata{
+        runtime.iteration, runtime.end_time, runtime.base_delta_time,
+        runtime.timefac};
+    ScheduleInternal::ScopedLevelTimeMetadata<cGH, PropagateRootMetadata>
+        synchronized(root_, metadata, PropagateRootMetadata{});
+    ScheduleInternal::restrict_and_sync_static_v1_evolved_groups(
+        &root_, restricted_evolved_groups_);
+  }
+
+  void end_synchronization(const int, const int,
+                           const hierarchy_time_t) noexcept override {
+    synchronization_active_ = false;
+  }
+
+  void run_sync_observers(const hierarchy_time_t time,
+                          const double physical_time,
+                          const std::uint64_t completed_epoch,
+                          const bool stop_requested) override {
+    static_cast<void>(stop_requested);
+    validate_immutable_contract();
+    const auto &levels = driver_->patchdata.front().leveldata;
+    const auto &stepper_clocks = stepper_->clocks();
+    if (stepper_clocks.size() != 2)
+      throw std::logic_error(
+          "static-v1 stepper lost its two-level clock inventory");
+    validate_static_v1_clock_envelope(StaticV1ClockEnvelope{
+        2,
+        2,
+        false,
+        false,
+        time,
+        {exact_clock(levels[0].iteration),
+         exact_clock(levels[1].iteration)},
+        {exact_clock(levels[0].delta_iteration),
+         exact_clock(levels[1].delta_iteration)},
+        completed_epoch,
+        {stepper_clocks[0].accepted_steps,
+         stepper_clocks[1].accepted_steps}});
+
+    const auto metadata = full_sync_root_runtime_clock(
+        completed_epoch, physical_time, base_delta_time_);
+    apply_persistent_metadata(metadata);
+
+    ScheduleInternal::ScopedActiveLevels<active_levels_t> all_levels(
+        active_levels, active_levels_t(0, 2, 0, 1));
+    for (const auto action : static_v1_sync_observer_order()) {
+      switch (action) {
+      case StaticV1SyncObserverAction::cycle_synchronized_globals:
+        ScheduleInternal::cycle_synchronized_global_timelevels(&root_);
+        break;
+      case StaticV1SyncObserverAction::postrestrict:
+        CCTK_Traverse(&root_, "CCTK_POSTRESTRICT");
+        break;
+      case StaticV1SyncObserverAction::poststep:
+        CCTK_Traverse(&root_, "CCTK_POSTSTEP");
+        break;
+      case StaticV1SyncObserverAction::analysis:
+        CCTK_Traverse(&root_, "CCTK_ANALYSIS");
+        break;
+      case StaticV1SyncObserverAction::output:
+        CCTK_OutputGH(&root_);
+        break;
+      case StaticV1SyncObserverAction::checkpoint:
+        CCTK_Traverse(&root_, "CCTK_CHECKPOINT");
+        break;
+      }
+    }
+  }
+
+private:
+  struct PropagateRootMetadata {
+    void operator()(cGH &root) const noexcept {
+      ScheduleInternal::propagate_root_runtime_metadata(root);
+    }
+  };
+
+  template <class Function>
+  auto with_candidate_scope(const StepContext &context, Function &&function)
+      -> std::invoke_result_t<Function> {
+    const auto runtime =
+        candidate_runtime_clock(context, base_delta_time_);
+    const ScheduleInternal::LevelTimeMetadata<CCTK_REAL> metadata{
+        runtime.iteration, runtime.end_time, runtime.base_delta_time,
+        runtime.timefac};
+    ScheduleInternal::ScopedActiveLevels<active_levels_t> requested_level(
+        active_levels,
+        active_levels_t(context.level, context.level + 1, 0, 1));
+    ScheduleInternal::ScopedLevelTimeMetadata<cGH, PropagateRootMetadata>
+        candidate(root_, metadata, PropagateRootMetadata{});
+    return std::forward<Function>(function)();
+  }
+
+  void apply_persistent_metadata(
+      const RuntimeClockMetadata &runtime) noexcept {
+    ScheduleInternal::apply_level_time_metadata(
+        root_, ScheduleInternal::LevelTimeMetadata<CCTK_REAL>{
+                   runtime.iteration, runtime.end_time,
+                   runtime.base_delta_time, runtime.timefac});
+    ScheduleInternal::propagate_root_runtime_metadata(root_);
+  }
+
+  void validate_immutable_contract() const {
+    if (!ghext || ghext.get() != driver_ ||
+        static_cast<std::int64_t>(CarpetX_GetEpoch()) != hierarchy_epoch_ ||
+        driver_->patchdata.size() != 1 ||
+        driver_->patchdata.front().leveldata.size() != 2)
+      throw std::runtime_error(
+          "static-v1 hierarchy identity changed after preflight");
+    validate_registered_subcycling_method_contract(method_snapshot_);
+
+    const auto &levels = driver_->patchdata.front().leveldata;
+    for (std::size_t level_index = 0; level_index < levels.size();
+         ++level_index) {
+      const auto &level = levels[level_index];
+      const auto &expected = level_contracts_[level_index];
+      if (&level != expected.level_identity ||
+          level.get_patch_cctkGH() != expected.patch_gh_identity ||
+          level.fab.get() != expected.fab_identity ||
+          level.delta_iteration != expected.delta_iteration ||
+          level.is_subcycling_level != expected.is_subcycling_level ||
+          expected.groups.empty())
+        throw std::runtime_error(
+            "static-v1 LevelData identity or clock contract changed");
+      for (const auto &group : expected.groups) {
+        if (group.group_index < 0 ||
+            static_cast<std::size_t>(group.group_index) >=
+                level.groupdata.size() ||
+            level.groupdata[static_cast<std::size_t>(group.group_index)] ==
+                nullptr)
+          throw std::runtime_error(
+              "static-v1 group identity disappeared");
+        const auto &current = *level.groupdata[static_cast<std::size_t>(
+            group.group_index)];
+        std::vector<const void *> storage_identities;
+        std::vector<const void *> validity_identities;
+        storage_identities.reserve(current.mfab.size());
+        validity_identities.reserve(current.valid.size());
+        for (const auto &storage : current.mfab)
+          storage_identities.push_back(storage.get());
+        for (const auto &validity : current.valid)
+          validity_identities.push_back(validity.data());
+        const auto canonicalize = [](auto &identities) {
+          std::sort(identities.begin(), identities.end(),
+                    std::less<const void *>{});
+        };
+        canonicalize(storage_identities);
+        canonicalize(validity_identities);
+        if (&current != group.group_identity ||
+            current.numvars != group.numvars ||
+            current.do_restrict != group.do_restrict ||
+            current.mfab.size() != group.timelevel_count ||
+            current.valid.size() != group.validity_timelevel_count ||
+            current.mfab.empty() || current.valid.empty() ||
+            storage_identities != group.storage_identities ||
+            validity_identities != group.validity_identities)
+          throw std::runtime_error(
+              "static-v1 group storage contract changed");
+      }
+    }
+  }
+
+  BeginLevelSnapshot
+  validate_begin_context(const StepContext &context,
+                         const bool require_dense) const {
+    validate_immutable_contract();
+    if (context.level < 0 || context.level > 1 ||
+        context.method != method_snapshot_.contract.dense.method ||
+        require_dense != (context.level == 0) ||
+        context.require_dense_output != require_dense)
+      throw std::invalid_argument(
+          "static-v1 level-step context differs from the frozen method");
+    static_cast<void>(candidate_runtime_clock(context, base_delta_time_));
+
+    const auto &levels = driver_->patchdata.front().leveldata;
+    BeginLevelSnapshot begin{{levels[0].iteration, levels[1].iteration},
+                             level_clock(context.end_clock)};
+    if (exact_clock(begin.clocks[static_cast<std::size_t>(context.level)]) !=
+        context.begin_clock)
+      throw std::logic_error(
+          "static-v1 active LevelData clock differs from the step begin");
+    return begin;
+  }
+
+  LevelData &validate_commit_target(const StepContext &context,
+                                    const BeginLevelSnapshot &begin) {
+    validate_immutable_contract();
+    auto &levels = driver_->patchdata.front().leveldata;
+    if (levels[0].iteration != begin.clocks[0] ||
+        levels[1].iteration != begin.clocks[1] ||
+        exact_clock(levels[static_cast<std::size_t>(context.level)]
+                        .iteration) != context.begin_clock ||
+        exact_clock(begin.endpoint_clock) != context.end_clock)
+      throw std::logic_error(
+          "static-v1 LevelData clocks changed before accepted commit");
+    return levels[static_cast<std::size_t>(context.level)];
+  }
+
+  cGH &root_;
+  GHExt *const driver_;
+  const SubcyclingMethodContractSnapshot method_snapshot_;
+  const std::int64_t hierarchy_epoch_;
+  const double initial_physical_time_;
+  const double base_delta_time_;
+  const std::vector<int> restricted_evolved_groups_;
+  const std::array<LevelContractIdentity, 2> level_contracts_;
+  DenseOutputRegistry dense_registry_;
+  std::shared_ptr<const DenseOutputProvider> dense_provider_;
+  std::unique_ptr<CertifiedLocalScheduleRegistry> schedule_registry_;
+  std::unique_ptr<TwoLevelStageSpatialPreparer> stage_preparer_;
+  std::unique_ptr<HierarchyStepper> stepper_;
+  bool synchronization_active_{false};
+};
+
+} // namespace
+
+int EvolveStaticV1(tFleshConfig *const config) {
+  try {
+    if (config == nullptr || config->nGHs == 0 || config->GH == nullptr ||
+        config->GH[0] == nullptr)
+      throw std::invalid_argument(
+          "static-v1 requires a configured root grid hierarchy");
+    cGH &root = *config->GH[0];
+    auto preflight =
+        preflight_static_v1(root, config->recovered != 0);
+    StaticV1EvolutionAdapter adapter(root, std::move(preflight));
+
+#pragma omp critical
+    CCTK_VINFO("Starting static-v1 factor-two subcycling evolution...");
+
+    const double weighted_cells = adapter.weighted_cells_per_epoch();
+    double total_seconds = 0.0;
+    std::uint64_t coarse_epochs = 0;
+    while (!ScheduleInternal::evolution_is_done_at_sync(&root)) {
+      const auto started = std::chrono::steady_clock::now();
+      const auto result = adapter.advance_one_epoch();
+      const auto finished = std::chrono::steady_clock::now();
+      const double elapsed =
+          std::chrono::duration<double>(finished - started).count();
+      total_seconds += elapsed;
+      ++coarse_epochs;
+      const double rate = elapsed > 0.0 ? weighted_cells / elapsed : 0.0;
+#pragma omp critical
+      CCTK_VINFO("Static-v1 epoch: %llu   simulation time: %.17g   "
+                 "weighted cells: %.0f   weighted cell updates/s: %.17g",
+                 static_cast<unsigned long long>(result.epoch),
+                 result.synchronized_physical_time, weighted_cells, rate);
+    }
+
+    if (coarse_epochs > 0 && total_seconds > 0.0) {
+#pragma omp critical
+      CCTK_VINFO("Static-v1 performance: coarse epochs=%llu   "
+                 "evolution seconds=%.17g   average weighted cell updates/s="
+                 "%.17g",
+                 static_cast<unsigned long long>(coarse_epochs),
+                 total_seconds,
+                 coarse_epochs * weighted_cells / total_seconds);
+    }
+    return 0;
+  } catch (const std::exception &error) {
+    CCTK_VERROR("Static-v1 subcycling evolution failed closed: %s",
+                error.what());
+  } catch (...) {
+    CCTK_ERROR(
+        "Static-v1 subcycling evolution failed closed with an unknown error");
+  }
+  return -1;
+}
+
+} // namespace CarpetX

--- a/CarpetX/src/subcycling_static_v1_top_adapter.cxx
+++ b/CarpetX/src/subcycling_static_v1_top_adapter.cxx
@@ -245,7 +245,8 @@ struct StaticV1Preflight {
   GHExt *driver;
   SubcyclingMethodContractSnapshot method_snapshot;
   std::int64_t hierarchy_epoch;
-  double initial_physical_time;
+  bool recovering;
+  StaticV1StepperSeed stepper_seed;
   double base_delta_time;
   std::vector<int> restricted_evolved_groups;
   std::array<LevelContractIdentity, 2> level_contracts;
@@ -312,7 +313,7 @@ StaticV1Preflight preflight_static_v1(cGH &root,
       supported_schema,
       bounded_configuration});
 
-  const auto &levels = ghext->patchdata.front().leveldata;
+  auto &levels = ghext->patchdata.front().leveldata;
   for (std::size_t level = 0; level < levels.size(); ++level) {
     const auto &data = levels[level];
     if (data.patch != 0 || data.level != static_cast<int>(level) ||
@@ -322,24 +323,45 @@ StaticV1Preflight preflight_static_v1(cGH &root,
           "static-v1 requires initialized, non-empty level and patch-GH "
           "storage for levels zero and one");
   }
-  validate_static_v1_clock_envelope(StaticV1ClockEnvelope{
-      2,
-      2,
-      recovering,
-      regrid_every != 0,
-      step_clock_t(0),
-      {exact_clock(levels[0].iteration),
-       exact_clock(levels[1].iteration)},
-      {exact_clock(levels[0].delta_iteration),
-       exact_clock(levels[1].delta_iteration)},
-      0,
-      {0, 0}});
+  if (!recovering)
+    validate_static_v1_clock_envelope(StaticV1ClockEnvelope{
+        2,
+        2,
+        false,
+        regrid_every != 0,
+        step_clock_t(0),
+        {exact_clock(levels[0].iteration),
+         exact_clock(levels[1].iteration)},
+        {exact_clock(levels[0].delta_iteration),
+         exact_clock(levels[1].delta_iteration)},
+        0,
+        {0, 0}});
 
   if (!std::isfinite(root.cctk_time))
     throw std::invalid_argument(
         "static-v1 initial physical time must be finite");
   const double base_delta_time =
       static_v1_base_delta_time(root.cctk_delta_time, level_count);
+  StaticV1StepperSeed stepper_seed{
+      step_clock_t(0), root.cctk_time, 0, {0, 0}};
+  if (recovering) {
+    const auto *const recovery_mode = static_cast<const char *const *>(
+        CCTK_ParameterGet("recovery_mode", "Cactus", nullptr));
+    stepper_seed = static_v1_recovery_seed(StaticV1RecoverySeedEnvelope{
+        level_count,
+        spatial_refinement_ratio,
+        recovery_mode != nullptr && *recovery_mode != nullptr &&
+            CCTK_Equals(*recovery_mode, "strict"),
+        regrid_every != 0,
+        root.cctk_iteration,
+        root.cctk_timefac,
+        root.cctk_time,
+        base_delta_time,
+        {exact_clock(levels[0].iteration),
+         exact_clock(levels[1].iteration)},
+        {exact_clock(levels[0].delta_iteration),
+         exact_clock(levels[1].delta_iteration)}});
+  }
   const auto groups = contract_groups(*method_snapshot.group_schema);
   std::vector<int> restricted_evolved_groups;
   restricted_evolved_groups.reserve(
@@ -367,15 +389,17 @@ StaticV1Preflight preflight_static_v1(cGH &root,
     throw std::invalid_argument(
         "static-v1 hierarchy epoch must be non-negative");
 
-  return StaticV1Preflight{
+  StaticV1Preflight result{
       ghext.get(),
       std::move(method_snapshot),
       hierarchy_epoch,
-      root.cctk_time,
+      recovering,
+      stepper_seed,
       base_delta_time,
       std::move(restricted_evolved_groups),
       {capture_level_contract(levels[0], groups),
        capture_level_contract(levels[1], groups)}};
+  return result;
 }
 
 struct BeginLevelSnapshot {
@@ -389,7 +413,8 @@ public:
       : root_(root), driver_(preflight.driver),
         method_snapshot_(std::move(preflight.method_snapshot)),
         hierarchy_epoch_(preflight.hierarchy_epoch),
-        initial_physical_time_(preflight.initial_physical_time),
+        initial_clock_(preflight.stepper_seed.initial_clock),
+        initial_physical_time_(preflight.stepper_seed.initial_physical_time),
         base_delta_time_(preflight.base_delta_time),
         restricted_evolved_groups_(
             std::move(preflight.restricted_evolved_groups)),
@@ -406,15 +431,25 @@ public:
         method_snapshot_.contract.dense.method,
         method_snapshot_.contract.dense.tableau_fingerprint};
     HierarchyStepperConfig config{
-        {method, method}, step_clock_t(0), initial_physical_time_,
-        base_delta_time_, 2, 0, {0, 0}};
+        {method, method}, initial_clock_, initial_physical_time_,
+        base_delta_time_, 2, preflight.stepper_seed.initial_epoch,
+        {preflight.stepper_seed.initial_accepted_steps[0],
+         preflight.stepper_seed.initial_accepted_steps[1]}};
     stepper_ =
         std::make_unique<HierarchyStepper>(std::move(config), dense_registry_);
 
     // Everything above is preflight/read-only. This is the single transition
-    // from the legacy finest physical delta to the static-v1 coarse base delta.
+    // from the recovered SetupLevel clocks and legacy finest physical delta
+    // to the canonical static-v1 full-sync seed and coarse base delta.
+    if (preflight.recovering) {
+      auto &levels = driver_->patchdata.front().leveldata;
+      const auto synchronized_clock = level_clock(initial_clock_);
+      levels[0].iteration = synchronized_clock;
+      levels[1].iteration = synchronized_clock;
+    }
     const auto initial_metadata = full_sync_root_runtime_clock(
-        0, initial_physical_time_, base_delta_time_);
+        preflight.stepper_seed.initial_epoch, initial_physical_time_,
+        base_delta_time_);
     apply_persistent_metadata(initial_metadata);
   }
 
@@ -521,7 +556,8 @@ public:
       throw std::logic_error(
           "static-v1 synchronization clock is not a coarse endpoint");
     const double physical_time =
-        initial_physical_time_ + static_cast<double>(time) * base_delta_time_;
+        initial_physical_time_ +
+        static_cast<double>(time - initial_clock_) * base_delta_time_;
     const auto runtime = full_sync_root_runtime_clock(
         static_cast<std::uint64_t>(time.num), physical_time,
         base_delta_time_);
@@ -726,6 +762,7 @@ private:
   GHExt *const driver_;
   const SubcyclingMethodContractSnapshot method_snapshot_;
   const std::int64_t hierarchy_epoch_;
+  const hierarchy_time_t initial_clock_;
   const double initial_physical_time_;
   const double base_delta_time_;
   const std::vector<int> restricted_evolved_groups_;

--- a/CarpetX/src/subcycling_static_v1_top_adapter.hxx
+++ b/CarpetX/src/subcycling_static_v1_top_adapter.hxx
@@ -1,0 +1,14 @@
+#ifndef CARPETX_SUBCYCLING_STATIC_V1_TOP_ADAPTER_HXX
+#define CARPETX_SUBCYCLING_STATIC_V1_TOP_ADAPTER_HXX
+
+#include "subcycling_static_v1_contract.hxx"
+
+#include <cctk.h>
+
+namespace CarpetX {
+
+int EvolveStaticV1(tFleshConfig *config);
+
+} // namespace CarpetX
+
+#endif // CARPETX_SUBCYCLING_STATIC_V1_TOP_ADAPTER_HXX

--- a/CarpetX/src/subcycling_step_context.cxx
+++ b/CarpetX/src/subcycling_step_context.cxx
@@ -1,0 +1,116 @@
+#include "subcycling_step_context.hxx"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+namespace CarpetX {
+namespace {
+
+struct ActiveStepContext {
+  const StepContext *context{nullptr};
+  StagePreparer *preparer{nullptr};
+};
+
+thread_local ActiveStepContext active_step_context;
+thread_local ScratchStateTransaction *active_scratch_transaction{nullptr};
+
+} // namespace
+
+ScopedStepContext::ScopedStepContext(const StepContext &context,
+                                     StagePreparer &preparer)
+    : ScopedStepContext(context, preparer, nullptr) {}
+
+ScopedStepContext::ScopedStepContext(const StepContext &context,
+                                     StagePreparer &preparer,
+                                     ScratchStateTransaction *transaction)
+    : prior_transaction_(active_scratch_transaction) {
+  if (active_step_context.context != nullptr)
+    throw std::logic_error("a StepContext is already active on this thread");
+  if (context.level < 0)
+    throw std::invalid_argument("StepContext level must be non-negative");
+  if (!(context.begin_clock < context.end_clock))
+    throw std::invalid_argument("StepContext clocks must increase exactly");
+  if (!std::isfinite(context.begin_time) ||
+      !std::isfinite(context.end_time) ||
+      !(context.begin_time < context.end_time))
+    throw std::invalid_argument("StepContext times must be finite and increase");
+
+  active_step_context = ActiveStepContext{&context, &preparer};
+  active_scratch_transaction = transaction;
+}
+
+ScopedStepContext::~ScopedStepContext() {
+  active_step_context = ActiveStepContext{};
+  active_scratch_transaction = prior_transaction_;
+}
+
+const StepContext *current_step_context() noexcept {
+  return active_step_context.context;
+}
+
+bool step_context_active() noexcept {
+  return active_step_context.context != nullptr;
+}
+
+ScratchStateTransaction *current_scratch_state_transaction() noexcept {
+  return active_scratch_transaction;
+}
+
+void prepare_stage(const StagePoint &stage_point,
+                   const SubcyclingODEMethod method) {
+  const auto context = active_step_context.context;
+  if (context == nullptr)
+    return;
+  if (method != context->method)
+    throw std::invalid_argument("ODE method does not match active StepContext");
+  if (stage_point.stage_index <= 0 || stage_point.stage_count <= 0 ||
+      stage_point.stage_index > stage_point.stage_count)
+    throw std::invalid_argument("stage index/count are invalid");
+  switch (stage_point.kind) {
+  case StageKind::primary:
+  case StageKind::fractional:
+    break;
+  case StageKind::endpoint_probe:
+    if (stage_point.stage_index != 1 || stage_point.stage_count != 1)
+      throw std::invalid_argument(
+          "endpoint probe must use the singleton stage index");
+    break;
+  default:
+    throw std::invalid_argument("stage kind is invalid");
+  }
+  if (stage_point.stage_fraction < step_clock_t(0) ||
+      stage_point.stage_fraction > step_clock_t(1))
+    throw std::out_of_range("exact stage fraction is outside [0,1]");
+  if (!std::isfinite(stage_point.stage_time))
+    throw std::invalid_argument("stage time must be finite");
+
+  if (stage_point.kind != StageKind::primary &&
+      active_scratch_transaction == nullptr)
+    throw std::logic_error(
+        "auxiliary stage requires the active scratch transaction");
+
+  const auto time_scale =
+      std::max({1.0, std::abs(context->begin_time),
+                std::abs(context->end_time),
+                std::abs(stage_point.stage_time)});
+  const auto tolerance =
+      32.0 * std::numeric_limits<double>::epsilon() * time_scale;
+  if (stage_point.stage_time < context->begin_time - tolerance ||
+      stage_point.stage_time > context->end_time + tolerance)
+    throw std::out_of_range("stage time is outside the active StepContext");
+
+  const auto fraction = static_cast<double>(stage_point.stage_fraction);
+  const auto canonical_stage_time =
+      context->begin_time +
+      fraction * (context->end_time - context->begin_time);
+  if (!std::isfinite(canonical_stage_time) ||
+      std::abs(stage_point.stage_time - canonical_stage_time) > tolerance)
+    throw std::invalid_argument(
+        "stage time does not match the exact stage fraction");
+
+  active_step_context.preparer->prepare_stage(*context, stage_point);
+}
+
+} // namespace CarpetX

--- a/CarpetX/src/subcycling_step_context.hxx
+++ b/CarpetX/src/subcycling_step_context.hxx
@@ -1,0 +1,64 @@
+#ifndef CARPETX_SUBCYCLING_STEP_CONTEXT_HXX
+#define CARPETX_SUBCYCLING_STEP_CONTEXT_HXX
+
+#include <rational.hxx>
+
+#include <cstdint>
+
+namespace CarpetX {
+
+class ScratchStateTransaction;
+
+using step_clock_t = Arith::rational<std::int64_t>;
+
+enum class SubcyclingODEMethod { rk4, rkf78_order7, dp87_order8 };
+
+enum class StageKind : std::uint8_t { primary, fractional, endpoint_probe };
+
+struct StagePoint {
+  StageKind kind;
+  int stage_index;
+  int stage_count;
+  step_clock_t stage_fraction;
+  double stage_time;
+};
+
+struct StepContext {
+  int level;
+  step_clock_t begin_clock;
+  step_clock_t end_clock;
+  double begin_time;
+  double end_time;
+  SubcyclingODEMethod method;
+  bool require_dense_output{false};
+  std::uint64_t endpoint_accepted_step{0};
+};
+
+class StagePreparer {
+public:
+  virtual ~StagePreparer() = default;
+  virtual void prepare_stage(const StepContext &context,
+                             const StagePoint &stage_point) = 0;
+};
+
+class ScopedStepContext {
+public:
+  ScopedStepContext(const StepContext &context, StagePreparer &preparer);
+  ScopedStepContext(const StepContext &context, StagePreparer &preparer,
+                    ScratchStateTransaction *transaction);
+  ~ScopedStepContext();
+  ScopedStepContext(const ScopedStepContext &) = delete;
+  ScopedStepContext &operator=(const ScopedStepContext &) = delete;
+
+private:
+  ScratchStateTransaction *prior_transaction_{nullptr};
+};
+
+const StepContext *current_step_context() noexcept;
+bool step_context_active() noexcept;
+ScratchStateTransaction *current_scratch_state_transaction() noexcept;
+void prepare_stage(const StagePoint &stage_point, SubcyclingODEMethod method);
+
+} // namespace CarpetX
+
+#endif // CARPETX_SUBCYCLING_STEP_CONTEXT_HXX

--- a/CarpetX/src/transaction_level_step_session.cxx
+++ b/CarpetX/src/transaction_level_step_session.cxx
@@ -1,0 +1,110 @@
+#include "transaction_level_step_session.hxx"
+
+#include <exception>
+#include <stdexcept>
+#include <utility>
+
+namespace CarpetX {
+
+TransactionLevelStepSession::TransactionLevelStepSession(
+    std::unique_ptr<ScratchStateTransaction> transaction,
+    const bool require_dense, TransactionLevelEvolution evolution,
+    ValidatedLevelCommit validated_commit)
+    : transaction_(std::move(transaction)), require_dense_(require_dense),
+      evolution_(std::move(evolution)),
+      validated_commit_(std::move(validated_commit)) {
+  if (transaction_ == nullptr)
+    throw std::invalid_argument(
+        "transaction level session requires a transaction");
+  if (!evolution_)
+    throw std::invalid_argument(
+        "transaction level session requires an evolution callback");
+  primary_left_ = transaction_->capture_live_evolved();
+}
+
+TransactionLevelStepSession::~TransactionLevelStepSession() noexcept {
+  if (lifecycle_ != Lifecycle::committed &&
+      lifecycle_ != Lifecycle::rolled_back)
+    rollback_or_terminate();
+}
+
+ScratchStateTransaction *
+TransactionLevelStepSession::transaction() noexcept {
+  switch (lifecycle_) {
+  case Lifecycle::ready:
+  case Lifecycle::advancing:
+  case Lifecycle::advanced:
+  case Lifecycle::committing:
+    return transaction_.get();
+  case Lifecycle::committed:
+  case Lifecycle::rolled_back:
+    return nullptr;
+  }
+  return nullptr;
+}
+
+LevelAdvanceResult TransactionLevelStepSession::advance() {
+  if (lifecycle_ != Lifecycle::ready)
+    throw std::logic_error(
+        "transaction level session advance is not available");
+  lifecycle_ = Lifecycle::advancing;
+  try {
+    evolution_(*transaction_);
+    if (transaction_->faulted() || transaction_->discarded())
+      throw std::logic_error(
+          "level evolution left its transaction unavailable");
+
+    auto dense_interval = transaction_->take_committed_dense();
+    if (transaction_->faulted() || transaction_->discarded())
+      throw std::logic_error(
+          "dense publication left its transaction unavailable");
+    if (require_dense_ && dense_interval == nullptr)
+      throw std::logic_error(
+          "transaction level session requires a dense interval");
+    if (!require_dense_ && dense_interval != nullptr)
+      throw std::logic_error(
+          "transaction leaf level published an unexpected dense interval");
+
+    lifecycle_ = Lifecycle::advanced;
+    return LevelAdvanceResult{std::move(dense_interval)};
+  } catch (...) {
+    rollback_or_terminate();
+    throw;
+  }
+}
+
+void TransactionLevelStepSession::commit() {
+  if (lifecycle_ != Lifecycle::advanced)
+    throw std::logic_error(
+        "transaction level session has no accepted endpoint to commit");
+  lifecycle_ = Lifecycle::committing;
+  try {
+    if (validated_commit_)
+      validated_commit_();
+    if (transaction_->faulted() || transaction_->discarded())
+      throw std::logic_error(
+          "accepted metadata callback left its transaction unavailable");
+    transaction_->discard();
+    lifecycle_ = Lifecycle::committed;
+    transaction_.reset();
+  } catch (...) {
+    rollback_or_terminate();
+    throw;
+  }
+}
+
+void TransactionLevelStepSession::rollback_or_terminate() noexcept {
+  if (lifecycle_ == Lifecycle::committed ||
+      lifecycle_ == Lifecycle::rolled_back)
+    return;
+  if (transaction_ == nullptr || !primary_left_.valid())
+    std::terminate();
+  try {
+    transaction_->rollback_live_evolved(primary_left_);
+    lifecycle_ = Lifecycle::rolled_back;
+  } catch (...) {
+    std::terminate();
+  }
+}
+
+} // namespace CarpetX

--- a/CarpetX/src/transaction_level_step_session.cxx
+++ b/CarpetX/src/transaction_level_step_session.cxx
@@ -19,7 +19,7 @@ TransactionLevelStepSession::TransactionLevelStepSession(
   if (!evolution_)
     throw std::invalid_argument(
         "transaction level session requires an evolution callback");
-  primary_left_ = transaction_->capture_live_evolved();
+  transaction_->arm_live_evolved_rollback();
 }
 
 TransactionLevelStepSession::~TransactionLevelStepSession() noexcept {
@@ -84,6 +84,7 @@ void TransactionLevelStepSession::commit() {
     if (transaction_->faulted() || transaction_->discarded())
       throw std::logic_error(
           "accepted metadata callback left its transaction unavailable");
+    transaction_->disarm_live_evolved_rollback();
     transaction_->discard();
     lifecycle_ = Lifecycle::committed;
     transaction_.reset();
@@ -97,10 +98,10 @@ void TransactionLevelStepSession::rollback_or_terminate() noexcept {
   if (lifecycle_ == Lifecycle::committed ||
       lifecycle_ == Lifecycle::rolled_back)
     return;
-  if (transaction_ == nullptr || !primary_left_.valid())
+  if (transaction_ == nullptr)
     std::terminate();
   try {
-    transaction_->rollback_live_evolved(primary_left_);
+    transaction_->rollback_live_evolved();
     lifecycle_ = Lifecycle::rolled_back;
   } catch (...) {
     std::terminate();

--- a/CarpetX/src/transaction_level_step_session.hxx
+++ b/CarpetX/src/transaction_level_step_session.hxx
@@ -51,7 +51,6 @@ private:
   bool require_dense_{false};
   TransactionLevelEvolution evolution_;
   ValidatedLevelCommit validated_commit_;
-  ScratchStateToken primary_left_;
   Lifecycle lifecycle_{Lifecycle::ready};
 };
 

--- a/CarpetX/src/transaction_level_step_session.hxx
+++ b/CarpetX/src/transaction_level_step_session.hxx
@@ -1,0 +1,60 @@
+#ifndef CARPETX_TRANSACTION_LEVEL_STEP_SESSION_HXX
+#define CARPETX_TRANSACTION_LEVEL_STEP_SESSION_HXX
+
+#include "hierarchy_stepper.hxx"
+#include "subcycling_scratch_state_transaction.hxx"
+
+#include <functional>
+#include <memory>
+
+namespace CarpetX {
+
+using TransactionLevelEvolution =
+    std::function<void(ScratchStateTransaction &)>;
+
+// This callback is optional. A driver adapter must finish validation before
+// mutating accepted LevelData metadata and must not throw after mutation.
+using ValidatedLevelCommit = std::function<void()>;
+
+class TransactionLevelStepSession final : public LevelStepSession {
+public:
+  TransactionLevelStepSession(
+      std::unique_ptr<ScratchStateTransaction> transaction,
+      bool require_dense, TransactionLevelEvolution evolution,
+      ValidatedLevelCommit validated_commit = {});
+  ~TransactionLevelStepSession() noexcept override;
+
+  TransactionLevelStepSession(const TransactionLevelStepSession &) = delete;
+  TransactionLevelStepSession &
+  operator=(const TransactionLevelStepSession &) = delete;
+  TransactionLevelStepSession(TransactionLevelStepSession &&) = delete;
+  TransactionLevelStepSession &operator=(TransactionLevelStepSession &&) =
+      delete;
+
+  ScratchStateTransaction *transaction() noexcept override;
+  LevelAdvanceResult advance() override;
+  void commit() override;
+
+private:
+  enum class Lifecycle {
+    ready,
+    advancing,
+    advanced,
+    committing,
+    committed,
+    rolled_back,
+  };
+
+  void rollback_or_terminate() noexcept;
+
+  std::unique_ptr<ScratchStateTransaction> transaction_;
+  bool require_dense_{false};
+  TransactionLevelEvolution evolution_;
+  ValidatedLevelCommit validated_commit_;
+  ScratchStateToken primary_left_;
+  Lifecycle lifecycle_{Lifecycle::ready};
+};
+
+} // namespace CarpetX
+
+#endif // CARPETX_TRANSACTION_LEVEL_STEP_SESSION_HXX

--- a/CarpetX/test/hierarchy_stepper_unit.cxx
+++ b/CarpetX/test/hierarchy_stepper_unit.cxx
@@ -1,4 +1,5 @@
 #include "hierarchy_stepper.hxx"
+#include "subcycling_runtime_clock.hxx"
 
 #include <cassert>
 #include <atomic>
@@ -31,10 +32,13 @@ using CarpetX::LevelStepSession;
 using CarpetX::LevelAdvanceConfig;
 using CarpetX::LevelAdvanceResult;
 using CarpetX::ScratchStateTransaction;
+using CarpetX::StaticV1RecoverySeedEnvelope;
+using CarpetX::StaticV1StepperSeed;
 using CarpetX::StepContext;
 using CarpetX::SubcyclingODEMethod;
 using CarpetX::TableauFingerprint;
 using CarpetX::hierarchy_time_t;
+using CarpetX::static_v1_recovery_seed;
 
 std::string time_string(const hierarchy_time_t time) {
   return std::to_string(time.num) + "/" + std::to_string(time.den);
@@ -142,6 +146,7 @@ public:
   bool observers_saw_all_dense_released{false};
   bool observer_stop_requested{false};
   bool throw_during_observer{false};
+  std::vector<std::uint64_t> observer_epochs;
   std::function<void()> sync_observer_hook;
   std::size_t begin_level_step_calls{0};
   std::size_t committed_level_sessions{0};
@@ -308,6 +313,7 @@ public:
                           const double physical_time,
                           const std::uint64_t completed_epoch,
                           const bool stop_requested) override {
+    observer_epochs.push_back(completed_epoch);
     observer_stop_requested = stop_requested;
     observers_saw_all_dense_released = true;
     for (const auto &record : dense_lifetimes)
@@ -805,6 +811,61 @@ void test_recovery_metadata_initializes_epoch_clocks_and_step_counts() {
   assert(stepper.clocks()[1].accepted_steps == 16);
 }
 
+void test_reconstructed_epoch_matches_uninterrupted_next_epoch_trace() {
+  Fixture fixture(2);
+  fixture.config.initial_physical_time = 4.0;
+  fixture.config.coarse_dt = 0.25;
+  HierarchyStepper uninterrupted(fixture.config, fixture.registry);
+  RecordingAdapter uninterrupted_adapter(fixture.capabilities,
+                                          hierarchy_time_t(0), 4.0, 0.25);
+  uninterrupted.advance_one_epoch(uninterrupted_adapter);
+  uninterrupted.advance_one_epoch(uninterrupted_adapter);
+  const auto uninterrupted_result =
+      uninterrupted.advance_one_epoch(uninterrupted_adapter);
+
+  const StaticV1StepperSeed seed = static_v1_recovery_seed(
+      StaticV1RecoverySeedEnvelope{
+          2,
+          2,
+          true,
+          false,
+          2,
+          1,
+          4.5,
+          0.25,
+          {hierarchy_time_t(0), hierarchy_time_t(0)},
+          {hierarchy_time_t(1), hierarchy_time_t(1, 2)}});
+  auto recovered_config = fixture.config;
+  recovered_config.initial_clock = seed.initial_clock;
+  recovered_config.initial_physical_time = seed.initial_physical_time;
+  recovered_config.initial_epoch = seed.initial_epoch;
+  recovered_config.initial_accepted_steps = {
+      seed.initial_accepted_steps[0], seed.initial_accepted_steps[1]};
+  HierarchyStepper recovered(recovered_config, fixture.registry);
+  RecordingAdapter recovered_adapter(
+      fixture.capabilities, seed.initial_clock, seed.initial_physical_time,
+      fixture.config.coarse_dt);
+  const auto recovered_result = recovered.advance_one_epoch(recovered_adapter);
+
+  assert(recovered_result.synchronized_time ==
+         uninterrupted_result.synchronized_time);
+  assert(recovered_result.synchronized_physical_time ==
+         uninterrupted_result.synchronized_physical_time);
+  assert(recovered_result.epoch == uninterrupted_result.epoch);
+  assert(recovered_adapter.observer_epochs ==
+         std::vector<std::uint64_t>{3});
+  assert(recovered_adapter.observer_epochs.back() ==
+         uninterrupted_adapter.observer_epochs.back());
+  assert(recovered.clocks().size() == uninterrupted.clocks().size());
+  for (std::size_t level = 0; level < recovered.clocks().size(); ++level) {
+    assert(recovered.clocks()[level].time ==
+           uninterrupted.clocks()[level].time);
+    assert(recovered.clocks()[level].dt == uninterrupted.clocks()[level].dt);
+    assert(recovered.clocks()[level].accepted_steps ==
+           uninterrupted.clocks()[level].accepted_steps);
+  }
+}
+
 void test_stop_request_is_safe_from_an_asynchronous_thread() {
   Fixture fixture(2);
   HierarchyStepper stepper(fixture.config, fixture.registry);
@@ -848,6 +909,7 @@ int main() {
   test_endpoint_roundoff_is_canonicalized_before_parent_dense_evaluation();
   test_synchronization_scope_ends_and_releases_dense_on_failure();
   test_recovery_metadata_initializes_epoch_clocks_and_step_counts();
+  test_reconstructed_epoch_matches_uninterrupted_next_epoch_trace();
   test_stop_request_is_safe_from_an_asynchronous_thread();
   std::cout << "HierarchyStepper dense recursion tests passed\n";
   return 0;

--- a/CarpetX/test/hierarchy_stepper_unit.cxx
+++ b/CarpetX/test/hierarchy_stepper_unit.cxx
@@ -1,0 +1,854 @@
+#include "hierarchy_stepper.hxx"
+
+#include <cassert>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using CarpetX::DenseCapability;
+using CarpetX::DenseInterval;
+using CarpetX::DenseIntervalBuilder;
+using CarpetX::DenseIntervalId;
+using CarpetX::DenseOutputProvider;
+using CarpetX::DenseOutputRegistry;
+using CarpetX::DenseStateVector;
+using CarpetX::HierarchyAdvanceResult;
+using CarpetX::HierarchyEvolutionAdapter;
+using CarpetX::HierarchyStepper;
+using CarpetX::HierarchyStepperConfig;
+using CarpetX::LevelStepSession;
+using CarpetX::LevelAdvanceConfig;
+using CarpetX::LevelAdvanceResult;
+using CarpetX::ScratchStateTransaction;
+using CarpetX::StepContext;
+using CarpetX::SubcyclingODEMethod;
+using CarpetX::TableauFingerprint;
+using CarpetX::hierarchy_time_t;
+
+std::string time_string(const hierarchy_time_t time) {
+  return std::to_string(time.num) + "/" + std::to_string(time.den);
+}
+
+TableauFingerprint fingerprint(const std::uint8_t marker) {
+  TableauFingerprint result{};
+  result.fill(marker);
+  return result;
+}
+
+DenseCapability capability(const SubcyclingODEMethod method,
+                           const TableauFingerprint &tableau_fingerprint) {
+  switch (method) {
+  case SubcyclingODEMethod::rk4:
+    return DenseCapability{method, tableau_fingerprint, 4, 4, 4, 4, 5,
+                           true, true};
+  case SubcyclingODEMethod::rkf78_order7:
+    return DenseCapability{method, tableau_fingerprint, 7, 7, 11, 23, 8,
+                           true, true};
+  case SubcyclingODEMethod::dp87_order8:
+    return DenseCapability{method, tableau_fingerprint, 8, 8, 13, 39, 9,
+                           true, true};
+  }
+  throw std::logic_error("test requested an unknown method");
+}
+
+class ScalarState final : public DenseStateVector {
+public:
+  explicit ScalarState(const double value) : value(value) {}
+
+  bool compatible(const DenseStateVector &other) const noexcept override {
+    return dynamic_cast<const ScalarState *>(&other) != nullptr;
+  }
+
+  void copy_from(const DenseStateVector &other) override {
+    value = dynamic_cast<const ScalarState &>(other).value;
+  }
+
+  void linear_combination(
+      const std::vector<double> &weights,
+      const std::vector<const DenseStateVector *> &sources) override {
+    assert(weights.size() == sources.size());
+    value = 0.0;
+    for (std::size_t index = 0; index < weights.size(); ++index)
+      value += weights[index] *
+               dynamic_cast<const ScalarState &>(*sources[index]).value;
+  }
+
+  double value;
+};
+
+std::shared_ptr<const DenseInterval>
+make_linear_time_interval(const StepContext &context,
+                          const DenseCapability &dense_capability) {
+  DenseIntervalBuilder builder(
+      dense_capability,
+      DenseIntervalId{context.level, context.begin_clock, context.end_clock,
+                      context.begin_time, context.end_time, context.method,
+                      dense_capability.tableau_fingerprint});
+  const int degree = dense_capability.persistent_vector_count - 1;
+  for (int control = 0; control <= degree; ++control) {
+    const double fraction = static_cast<double>(control) / degree;
+    const double value = context.begin_time +
+                         fraction * (context.end_time - context.begin_time);
+    builder.add_control(std::make_unique<ScalarState>(value));
+  }
+  return builder.seal();
+}
+
+struct StageObservation {
+  int level;
+  hierarchy_time_t begin_clock;
+  hierarchy_time_t end_clock;
+  double stage_time;
+  int parent_level;
+  double parent_value;
+};
+
+struct DenseLifetimeRecord {
+  int level;
+  hierarchy_time_t begin_clock;
+  hierarchy_time_t end_clock;
+  std::weak_ptr<const DenseInterval> interval;
+};
+
+class RecordingAdapter : public HierarchyEvolutionAdapter {
+public:
+  explicit RecordingAdapter(std::vector<DenseCapability> capabilities,
+                            const hierarchy_time_t initial_clock = 0,
+                            const double initial_physical_time = 0.0,
+                            const double coarse_dt = 1.0)
+      : capabilities_(std::move(capabilities)),
+        transaction_slots_(capabilities_.size()),
+        initial_clock_(initial_clock),
+        initial_physical_time_(initial_physical_time), coarse_dt_(coarse_dt) {}
+
+  std::vector<std::string> events;
+  std::vector<StageObservation> stages;
+  std::vector<DenseLifetimeRecord> dense_lifetimes;
+  int throw_on_level{-1};
+  bool omit_required_dense{false};
+  bool round_child_endpoint_up{false};
+  bool throw_during_sync{false};
+  bool observers_saw_all_dense_released{false};
+  bool observer_stop_requested{false};
+  bool throw_during_observer{false};
+  std::function<void()> sync_observer_hook;
+  std::size_t begin_level_step_calls{0};
+  std::size_t committed_level_sessions{0};
+  std::size_t discarded_level_sessions{0};
+  std::vector<std::pair<std::string, ScratchStateTransaction *>>
+      stage_transactions;
+
+  class Session final : public LevelStepSession {
+  public:
+    Session(RecordingAdapter &adapter, StepContext context,
+            const bool require_dense)
+        : adapter_(adapter), context_(std::move(context)),
+          require_dense_(require_dense) {}
+
+    ~Session() override {
+      if (!committed_)
+        ++adapter_.discarded_level_sessions;
+    }
+
+    ScratchStateTransaction *transaction() noexcept override {
+      return adapter_.transaction_for_level(context_.level);
+    }
+
+    LevelAdvanceResult advance() override {
+      return adapter_.advance_level_impl(context_, require_dense_);
+    }
+
+    void commit() override {
+      assert(!committed_);
+      assert(CarpetX::current_step_context() == nullptr);
+      assert(CarpetX::current_scratch_state_transaction() == nullptr);
+      committed_ = true;
+      ++adapter_.committed_level_sessions;
+    }
+
+  private:
+    RecordingAdapter &adapter_;
+    StepContext context_;
+    bool require_dense_;
+    bool committed_{false};
+  };
+
+  std::unique_ptr<LevelStepSession>
+  begin_level_step(const StepContext &context,
+                   const bool require_dense) override {
+    ++begin_level_step_calls;
+    assert(CarpetX::current_step_context() == nullptr);
+    assert(CarpetX::current_scratch_state_transaction() == nullptr);
+    assert(context.require_dense_output == require_dense);
+    assert(context.endpoint_accepted_step > 0);
+    return std::make_unique<Session>(*this, context, require_dense);
+  }
+
+  virtual LevelAdvanceResult advance_level_impl(const StepContext &context,
+                                                const bool require_dense) {
+    assert(CarpetX::current_scratch_state_transaction() ==
+           transaction_for_level(context.level));
+    assert_covering_ancestor_dense_is_live(context);
+    events.push_back("advance L" + std::to_string(context.level) + " [" +
+                     time_string(context.begin_clock) + "," +
+                     time_string(context.end_clock) + "] dense=" +
+                     (require_dense ? "required" : "none"));
+    if (context.level == throw_on_level)
+      throw std::runtime_error("requested test advance failure");
+
+    next_stage_kind_ = "primary";
+    CarpetX::prepare_stage(
+        {CarpetX::StageKind::primary, 1, 3, hierarchy_time_t(0),
+         context.begin_time},
+        context.method);
+    next_stage_kind_ = "auxiliary";
+    CarpetX::prepare_stage(
+        {CarpetX::StageKind::fractional, 2, 3,
+         hierarchy_time_t(1, 2),
+         0.5 * (context.begin_time + context.end_time)},
+        context.method);
+    const double endpoint =
+        round_child_endpoint_up && context.level > 0
+            ? std::nextafter(context.end_time,
+                             std::numeric_limits<double>::infinity())
+            : context.end_time;
+    next_stage_kind_ = "primary";
+    CarpetX::prepare_stage(
+        {CarpetX::StageKind::primary, 3, 3, hierarchy_time_t(1), endpoint},
+        context.method);
+
+    if (!require_dense || omit_required_dense)
+      return {};
+
+    auto interval = make_linear_time_interval(
+        context, capabilities_.at(static_cast<std::size_t>(context.level)));
+    dense_lifetimes.push_back(DenseLifetimeRecord{
+        context.level, context.begin_clock, context.end_clock, interval});
+    return LevelAdvanceResult{std::move(interval)};
+  }
+
+  void prepare_stage(const StepContext &context,
+                      const CarpetX::StagePoint &stage_point,
+                      const DenseInterval *parent_dense) override {
+    if (next_stage_kind_ == "auxiliary")
+      assert(stage_point.kind == CarpetX::StageKind::fractional);
+    else
+      assert(stage_point.kind == CarpetX::StageKind::primary);
+    stage_transactions.emplace_back(
+        next_stage_kind_, CarpetX::current_scratch_state_transaction());
+    assert(stage_transactions.back().second ==
+           transaction_for_level(context.level));
+    if (context.level == 0) {
+      assert(parent_dense == nullptr);
+      stages.push_back(StageObservation{context.level, context.begin_clock,
+                                        context.end_clock,
+                                        stage_point.stage_time, -1,
+                                        stage_point.stage_time});
+      return;
+    }
+
+    assert(parent_dense != nullptr);
+    assert(parent_dense->id().level == context.level - 1);
+    assert(parent_dense->id().begin_clock <= context.begin_clock);
+    assert(parent_dense->id().end_clock >= context.end_clock);
+    const auto exact_stage_clock =
+        context.begin_clock +
+        stage_point.stage_fraction * (context.end_clock - context.begin_clock);
+    const auto exact_theta =
+        (exact_stage_clock - parent_dense->id().begin_clock) /
+        (parent_dense->id().end_clock - parent_dense->id().begin_clock);
+    const double theta = static_cast<double>(exact_theta);
+    ScalarState parent_value(-1.0);
+    parent_dense->evaluate(theta, parent_value);
+    assert(std::abs(parent_value.value - stage_point.stage_time) < 1.0e-13);
+    stages.push_back(StageObservation{
+        context.level, context.begin_clock, context.end_clock,
+        stage_point.stage_time,
+        parent_dense->id().level, parent_value.value});
+  }
+
+  void begin_synchronization(const int coarse_level, const int fine_level,
+                             const hierarchy_time_t time) override {
+    assert_dense_live(coarse_level, time);
+    events.push_back("sync_begin L" + std::to_string(coarse_level) +
+                     "<-L" + std::to_string(fine_level) + " at " +
+                     time_string(time));
+  }
+
+  void synchronize_levels(const int coarse_level, const int fine_level,
+                          const hierarchy_time_t time) override {
+    assert_dense_live(coarse_level, time);
+    events.push_back("synchronize L" + std::to_string(coarse_level) +
+                     "<-L" + std::to_string(fine_level) + " at " +
+                     time_string(time));
+    if (throw_during_sync)
+      throw std::runtime_error("requested synchronization failure");
+  }
+
+  void end_synchronization(const int coarse_level, const int fine_level,
+                           const hierarchy_time_t time) noexcept override {
+    assert_dense_live(coarse_level, time);
+    events.push_back("sync_end L" + std::to_string(coarse_level) + "<-L" +
+                     std::to_string(fine_level) + " at " +
+                     time_string(time));
+  }
+
+  void run_sync_observers(const hierarchy_time_t time,
+                          const double physical_time,
+                          const std::uint64_t completed_epoch,
+                          const bool stop_requested) override {
+    observer_stop_requested = stop_requested;
+    observers_saw_all_dense_released = true;
+    for (const auto &record : dense_lifetimes)
+      observers_saw_all_dense_released &= record.interval.expired();
+    const double expected_physical_time =
+        initial_physical_time_ +
+        static_cast<double>(time - initial_clock_) * coarse_dt_;
+    assert(physical_time == expected_physical_time);
+    events.push_back("sync_observers epoch=" +
+                     std::to_string(completed_epoch) + " at " +
+                     time_string(time));
+    if (sync_observer_hook)
+      sync_observer_hook();
+    if (throw_during_observer)
+      throw std::runtime_error("requested sync-observer failure");
+  }
+
+private:
+  ScratchStateTransaction *transaction_for_level(const int level) noexcept {
+    return reinterpret_cast<ScratchStateTransaction *>(
+        &transaction_slots_.at(static_cast<std::size_t>(level)));
+  }
+
+  void assert_covering_ancestor_dense_is_live(
+      const StepContext &context) const {
+    for (const auto &record : dense_lifetimes) {
+      const bool covers = record.level < context.level &&
+                          record.begin_clock <= context.begin_clock &&
+                          record.end_clock >= context.end_clock;
+      if (covers)
+        assert(!record.interval.expired());
+    }
+  }
+
+  void assert_dense_live(const int level, const hierarchy_time_t end) const {
+    for (auto record = dense_lifetimes.rbegin();
+         record != dense_lifetimes.rend(); ++record) {
+      if (record->level == level && record->end_clock == end) {
+        assert(!record->interval.expired());
+        return;
+      }
+    }
+    assert(false && "synchronization has no retained dense interval");
+  }
+
+  std::vector<DenseCapability> capabilities_;
+  std::vector<std::uintptr_t> transaction_slots_;
+  std::string next_stage_kind_;
+  hierarchy_time_t initial_clock_{0};
+  double initial_physical_time_{0.0};
+  double coarse_dt_{1.0};
+};
+
+class ConcurrentStopAdapter final : public RecordingAdapter {
+public:
+  using RecordingAdapter::RecordingAdapter;
+
+  std::atomic<bool> root_entered{false};
+  std::atomic<bool> release_root{false};
+
+  LevelAdvanceResult advance_level_impl(const StepContext &context,
+                                        const bool require_dense) override {
+    if (context.level == 0) {
+      root_entered.store(true, std::memory_order_relaxed);
+      while (!release_root.load(std::memory_order_relaxed))
+        std::this_thread::yield();
+    }
+    return RecordingAdapter::advance_level_impl(context, require_dense);
+  }
+};
+
+struct Fixture {
+  DenseOutputRegistry registry;
+  std::vector<DenseCapability> capabilities;
+  HierarchyStepperConfig config;
+
+  explicit Fixture(const int level_count) {
+    assert(level_count > 0);
+    capabilities.reserve(static_cast<std::size_t>(level_count));
+    config.levels.reserve(static_cast<std::size_t>(level_count));
+    for (int level = 0; level < level_count; ++level) {
+      const auto method = level % 3 == 0
+                              ? SubcyclingODEMethod::rk4
+                              : level % 3 == 1
+                                    ? SubcyclingODEMethod::rkf78_order7
+                                    : SubcyclingODEMethod::dp87_order8;
+      const auto table = fingerprint(static_cast<std::uint8_t>(0x31 + level));
+      capabilities.push_back(capability(method, table));
+      config.levels.push_back(LevelAdvanceConfig{method, table});
+      registry.register_provider(
+          std::make_shared<DenseOutputProvider>(capabilities.back()));
+    }
+  }
+};
+
+void test_two_levels_use_parent_dense_at_every_exact_child_stage() {
+  Fixture fixture(2);
+  HierarchyStepper stepper(fixture.config, fixture.registry);
+  RecordingAdapter adapter(fixture.capabilities);
+
+  const HierarchyAdvanceResult result = stepper.advance_one_epoch(adapter);
+
+  assert(result.synchronized_time == hierarchy_time_t(1));
+  assert(result.synchronized_physical_time == 1.0);
+  assert(result.epoch == 1);
+  assert(!result.stop_requested);
+  assert(adapter.events == std::vector<std::string>({
+                               "advance L0 [0/1,1/1] dense=required",
+                               "advance L1 [0/1,1/2] dense=none",
+                               "advance L1 [1/2,1/1] dense=none",
+                               "sync_begin L0<-L1 at 1/1",
+                               "synchronize L0<-L1 at 1/1",
+                               "sync_end L0<-L1 at 1/1",
+                               "sync_observers epoch=1 at 1/1",
+                           }));
+
+  std::vector<double> child_stage_times;
+  for (const auto &stage : adapter.stages) {
+    if (stage.level == 1) {
+      assert(stage.parent_level == 0);
+      assert(std::abs(stage.parent_value - stage.stage_time) < 1.0e-13);
+      child_stage_times.push_back(stage.stage_time);
+    }
+  }
+  assert(child_stage_times ==
+         std::vector<double>({0.0, 0.25, 0.5, 0.5, 0.75, 1.0}));
+  assert(adapter.observers_saw_all_dense_released);
+  assert(stepper.hierarchy_synchronized());
+  assert(stepper.clocks()[0].accepted_steps == 1);
+  assert(stepper.clocks()[1].accepted_steps == 2);
+  assert(adapter.committed_level_sessions == 3);
+  assert(adapter.discarded_level_sessions == 0);
+}
+
+void test_three_level_trace_retains_each_parent_until_child_catchup() {
+  Fixture fixture(3);
+  HierarchyStepper stepper(fixture.config, fixture.registry);
+  RecordingAdapter adapter(fixture.capabilities);
+
+  stepper.advance_one_epoch(adapter);
+
+  assert(adapter.events == std::vector<std::string>({
+                               "advance L0 [0/1,1/1] dense=required",
+                               "advance L1 [0/1,1/2] dense=required",
+                               "advance L2 [0/1,1/4] dense=none",
+                               "advance L2 [1/4,1/2] dense=none",
+                               "sync_begin L1<-L2 at 1/2",
+                               "synchronize L1<-L2 at 1/2",
+                               "sync_end L1<-L2 at 1/2",
+                               "advance L1 [1/2,1/1] dense=required",
+                               "advance L2 [1/2,3/4] dense=none",
+                               "advance L2 [3/4,1/1] dense=none",
+                               "sync_begin L1<-L2 at 1/1",
+                               "synchronize L1<-L2 at 1/1",
+                               "sync_end L1<-L2 at 1/1",
+                               "sync_begin L0<-L1 at 1/1",
+                               "synchronize L0<-L1 at 1/1",
+                               "sync_end L0<-L1 at 1/1",
+                               "sync_observers epoch=1 at 1/1",
+                           }));
+  assert(adapter.observers_saw_all_dense_released);
+  assert(stepper.clocks()[0].time == hierarchy_time_t(1));
+  assert(stepper.clocks()[1].time == hierarchy_time_t(1));
+  assert(stepper.clocks()[2].time == hierarchy_time_t(1));
+  assert(stepper.clocks()[0].accepted_steps == 1);
+  assert(stepper.clocks()[1].accepted_steps == 2);
+  assert(stepper.clocks()[2].accepted_steps == 4);
+}
+
+void test_level_session_installs_adapter_transaction_for_primary_and_auxiliary() {
+  Fixture fixture(3);
+  HierarchyStepper stepper(fixture.config, fixture.registry);
+  RecordingAdapter adapter(fixture.capabilities);
+
+  stepper.advance_one_epoch(adapter);
+
+  bool saw_primary = false;
+  bool saw_auxiliary = false;
+  for (const auto &observation : adapter.stage_transactions) {
+    assert(observation.second != nullptr);
+    saw_primary |= observation.first == "primary";
+    saw_auxiliary |= observation.first == "auxiliary";
+  }
+  assert(saw_primary);
+  assert(saw_auxiliary);
+  assert(CarpetX::current_scratch_state_transaction() == nullptr);
+}
+
+void test_preflight_rejects_unsupported_method_or_dense_capability() {
+  Fixture fixture(2);
+
+  auto unsupported = fixture.config;
+  unsupported.levels[0].method = static_cast<SubcyclingODEMethod>(99);
+  bool rejected_method = false;
+  try {
+    HierarchyStepper stepper(unsupported, fixture.registry);
+  } catch (const std::invalid_argument &) {
+    rejected_method = true;
+  }
+  assert(rejected_method);
+
+  auto missing = fixture.config;
+  missing.levels[0].tableau_fingerprint = fingerprint(0x7f);
+  bool rejected_capability = false;
+  try {
+    HierarchyStepper stepper(missing, fixture.registry);
+  } catch (const std::invalid_argument &) {
+    rejected_capability = true;
+  }
+  assert(rejected_capability);
+
+  auto missing_leaf = fixture.config;
+  missing_leaf.levels[1].tableau_fingerprint = fingerprint(0x6e);
+  bool rejected_leaf_capability = false;
+  try {
+    HierarchyStepper stepper(missing_leaf, fixture.registry);
+  } catch (const std::invalid_argument &) {
+    rejected_leaf_capability = true;
+  }
+  assert(rejected_leaf_capability);
+
+  auto invalid_ratio = fixture.config;
+  invalid_ratio.refinement_ratio = 3;
+  bool rejected_ratio = false;
+  try {
+    HierarchyStepper stepper(invalid_ratio, fixture.registry);
+  } catch (const std::invalid_argument &) {
+    rejected_ratio = true;
+  }
+  assert(rejected_ratio);
+}
+
+void test_preflight_rejects_noncanonical_method_capability_shape() {
+  const std::vector<SubcyclingODEMethod> methods{
+      SubcyclingODEMethod::rk4, SubcyclingODEMethod::rkf78_order7,
+      SubcyclingODEMethod::dp87_order8};
+
+  for (std::size_t method_index = 0; method_index < methods.size();
+       ++method_index) {
+    const auto table =
+        fingerprint(static_cast<std::uint8_t>(0x60 + method_index));
+    const auto canonical = capability(methods[method_index], table);
+    std::vector<DenseCapability> malformed;
+
+    auto wrong_endpoint = canonical;
+    --wrong_endpoint.endpoint_order;
+    malformed.push_back(wrong_endpoint);
+
+    auto wrong_dense_order = canonical;
+    ++wrong_dense_order.dense_uniform_order;
+    ++wrong_dense_order.persistent_vector_count;
+    malformed.push_back(wrong_dense_order);
+
+    auto wrong_stage_count = canonical;
+    ++wrong_stage_count.stage_count;
+    malformed.push_back(wrong_stage_count);
+
+    auto wrong_rhs_cost = canonical;
+    ++wrong_rhs_cost.extra_rhs_evaluations;
+    malformed.push_back(wrong_rhs_cost);
+
+    for (const auto &candidate : malformed) {
+      DenseOutputRegistry registry;
+      registry.register_provider(
+          std::make_shared<DenseOutputProvider>(candidate));
+      HierarchyStepperConfig config;
+      config.levels.push_back(LevelAdvanceConfig{candidate.method, table});
+
+      bool rejected = false;
+      try {
+        HierarchyStepper stepper(config, registry);
+      } catch (const std::invalid_argument &) {
+        rejected = true;
+      }
+      assert(rejected);
+    }
+  }
+}
+
+void test_missing_dense_fails_before_parent_clock_commit() {
+  Fixture fixture(2);
+  HierarchyStepper stepper(fixture.config, fixture.registry);
+  RecordingAdapter adapter(fixture.capabilities);
+  adapter.omit_required_dense = true;
+
+  bool rejected = false;
+  try {
+    stepper.advance_one_epoch(adapter);
+  } catch (const std::logic_error &) {
+    rejected = true;
+  }
+  assert(rejected);
+  assert(stepper.clocks()[0].time == hierarchy_time_t(0));
+  assert(stepper.clocks()[0].accepted_steps == 0);
+  assert(adapter.committed_level_sessions == 0);
+  assert(adapter.discarded_level_sessions == 1);
+  assert(!stepper.hierarchy_synchronized());
+}
+
+void test_clock_overflow_fails_before_adapter_session_creation() {
+  Fixture fixture(1);
+  fixture.config.initial_clock = hierarchy_time_t(
+      std::numeric_limits<std::int64_t>::max());
+  HierarchyStepper stepper(fixture.config, fixture.registry);
+  RecordingAdapter adapter(fixture.capabilities, fixture.config.initial_clock);
+
+  bool rejected = false;
+  try {
+    stepper.advance_one_epoch(adapter);
+  } catch (const std::overflow_error &) {
+    rejected = true;
+  } catch (...) {
+  }
+
+  assert(rejected);
+  assert(adapter.begin_level_step_calls == 0);
+  assert(stepper.clocks()[0].time == fixture.config.initial_clock);
+  assert(stepper.clocks()[0].accepted_steps == 0);
+}
+
+void test_epoch_wide_step_counter_overflow_fails_before_adapter_call() {
+  Fixture fixture(2);
+  const auto maximum = std::numeric_limits<std::uint64_t>::max();
+  fixture.config.initial_epoch = maximum / 2;
+  fixture.config.initial_accepted_steps = {maximum / 2, maximum - 1};
+  HierarchyStepper stepper(fixture.config, fixture.registry);
+  RecordingAdapter adapter(fixture.capabilities);
+
+  bool rejected = false;
+  try {
+    stepper.advance_one_epoch(adapter);
+  } catch (const std::overflow_error &) {
+    rejected = true;
+  }
+
+  assert(rejected);
+  assert(adapter.begin_level_step_calls == 0);
+  assert(stepper.clocks()[0].accepted_steps == maximum / 2);
+  assert(stepper.clocks()[1].accepted_steps == maximum - 1);
+}
+
+void test_child_failure_poisoning_keeps_failing_clock_uncommitted() {
+  Fixture fixture(2);
+  HierarchyStepper stepper(fixture.config, fixture.registry);
+  RecordingAdapter adapter(fixture.capabilities);
+  adapter.throw_on_level = 1;
+
+  bool threw = false;
+  try {
+    stepper.advance_one_epoch(adapter);
+  } catch (const std::runtime_error &) {
+    threw = true;
+  }
+  assert(threw);
+  assert(stepper.clocks()[0].time == hierarchy_time_t(1));
+  assert(stepper.clocks()[0].accepted_steps == 1);
+  assert(stepper.clocks()[1].time == hierarchy_time_t(0));
+  assert(stepper.clocks()[1].accepted_steps == 0);
+  assert(adapter.committed_level_sessions == 1);
+  assert(adapter.discarded_level_sessions == 1);
+  assert(!stepper.hierarchy_synchronized());
+  for (const auto &record : adapter.dense_lifetimes)
+    assert(record.interval.expired());
+}
+
+void test_stop_request_is_consumed_only_after_sync_observers() {
+  Fixture fixture(2);
+  HierarchyStepper stepper(fixture.config, fixture.registry);
+  RecordingAdapter adapter(fixture.capabilities);
+  stepper.request_stop_at_next_sync();
+  adapter.sync_observer_hook = [&] { assert(stepper.stop_pending()); };
+
+  const auto stopped = stepper.advance_one_epoch(adapter);
+  assert(stopped.stop_requested);
+  assert(adapter.observer_stop_requested);
+  assert(!stepper.stop_pending());
+  assert(adapter.events.back() == "sync_observers epoch=1 at 1/1");
+
+  RecordingAdapter resumed_adapter(fixture.capabilities);
+  const auto resumed = stepper.advance_one_epoch(resumed_adapter);
+  assert(!resumed.stop_requested);
+  assert(!resumed_adapter.observer_stop_requested);
+  assert(resumed.synchronized_time == hierarchy_time_t(2));
+  assert(resumed.epoch == 2);
+}
+
+void test_stop_request_arriving_during_observer_is_not_lost() {
+  Fixture fixture(2);
+  HierarchyStepper stepper(fixture.config, fixture.registry);
+  RecordingAdapter first_adapter(fixture.capabilities);
+  stepper.request_stop_at_next_sync();
+  first_adapter.sync_observer_hook =
+      [&] { stepper.request_stop_at_next_sync(); };
+
+  const auto first = stepper.advance_one_epoch(first_adapter);
+  assert(first.stop_requested);
+  assert(first_adapter.observer_stop_requested);
+
+  RecordingAdapter second_adapter(fixture.capabilities);
+  const auto second = stepper.advance_one_epoch(second_adapter);
+  assert(second.stop_requested);
+  assert(second_adapter.observer_stop_requested);
+
+  RecordingAdapter third_adapter(fixture.capabilities);
+  const auto third = stepper.advance_one_epoch(third_adapter);
+  assert(!third.stop_requested);
+  assert(!third_adapter.observer_stop_requested);
+}
+
+void test_stop_request_is_not_consumed_when_observer_fails() {
+  Fixture fixture(2);
+  HierarchyStepper stepper(fixture.config, fixture.registry);
+  RecordingAdapter adapter(fixture.capabilities);
+  adapter.throw_during_observer = true;
+  stepper.request_stop_at_next_sync();
+
+  bool threw = false;
+  try {
+    stepper.advance_one_epoch(adapter);
+  } catch (const std::runtime_error &) {
+    threw = true;
+  }
+
+  assert(threw);
+  assert(adapter.observer_stop_requested);
+  assert(stepper.stop_pending());
+  assert(!stepper.hierarchy_synchronized());
+}
+
+void test_endpoint_roundoff_is_canonicalized_before_parent_dense_evaluation() {
+  Fixture fixture(2);
+  HierarchyStepper stepper(fixture.config, fixture.registry);
+  RecordingAdapter adapter(fixture.capabilities);
+  adapter.round_child_endpoint_up = true;
+
+  const auto result = stepper.advance_one_epoch(adapter);
+
+  assert(result.synchronized_time == hierarchy_time_t(1));
+  std::vector<double> child_endpoint_times;
+  for (const auto &stage : adapter.stages) {
+    if (stage.level == 1 &&
+        stage.stage_time == static_cast<double>(stage.end_clock))
+      child_endpoint_times.push_back(stage.stage_time);
+  }
+  assert(child_endpoint_times == std::vector<double>({0.5, 1.0}));
+}
+
+void test_synchronization_scope_ends_and_releases_dense_on_failure() {
+  Fixture fixture(2);
+  HierarchyStepper stepper(fixture.config, fixture.registry);
+  RecordingAdapter adapter(fixture.capabilities);
+  adapter.throw_during_sync = true;
+
+  bool threw = false;
+  try {
+    stepper.advance_one_epoch(adapter);
+  } catch (const std::runtime_error &) {
+    threw = true;
+  }
+
+  assert(threw);
+  assert(adapter.events.size() >= 3);
+  assert(adapter.events[adapter.events.size() - 3] ==
+         "sync_begin L0<-L1 at 1/1");
+  assert(adapter.events[adapter.events.size() - 2] ==
+         "synchronize L0<-L1 at 1/1");
+  assert(adapter.events.back() == "sync_end L0<-L1 at 1/1");
+  for (const auto &record : adapter.dense_lifetimes)
+    assert(record.interval.expired());
+}
+
+void test_recovery_metadata_initializes_epoch_clocks_and_step_counts() {
+  Fixture fixture(2);
+  fixture.config.initial_clock = hierarchy_time_t(3, 2);
+  fixture.config.initial_physical_time = 10.0;
+  fixture.config.coarse_dt = 0.25;
+  fixture.config.initial_epoch = 7;
+  fixture.config.initial_accepted_steps = {7, 14};
+  HierarchyStepper stepper(fixture.config, fixture.registry);
+  RecordingAdapter adapter(fixture.capabilities, fixture.config.initial_clock,
+                           fixture.config.initial_physical_time,
+                           fixture.config.coarse_dt);
+
+  assert(stepper.epoch() == 7);
+  assert(stepper.clocks()[0].time == hierarchy_time_t(3, 2));
+  assert(stepper.clocks()[1].time == hierarchy_time_t(3, 2));
+  assert(stepper.clocks()[0].accepted_steps == 7);
+  assert(stepper.clocks()[1].accepted_steps == 14);
+
+  const auto result = stepper.advance_one_epoch(adapter);
+  assert(result.synchronized_time == hierarchy_time_t(5, 2));
+  assert(result.synchronized_physical_time == 10.25);
+  assert(result.epoch == 8);
+  assert(stepper.clocks()[0].accepted_steps == 8);
+  assert(stepper.clocks()[1].accepted_steps == 16);
+}
+
+void test_stop_request_is_safe_from_an_asynchronous_thread() {
+  Fixture fixture(2);
+  HierarchyStepper stepper(fixture.config, fixture.registry);
+  ConcurrentStopAdapter adapter(fixture.capabilities);
+  HierarchyAdvanceResult result;
+  std::exception_ptr failure;
+
+  std::thread evolution([&] {
+    try {
+      result = stepper.advance_one_epoch(adapter);
+    } catch (...) {
+      failure = std::current_exception();
+    }
+  });
+  while (!adapter.root_entered.load(std::memory_order_relaxed))
+    std::this_thread::yield();
+  stepper.request_stop_at_next_sync();
+  adapter.release_root.store(true, std::memory_order_relaxed);
+  evolution.join();
+
+  assert(failure == nullptr);
+  assert(result.stop_requested);
+  assert(result.epoch == 1);
+}
+
+} // namespace
+
+int main() {
+  test_two_levels_use_parent_dense_at_every_exact_child_stage();
+  test_three_level_trace_retains_each_parent_until_child_catchup();
+  test_level_session_installs_adapter_transaction_for_primary_and_auxiliary();
+  test_preflight_rejects_unsupported_method_or_dense_capability();
+  test_preflight_rejects_noncanonical_method_capability_shape();
+  test_missing_dense_fails_before_parent_clock_commit();
+  test_clock_overflow_fails_before_adapter_session_creation();
+  test_epoch_wide_step_counter_overflow_fails_before_adapter_call();
+  test_child_failure_poisoning_keeps_failing_clock_uncommitted();
+  test_stop_request_is_consumed_only_after_sync_observers();
+  test_stop_request_arriving_during_observer_is_not_lost();
+  test_stop_request_is_not_consumed_when_observer_fails();
+  test_endpoint_roundoff_is_canonicalized_before_parent_dense_evaluation();
+  test_synchronization_scope_ends_and_releases_dense_on_failure();
+  test_recovery_metadata_initializes_epoch_clocks_and_step_counts();
+  test_stop_request_is_safe_from_an_asynchronous_thread();
+  std::cout << "HierarchyStepper dense recursion tests passed\n";
+  return 0;
+}

--- a/CarpetX/test/subcycling_dense_control_builder_unit.cxx
+++ b/CarpetX/test/subcycling_dense_control_builder_unit.cxx
@@ -1,0 +1,531 @@
+#include "subcycling_dense_control_builder.hxx"
+
+#include <AMReX_MultiFab.H>
+
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using CarpetX::DenseMFabControlSet;
+using CarpetX::DenseMFabKey;
+using CarpetX::DenseMFabRawSampleView;
+using CarpetX::DenseMFabView;
+using CarpetX::DenseSampleConstraint;
+using CarpetX::DenseSampleKind;
+using CarpetX::OwnedMultiFabDenseState;
+using CarpetX::SubcyclingODEMethod;
+
+static_assert(!std::is_copy_constructible_v<DenseMFabControlSet>);
+static_assert(!std::is_copy_assignable_v<DenseMFabControlSet>);
+static_assert(std::is_nothrow_move_constructible_v<DenseMFabControlSet>);
+static_assert(std::is_nothrow_move_assignable_v<DenseMFabControlSet>);
+
+constexpr SubcyclingODEMethod methods[] = {
+    SubcyclingODEMethod::rk4, SubcyclingODEMethod::rkf78_order7,
+    SubcyclingODEMethod::dp87_order8};
+
+template <typename Exception, typename Function>
+void expect_throw(Function &&function) {
+  bool threw = false;
+  try {
+    function();
+  } catch (const Exception &) {
+    threw = true;
+  }
+  assert(threw);
+}
+
+DenseMFabKey key(const std::int64_t epoch = 19, const int patch = 0,
+                 const int level = 1, const int group = 7) {
+  return DenseMFabKey{epoch, patch, level, group};
+}
+
+std::unique_ptr<amrex::MultiFab>
+borrowed_mfab(const DenseMFabKey &, const double value,
+              const int box_array = 11, const int distribution = 13,
+              const int components = 1, const int grow = 2) {
+  auto result = std::make_unique<amrex::MultiFab>(
+      amrex::BoxArray(box_array), amrex::DistributionMapping(distribution),
+      components, amrex::IntVect(grow));
+  result->setVal(static_cast<amrex::Real>(value), 0, components, 0);
+  for (int component = 0; component < components; ++component) {
+    result->test_set_valid(
+        component, 1,
+        static_cast<amrex::Real>(value + 0.125 * (component + 1)));
+    result->test_set_ghost(
+        component, static_cast<amrex::Real>(900.0 + value + component));
+  }
+  return result;
+}
+
+std::unique_ptr<OwnedMultiFabDenseState>
+state(const double value, const DenseMFabKey &entry_key = key(),
+      const int box_array = 11, const int distribution = 13,
+      const int components = 1, const int grow = 2) {
+  auto borrowed = borrowed_mfab(entry_key, value, box_array, distribution,
+                                components, grow);
+  return OwnedMultiFabDenseState::copy_of(
+      std::vector<DenseMFabView>{{entry_key, borrowed.get()}});
+}
+
+double first_value(const OwnedMultiFabDenseState &source) {
+  return static_cast<double>(source.multifab(0).test_valid(0, 0));
+}
+
+double first_ghost(const OwnedMultiFabDenseState &source) {
+  return static_cast<double>(source.multifab(0).test_ghost(0));
+}
+
+struct Samples {
+  std::vector<std::unique_ptr<OwnedMultiFabDenseState>> owned;
+  std::vector<DenseMFabRawSampleView> views;
+};
+
+Samples samples_from_values(const SubcyclingODEMethod method,
+                            const std::vector<double> &values) {
+  const auto &constraints =
+      CarpetX::reference_dense_stencil(method).specification().constraints;
+  assert(values.size() == constraints.size());
+
+  Samples result;
+  result.owned.reserve(values.size());
+  result.views.reserve(values.size());
+  for (std::size_t index = 0; index < values.size(); ++index) {
+    result.owned.push_back(state(values[index]));
+    result.views.push_back(
+        DenseMFabRawSampleView{constraints[index], result.owned.back().get()});
+  }
+  return result;
+}
+
+Samples monomial_samples(const SubcyclingODEMethod method, const double dt,
+                         const int power) {
+  const auto &constraints =
+      CarpetX::reference_dense_stencil(method).specification().constraints;
+  std::vector<double> values;
+  values.reserve(constraints.size());
+  for (const auto &constraint : constraints) {
+    if (constraint.kind == DenseSampleKind::value) {
+      values.push_back(std::pow(constraint.theta, power));
+    } else if (power == 0) {
+      values.push_back(0.0);
+    } else {
+      values.push_back(static_cast<double>(power) *
+                       std::pow(constraint.theta, power - 1) / dt);
+    }
+  }
+  return samples_from_values(method, values);
+}
+
+double binomial(const int n, const int k) {
+  if (k < 0 || k > n)
+    return 0.0;
+  const int smaller = k < n - k ? k : n - k;
+  double result = 1.0;
+  for (int j = 1; j <= smaller; ++j)
+    result *= static_cast<double>(n - smaller + j) / static_cast<double>(j);
+  return result;
+}
+
+double evaluate_bernstein(const DenseMFabControlSet &controls,
+                          const double theta) {
+  const int degree = static_cast<int>(controls.control_count()) - 1;
+  double value = 0.0;
+  for (int i = 0; i <= degree; ++i) {
+    value += first_value(controls.control(static_cast<std::size_t>(i))) *
+             binomial(degree, i) * std::pow(theta, i) *
+             std::pow(1.0 - theta, degree - i);
+  }
+  return value;
+}
+
+void assert_near(const double actual, const double expected,
+                 const double tolerance = 2.0e-5) {
+  assert(std::abs(actual - expected) <= tolerance);
+}
+
+void test_builds_owned_controls_and_reproduces_reference_polynomials() {
+  constexpr double dt = 0.375;
+  for (const auto method : methods) {
+    const auto &stencil = CarpetX::reference_dense_stencil(method);
+    const int degree = stencil.specification().dense_uniform_order;
+    for (int power = 0; power <= degree; ++power) {
+      auto samples = monomial_samples(method, dt, power);
+      std::vector<double> scalar_samples;
+      scalar_samples.reserve(samples.views.size());
+      for (std::size_t index = 0; index < samples.views.size(); ++index) {
+        const auto raw = first_value(*samples.views[index].state);
+        scalar_samples.push_back(
+            samples.views[index].constraint.kind == DenseSampleKind::value
+                ? raw
+                : dt * raw);
+      }
+      const auto scalar_controls = stencil.make_controls(scalar_samples);
+
+      const auto controls =
+          CarpetX::build_reference_dense_controls(method, dt, samples.views);
+      assert(controls.method() == method);
+      assert(controls.parent_dt() == dt);
+      assert(controls.control_count() == stencil.control_count());
+      for (std::size_t index = 0; index < controls.control_count(); ++index) {
+        assert_near(first_value(controls.control(index)),
+                    scalar_controls[index]);
+      }
+      for (const double theta : {0.0, 0.07, 0.31, 0.5, 0.83, 1.0}) {
+        assert_near(evaluate_bernstein(controls, theta),
+                    std::pow(theta, power), 7.0e-5);
+      }
+    }
+  }
+}
+
+void test_only_derivative_columns_receive_parent_dt() {
+  constexpr double dt = 3.25;
+  for (const auto method : methods) {
+    const auto &stencil = CarpetX::reference_dense_stencil(method);
+    std::vector<double> raw_samples(stencil.sample_count());
+    std::vector<double> scaled_samples(stencil.sample_count());
+    for (std::size_t index = 0; index < raw_samples.size(); ++index) {
+      raw_samples[index] = 0.5 + static_cast<double>(index);
+      scaled_samples[index] =
+          stencil.specification().constraints[index].kind ==
+                  DenseSampleKind::scaled_derivative
+              ? dt * raw_samples[index]
+              : raw_samples[index];
+    }
+    auto samples = samples_from_values(method, raw_samples);
+    const auto expected = stencil.make_controls(scaled_samples);
+    const auto controls =
+        CarpetX::build_reference_dense_controls(method, dt, samples.views);
+    for (std::size_t index = 0; index < controls.control_count(); ++index)
+      assert_near(first_value(controls.control(index)), expected[index]);
+  }
+}
+
+void test_endpoint_controls_are_exact_copy_operations() {
+  auto samples = samples_from_values(SubcyclingODEMethod::rk4,
+                                    {-0.0, 3.0, 4.0, -0.0, 5.0});
+  amrex::MultiFab::reset_operation_log();
+
+  const auto controls = CarpetX::build_reference_dense_controls(
+      SubcyclingODEMethod::rk4, 0.5, samples.views);
+
+  assert(std::signbit(first_value(controls.control(0))));
+  assert(std::signbit(first_value(controls.control(4))));
+  assert(amrex::MultiFab::copy_count() == 2);
+  assert(amrex::MultiFab::all_operations_interior_only());
+}
+
+std::size_t expected_interior_saxpy_count(const SubcyclingODEMethod method,
+                                          const double dt) {
+  const auto &stencil = CarpetX::reference_dense_stencil(method);
+  std::size_t result = 0;
+  for (std::size_t control = 1; control + 1 < stencil.control_count();
+       ++control) {
+    for (std::size_t sample = 0; sample < stencil.sample_count(); ++sample) {
+      double weight = stencil.weight(control, sample);
+      if (stencil.specification().constraints[sample].kind ==
+          DenseSampleKind::scaled_derivative)
+        weight *= dt;
+      const auto device_weight = static_cast<amrex::Real>(weight);
+      if (device_weight != amrex::Real(0))
+        ++result;
+    }
+  }
+  return result;
+}
+
+void test_zero_coefficients_are_removed_before_saxpy() {
+  constexpr double dt = 0.75;
+  for (const auto method : methods) {
+    const auto &stencil = CarpetX::reference_dense_stencil(method);
+    std::vector<double> values(stencil.sample_count(), 1.0);
+    auto samples = samples_from_values(method, values);
+    amrex::MultiFab::reset_operation_log();
+
+    const auto controls =
+        CarpetX::build_reference_dense_controls(method, dt, samples.views);
+
+    assert(controls.control_count() == stencil.control_count());
+    assert(amrex::MultiFab::saxpy_count() ==
+           expected_interior_saxpy_count(method, dt));
+    assert(amrex::MultiFab::setval_count() ==
+           static_cast<int>(stencil.control_count() - 2));
+    assert(amrex::MultiFab::copy_count() == 2);
+  }
+}
+
+template <typename Function>
+void expect_preallocation_failure(Function &&function) {
+  amrex::MultiFab::reset_construction_count();
+  expect_throw<std::invalid_argument>(std::forward<Function>(function));
+  assert(amrex::MultiFab::construction_count() == 0);
+}
+
+void test_invalid_method_dt_count_and_metadata_fail_before_allocation() {
+  auto samples = samples_from_values(SubcyclingODEMethod::rk4,
+                                    {1.0, 2.0, 3.0, 4.0, 5.0});
+  expect_preallocation_failure([&] {
+    CarpetX::build_reference_dense_controls(
+        static_cast<SubcyclingODEMethod>(99), 1.0, samples.views);
+  });
+  for (const double invalid_dt :
+       {0.0, -1.0, std::numeric_limits<double>::quiet_NaN(),
+        std::numeric_limits<double>::infinity()}) {
+    expect_preallocation_failure([&] {
+      CarpetX::build_reference_dense_controls(SubcyclingODEMethod::rk4,
+                                               invalid_dt, samples.views);
+    });
+  }
+
+  auto wrong_count = samples.views;
+  wrong_count.pop_back();
+  expect_preallocation_failure([&] {
+    CarpetX::build_reference_dense_controls(SubcyclingODEMethod::rk4, 1.0,
+                                             wrong_count);
+  });
+
+  for (std::size_t index = 0; index < samples.views.size(); ++index) {
+    auto wrong_theta = samples.views;
+    wrong_theta[index].constraint.theta =
+        std::nextafter(wrong_theta[index].constraint.theta, 2.0);
+    expect_preallocation_failure([&] {
+      CarpetX::build_reference_dense_controls(SubcyclingODEMethod::rk4, 1.0,
+                                               wrong_theta);
+    });
+
+    auto wrong_kind = samples.views;
+    wrong_kind[index].constraint.kind =
+        wrong_kind[index].constraint.kind == DenseSampleKind::value
+            ? DenseSampleKind::scaled_derivative
+            : DenseSampleKind::value;
+    expect_preallocation_failure([&] {
+      CarpetX::build_reference_dense_controls(SubcyclingODEMethod::rk4, 1.0,
+                                               wrong_kind);
+    });
+  }
+
+  auto null_sample = samples.views;
+  null_sample[2].state = nullptr;
+  expect_preallocation_failure([&] {
+    CarpetX::build_reference_dense_controls(SubcyclingODEMethod::rk4, 1.0,
+                                             null_sample);
+  });
+
+  auto duplicate_sample = samples.views;
+  duplicate_sample[2].state = duplicate_sample[0].state;
+  expect_preallocation_failure([&] {
+    CarpetX::build_reference_dense_controls(SubcyclingODEMethod::rk4, 1.0,
+                                             duplicate_sample);
+  });
+}
+
+void test_all_samples_are_globally_prevalidated_even_when_a_weight_is_zero() {
+  auto samples = samples_from_values(SubcyclingODEMethod::rk4,
+                                    {1.0, 2.0, 3.0, 4.0, 5.0});
+  const auto &stencil =
+      CarpetX::reference_dense_stencil(SubcyclingODEMethod::rk4);
+  std::size_t zero_weight_sample = stencil.sample_count();
+  for (std::size_t sample = 0; sample < stencil.sample_count(); ++sample) {
+    if (stencil.weight(1, sample) == 0.0) {
+      zero_weight_sample = sample;
+      break;
+    }
+  }
+  assert(zero_weight_sample < stencil.sample_count());
+
+  auto incompatible_epoch = state(8.0, key(20, 0, 1, 7));
+  auto epoch_views = samples.views;
+  epoch_views[zero_weight_sample].state = incompatible_epoch.get();
+  expect_preallocation_failure([&] {
+    CarpetX::build_reference_dense_controls(SubcyclingODEMethod::rk4, 1.0,
+                                             epoch_views);
+  });
+
+  const std::vector<std::unique_ptr<OwnedMultiFabDenseState>> mismatches = [&] {
+    std::vector<std::unique_ptr<OwnedMultiFabDenseState>> result;
+    result.push_back(state(8.0, key(19, 1, 1, 7)));
+    result.push_back(state(8.0, key(19, 0, 2, 7)));
+    result.push_back(state(8.0, key(19, 0, 1, 8)));
+    result.push_back(state(8.0, key(), 17, 13, 1, 2));
+    result.push_back(state(8.0, key(), 11, 19, 1, 2));
+    result.push_back(state(8.0, key(), 11, 13, 2, 2));
+    result.push_back(state(8.0, key(), 11, 13, 1, 3));
+    return result;
+  }();
+  for (const auto &mismatch : mismatches) {
+    auto views = samples.views;
+    views[zero_weight_sample].state = mismatch.get();
+    expect_preallocation_failure([&] {
+      CarpetX::build_reference_dense_controls(SubcyclingODEMethod::rk4, 1.0,
+                                               views);
+    });
+  }
+}
+
+void test_nonfinite_effective_coefficients_fail_before_allocation() {
+  bool found_double_overflow_case = false;
+  for (const auto method : methods) {
+    const auto &stencil = CarpetX::reference_dense_stencil(method);
+    for (std::size_t control = 1; control + 1 < stencil.control_count();
+         ++control) {
+      for (std::size_t sample = 0; sample < stencil.sample_count(); ++sample) {
+        if (stencil.specification().constraints[sample].kind !=
+            DenseSampleKind::scaled_derivative)
+          continue;
+        const double weight = std::abs(stencil.weight(control, sample));
+        if (!(weight > 1.0))
+          continue;
+        const double dt =
+            std::nextafter(std::numeric_limits<double>::max() / weight,
+                           std::numeric_limits<double>::max());
+        if (!std::isfinite(dt) ||
+            std::isfinite(dt * stencil.weight(control, sample)))
+          continue;
+        std::vector<double> values(stencil.sample_count(), 1.0);
+        auto samples = samples_from_values(method, values);
+        expect_preallocation_failure([&] {
+          CarpetX::build_reference_dense_controls(method, dt, samples.views);
+        });
+        found_double_overflow_case = true;
+        break;
+      }
+      if (found_double_overflow_case)
+        break;
+    }
+    if (found_double_overflow_case)
+      break;
+  }
+  assert(found_double_overflow_case);
+
+  if constexpr (std::numeric_limits<amrex::Real>::max() <
+                std::numeric_limits<double>::max()) {
+    const auto method = SubcyclingODEMethod::rk4;
+    const auto &stencil = CarpetX::reference_dense_stencil(method);
+    std::vector<double> values(stencil.sample_count(), 1.0);
+    auto samples = samples_from_values(method, values);
+    const double dt =
+        static_cast<double>(std::numeric_limits<amrex::Real>::max()) * 8.0;
+    assert(std::isfinite(dt));
+    bool has_finite_out_of_range_coefficient = false;
+    for (std::size_t control = 0; control < stencil.control_count();
+         ++control) {
+      for (std::size_t sample = 0; sample < stencil.sample_count(); ++sample) {
+        if (stencil.specification().constraints[sample].kind !=
+            DenseSampleKind::scaled_derivative)
+          continue;
+        const double effective = dt * stencil.weight(control, sample);
+        if (std::isfinite(effective) &&
+            (effective < static_cast<double>(
+                             std::numeric_limits<amrex::Real>::lowest()) ||
+             effective > static_cast<double>(
+                             std::numeric_limits<amrex::Real>::max()))) {
+          has_finite_out_of_range_coefficient = true;
+          break;
+        }
+      }
+      if (has_finite_out_of_range_coefficient)
+        break;
+    }
+    assert(has_finite_out_of_range_coefficient);
+    expect_preallocation_failure([&] {
+      CarpetX::build_reference_dense_controls(method, dt, samples.views);
+    });
+  }
+}
+
+void test_sources_and_ghosts_are_unchanged() {
+  auto samples = samples_from_values(SubcyclingODEMethod::rk4,
+                                    {1.0, 2.0, 3.0, 4.0, 5.0});
+  std::vector<double> interiors;
+  std::vector<double> ghosts;
+  for (const auto &sample : samples.views) {
+    interiors.push_back(first_value(*sample.state));
+    ghosts.push_back(first_ghost(*sample.state));
+  }
+
+  const auto controls = CarpetX::build_reference_dense_controls(
+      SubcyclingODEMethod::rk4, 0.5, samples.views);
+
+  for (std::size_t index = 0; index < samples.views.size(); ++index) {
+    assert(first_value(*samples.views[index].state) == interiors[index]);
+    assert(first_ghost(*samples.views[index].state) == ghosts[index]);
+  }
+  for (std::size_t index = 0; index < controls.control_count(); ++index)
+    assert(first_ghost(controls.control(index)) ==
+           static_cast<double>(amrex::MultiFab::uninitialized_value()));
+}
+
+void test_allocation_and_operation_failures_release_all_local_controls() {
+  auto samples = samples_from_values(SubcyclingODEMethod::dp87_order8,
+                                    {1.0, 2.0, 3.0, 4.0, 5.0,
+                                     6.0, 7.0, 8.0, 9.0});
+  const int baseline = amrex::MultiFab::live_count();
+
+  amrex::MultiFab::reset_failures();
+  amrex::MultiFab::fail_construction_after(2);
+  expect_throw<std::runtime_error>([&] {
+    CarpetX::build_reference_dense_controls(SubcyclingODEMethod::dp87_order8,
+                                             0.5, samples.views);
+  });
+  assert(amrex::MultiFab::live_count() == baseline);
+
+  amrex::MultiFab::reset_failures();
+  amrex::MultiFab::fail_setval_after(0);
+  expect_throw<std::runtime_error>([&] {
+    CarpetX::build_reference_dense_controls(SubcyclingODEMethod::dp87_order8,
+                                             0.5, samples.views);
+  });
+  assert(amrex::MultiFab::live_count() == baseline);
+
+  amrex::MultiFab::reset_failures();
+  amrex::MultiFab::fail_saxpy_after(5);
+  expect_throw<std::runtime_error>([&] {
+    CarpetX::build_reference_dense_controls(SubcyclingODEMethod::dp87_order8,
+                                             0.5, samples.views);
+  });
+  assert(amrex::MultiFab::live_count() == baseline);
+  amrex::MultiFab::reset_failures();
+}
+
+void test_move_release_and_bounds_contract() {
+  auto samples = samples_from_values(SubcyclingODEMethod::rk4,
+                                    {1.0, 2.0, 3.0, 4.0, 5.0});
+  auto controls = CarpetX::build_reference_dense_controls(
+      SubcyclingODEMethod::rk4, 0.5, samples.views);
+  expect_throw<std::out_of_range>([&] { controls.control(5); });
+
+  DenseMFabControlSet moved(std::move(controls));
+  assert(moved.control_count() == 5);
+  auto released = std::move(moved).release_controls();
+  assert(released.size() == 5);
+  for (const auto &control : released)
+    assert(control != nullptr);
+}
+
+} // namespace
+
+int main() {
+  test_builds_owned_controls_and_reproduces_reference_polynomials();
+  test_only_derivative_columns_receive_parent_dt();
+  test_endpoint_controls_are_exact_copy_operations();
+  test_zero_coefficients_are_removed_before_saxpy();
+  test_invalid_method_dt_count_and_metadata_fail_before_allocation();
+  test_all_samples_are_globally_prevalidated_even_when_a_weight_is_zero();
+  test_nonfinite_effective_coefficients_fail_before_allocation();
+  test_sources_and_ghosts_are_unchanged();
+  test_allocation_and_operation_failures_release_all_local_controls();
+  test_move_release_and_bounds_contract();
+  std::cout << "Dense MultiFab control-builder tests passed\n";
+  return 0;
+}

--- a/CarpetX/test/subcycling_dense_mfab_state_unit.cxx
+++ b/CarpetX/test/subcycling_dense_mfab_state_unit.cxx
@@ -1,0 +1,409 @@
+#include "subcycling_dense_mfab_state.hxx"
+
+#include <AMReX_MultiFab.H>
+
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using CarpetX::DenseMFabKey;
+using CarpetX::DenseMFabView;
+using CarpetX::DenseStateVector;
+using CarpetX::OwnedMultiFabDenseState;
+
+static_assert(!std::is_copy_constructible_v<OwnedMultiFabDenseState>);
+static_assert(!std::is_copy_assignable_v<OwnedMultiFabDenseState>);
+static_assert(!std::is_move_constructible_v<OwnedMultiFabDenseState>);
+static_assert(!std::is_move_assignable_v<OwnedMultiFabDenseState>);
+static_assert(std::is_final_v<OwnedMultiFabDenseState>);
+
+template <typename Function> void expect_invalid_argument(Function &&function) {
+  bool threw = false;
+  try {
+    function();
+  } catch (const std::invalid_argument &) {
+    threw = true;
+  }
+  assert(threw);
+}
+
+class OtherDenseState final : public DenseStateVector {
+public:
+  bool compatible(const DenseStateVector &) const noexcept override {
+    return false;
+  }
+
+  void copy_from(const DenseStateVector &) override {}
+
+  void linear_combination(
+      const std::vector<double> &,
+      const std::vector<const DenseStateVector *> &) override {}
+};
+
+DenseMFabKey key(const std::int64_t epoch = 7, const int patch = 1,
+                 const int level = 2, const int group = 3) {
+  return DenseMFabKey{epoch, patch, level, group};
+}
+
+std::unique_ptr<amrex::MultiFab>
+borrowed_mfab(const int box_array = 11, const int distribution = 13,
+              const int components = 2, const int grow = 1,
+              const double value = 1.0) {
+  auto result = std::make_unique<amrex::MultiFab>(
+      amrex::BoxArray(box_array), amrex::DistributionMapping(distribution),
+      components, amrex::IntVect(grow));
+  result->setVal(value, 0, components, 0);
+  for (int component = 0; component < components; ++component) {
+    result->test_set_valid(component, 1,
+                           value + 0.25 * static_cast<double>(component + 1));
+    result->test_set_ghost(component, value + 1000.0 + component);
+  }
+  return result;
+}
+
+std::unique_ptr<OwnedMultiFabDenseState>
+state(const DenseMFabKey &entry_key = key(), const int box_array = 11,
+      const int distribution = 13, const int components = 2,
+      const int grow = 1, const double value = 1.0) {
+  auto borrowed =
+      borrowed_mfab(box_array, distribution, components, grow, value);
+  return OwnedMultiFabDenseState::copy_of(
+      std::vector<DenseMFabView>{{entry_key, borrowed.get()}});
+}
+
+double first_value(const OwnedMultiFabDenseState &state) {
+  return state.multifab(0).test_valid(0, 0);
+}
+
+void assert_first_value(const OwnedMultiFabDenseState &state,
+                        const double expected) {
+  assert(std::abs(first_value(state) - expected) < 1.0e-12);
+}
+
+void test_copy_of_owns_values_and_copies_only_valid_interiors() {
+  amrex::MultiFab::reset_operation_log();
+  auto borrowed = borrowed_mfab(11, 13, 2, 2, 4.0);
+  const int live_before_copy = amrex::MultiFab::live_count();
+
+  auto owned = OwnedMultiFabDenseState::copy_of(
+      std::vector<DenseMFabView>{{key(), borrowed.get()}});
+
+  assert(amrex::MultiFab::live_count() == live_before_copy + 1);
+  assert(owned->entry_count() == 1);
+  assert(owned->key(0).hierarchy_epoch == 7);
+  assert(owned->key(0).patch == 1);
+  assert(owned->key(0).level == 2);
+  assert(owned->key(0).group_index == 3);
+  assert(owned->multifab(0).test_valid(0, 0) == 4.0);
+  assert(owned->multifab(0).test_valid(1, 1) == 4.5);
+  assert(owned->multifab(0).test_ghost(0) ==
+         amrex::MultiFab::uninitialized_value());
+  assert(amrex::MultiFab::all_operations_interior_only());
+
+  borrowed.reset();
+  assert(amrex::MultiFab::live_count() == live_before_copy);
+  assert(owned->multifab(0).test_valid(0, 0) == 4.0);
+  assert(owned->multifab(0).test_valid(1, 1) == 4.5);
+
+  const auto empty = OwnedMultiFabDenseState::empty_like(*owned);
+  assert(empty->compatible(*owned));
+  assert(owned->compatible(*empty));
+}
+
+void test_allocate_like_preserves_keys_and_layout_without_copying_values() {
+  auto first = borrowed_mfab(11, 13, 2, 1, 4.0);
+  auto second = borrowed_mfab(17, 19, 3, 2, 9.0);
+  const std::vector<DenseMFabView> views{
+      {key(7, 1, 2, 3), first.get()}, {key(7, 1, 2, 4), second.get()}};
+  const auto copied = OwnedMultiFabDenseState::copy_of(views);
+
+  amrex::MultiFab::reset_construction_count();
+  const auto allocated = OwnedMultiFabDenseState::allocate_like(views);
+
+  assert(amrex::MultiFab::construction_count() == 2);
+  assert(allocated->entry_count() == 2);
+  assert(allocated->key(0).hierarchy_epoch == 7);
+  assert(allocated->key(0).patch == 1);
+  assert(allocated->key(0).level == 2);
+  assert(allocated->key(0).group_index == 3);
+  assert(allocated->key(1).group_index == 4);
+  assert(allocated->multifab(0).boxArray() == first->boxArray());
+  assert(allocated->multifab(0).DistributionMap() ==
+         first->DistributionMap());
+  assert(allocated->multifab(0).nComp() == first->nComp());
+  assert(allocated->multifab(0).nGrowVect() == first->nGrowVect());
+  assert(allocated->multifab(1).boxArray() == second->boxArray());
+  assert(allocated->multifab(1).DistributionMap() ==
+         second->DistributionMap());
+  assert(allocated->multifab(1).nComp() == second->nComp());
+  assert(allocated->multifab(1).nGrowVect() == second->nGrowVect());
+  assert(allocated->compatible(*copied));
+  assert(copied->compatible(*allocated));
+  assert(allocated->multifab(0).test_valid(0, 0) ==
+         amrex::MultiFab::uninitialized_value());
+  assert(allocated->multifab(0).test_ghost(0) ==
+         amrex::MultiFab::uninitialized_value());
+  assert(allocated->multifab(1).test_valid(0, 0) ==
+         amrex::MultiFab::uninitialized_value());
+
+  amrex::MultiFab::reset_construction_count();
+  expect_invalid_argument(
+      [] { OwnedMultiFabDenseState::allocate_like({}); });
+  assert(amrex::MultiFab::construction_count() == 0);
+}
+
+void test_copy_of_rejects_invalid_views_before_allocation() {
+  auto first = borrowed_mfab();
+  auto second = borrowed_mfab();
+
+  amrex::MultiFab::reset_construction_count();
+  expect_invalid_argument(
+      [] { OwnedMultiFabDenseState::copy_of({}); });
+  assert(amrex::MultiFab::construction_count() == 0);
+
+  expect_invalid_argument([&] {
+    OwnedMultiFabDenseState::copy_of(
+        std::vector<DenseMFabView>{{key(), nullptr}});
+  });
+  assert(amrex::MultiFab::construction_count() == 0);
+
+  expect_invalid_argument([&] {
+    OwnedMultiFabDenseState::copy_of(std::vector<DenseMFabView>{
+        {key(7, 1, 2, 3), first.get()}, {key(7, 1, 2, 4), nullptr}});
+  });
+  assert(amrex::MultiFab::construction_count() == 0);
+
+  for (const auto &invalid_key :
+       std::vector<DenseMFabKey>{key(-1, 1, 2, 3), key(7, -1, 2, 3),
+                                 key(7, 1, -1, 3), key(7, 1, 2, -1)}) {
+    expect_invalid_argument([&] {
+      OwnedMultiFabDenseState::copy_of(
+          std::vector<DenseMFabView>{{invalid_key, first.get()}});
+    });
+    assert(amrex::MultiFab::construction_count() == 0);
+  }
+
+  expect_invalid_argument([&] {
+    OwnedMultiFabDenseState::copy_of(std::vector<DenseMFabView>{
+        {key(7, 1, 2, 3), first.get()}, {key(7, 1, 2, -1), second.get()}});
+  });
+  assert(amrex::MultiFab::construction_count() == 0);
+
+  expect_invalid_argument([&] {
+    OwnedMultiFabDenseState::copy_of(std::vector<DenseMFabView>{
+        {key(7, 1, 2, 3), first.get()}, {key(7, 1, 2, 3), second.get()}});
+  });
+  assert(amrex::MultiFab::construction_count() == 0);
+
+  expect_invalid_argument([&] {
+    OwnedMultiFabDenseState::copy_of(std::vector<DenseMFabView>{
+        {key(7, 1, 2, 4), first.get()}, {key(7, 1, 2, 3), second.get()}});
+  });
+  assert(amrex::MultiFab::construction_count() == 0);
+
+  expect_invalid_argument([&] {
+    OwnedMultiFabDenseState::copy_of(std::vector<DenseMFabView>{
+        {key(7, 1, 2, 3), first.get()}, {key(8, 1, 2, 3), second.get()}});
+  });
+  assert(amrex::MultiFab::construction_count() == 0);
+}
+
+void test_exact_key_and_layout_compatibility() {
+  const auto reference = state();
+  const auto identical = state();
+  assert(reference->compatible(*identical));
+  assert(identical->compatible(*reference));
+
+  const std::vector<std::unique_ptr<OwnedMultiFabDenseState>> mismatches = [&] {
+    std::vector<std::unique_ptr<OwnedMultiFabDenseState>> result;
+    result.push_back(state(key(8, 1, 2, 3)));
+    result.push_back(state(key(7, 2, 2, 3)));
+    result.push_back(state(key(7, 1, 3, 3)));
+    result.push_back(state(key(7, 1, 2, 4)));
+    result.push_back(state(key(), 17, 13, 2, 1));
+    result.push_back(state(key(), 11, 19, 2, 1));
+    result.push_back(state(key(), 11, 13, 3, 1));
+    result.push_back(state(key(), 11, 13, 2, 2));
+    return result;
+  }();
+
+  for (const auto &mismatch : mismatches) {
+    assert(!reference->compatible(*mismatch));
+    assert(!mismatch->compatible(*reference));
+  }
+
+  OtherDenseState other_type;
+  assert(!reference->compatible(other_type));
+}
+
+void test_copy_through_dense_state_interface() {
+  auto destination = state(key(), 11, 13, 2, 1, -3.0);
+  const auto source = state(key(), 11, 13, 2, 1, 9.0);
+  DenseStateVector &destination_base = *destination;
+  const DenseStateVector &source_base = *source;
+
+  amrex::MultiFab::reset_operation_log();
+  destination_base.copy_from(source_base);
+
+  assert_first_value(*destination, 9.0);
+  assert(destination->multifab(0).test_valid(1, 1) == 9.5);
+  assert(amrex::MultiFab::all_operations_interior_only());
+}
+
+void exercise_base_combination(const std::size_t count,
+                               const double expected) {
+  std::vector<std::unique_ptr<OwnedMultiFabDenseState>> owned_sources;
+  std::vector<const DenseStateVector *> base_sources;
+  std::vector<double> weights;
+  owned_sources.reserve(count);
+  base_sources.reserve(count);
+  weights.reserve(count);
+  for (std::size_t i = 0; i < count; ++i) {
+    owned_sources.push_back(state(key(), 11, 13, 2, 1,
+                                  static_cast<double>(i + 1)));
+    base_sources.push_back(owned_sources.back().get());
+    weights.push_back(static_cast<double>(i + 1));
+  }
+
+  auto destination = state(key(), 11, 13, 2, 1, -99.0);
+  DenseStateVector &destination_base = *destination;
+  amrex::MultiFab::reset_operation_log();
+  destination_base.linear_combination(weights, base_sources);
+  assert_first_value(*destination, expected);
+  assert(amrex::MultiFab::all_operations_interior_only());
+}
+
+void test_five_eight_and_nine_source_combinations_through_base_interface() {
+  exercise_base_combination(5, 55.0);
+  exercise_base_combination(8, 204.0);
+  exercise_base_combination(9, 285.0);
+
+  std::vector<std::unique_ptr<OwnedMultiFabDenseState>> owned_sources;
+  std::vector<const OwnedMultiFabDenseState *> concrete_sources;
+  std::vector<double> weights{1.0, 2.0, 3.0, 4.0, 5.0};
+  for (std::size_t i = 0; i < weights.size(); ++i) {
+    owned_sources.push_back(state(key(), 11, 13, 2, 1,
+                                  static_cast<double>(i + 1)));
+    concrete_sources.push_back(owned_sources.back().get());
+  }
+  const auto result = OwnedMultiFabDenseState::linear_combination_of(
+      weights, concrete_sources);
+  assert_first_value(*result, 55.0);
+}
+
+template <typename Function>
+void expect_failure_before_mutation(OwnedMultiFabDenseState &destination,
+                                    Function &&function) {
+  const double before = first_value(destination);
+  expect_invalid_argument(std::forward<Function>(function));
+  assert(first_value(destination) == before);
+}
+
+void test_copy_and_combination_failures_prevalidate_before_mutation() {
+  auto destination = state(key(), 11, 13, 2, 1, 314.0);
+  const auto compatible_source = state(key(), 11, 13, 2, 1, 2.0);
+  const auto incompatible_source = state(key(7, 1, 2, 4), 11, 13, 2, 1, 3.0);
+  OtherDenseState wrong_type;
+
+  expect_failure_before_mutation(*destination,
+                                 [&] { destination->copy_from(*destination); });
+  expect_failure_before_mutation(
+      *destination, [&] { destination->copy_from(wrong_type); });
+  expect_failure_before_mutation(
+      *destination, [&] { destination->copy_from(*incompatible_source); });
+
+  expect_failure_before_mutation(*destination, [&] {
+    destination->linear_combination({}, {});
+  });
+  expect_failure_before_mutation(*destination, [&] {
+    destination->linear_combination(
+        {1.0}, {compatible_source.get(), compatible_source.get()});
+  });
+  expect_failure_before_mutation(*destination, [&] {
+    destination->linear_combination({1.0}, {nullptr});
+  });
+  expect_failure_before_mutation(*destination, [&] {
+    destination->linear_combination(
+        {1.0, 1.0}, {compatible_source.get(), nullptr});
+  });
+  expect_failure_before_mutation(*destination, [&] {
+    destination->linear_combination({1.0}, {&wrong_type});
+  });
+  expect_failure_before_mutation(*destination, [&] {
+    destination->linear_combination(
+        {1.0, 1.0}, {compatible_source.get(), &wrong_type});
+  });
+  expect_failure_before_mutation(*destination, [&] {
+    destination->linear_combination({1.0}, {incompatible_source.get()});
+  });
+  expect_failure_before_mutation(*destination, [&] {
+    destination->linear_combination(
+        {1.0, 1.0}, {compatible_source.get(), incompatible_source.get()});
+  });
+  expect_failure_before_mutation(*destination, [&] {
+    destination->linear_combination(
+        {std::numeric_limits<double>::quiet_NaN()},
+        {compatible_source.get()});
+  });
+  expect_failure_before_mutation(*destination, [&] {
+    destination->linear_combination(
+        {1.0, std::numeric_limits<double>::quiet_NaN()},
+        {compatible_source.get(), compatible_source.get()});
+  });
+  expect_failure_before_mutation(*destination, [&] {
+    destination->linear_combination(
+        {std::numeric_limits<double>::infinity()},
+        {compatible_source.get()});
+  });
+  expect_failure_before_mutation(*destination, [&] {
+    destination->linear_combination({1.0}, {destination.get()});
+  });
+  expect_failure_before_mutation(*destination, [&] {
+    destination->linear_combination(
+        {1.0, 1.0}, {compatible_source.get(), destination.get()});
+  });
+
+  expect_invalid_argument([&] {
+    OwnedMultiFabDenseState::linear_combination_of(
+        {}, std::vector<const OwnedMultiFabDenseState *>{});
+  });
+  expect_invalid_argument([&] {
+    OwnedMultiFabDenseState::linear_combination_of(
+        {1.0}, std::vector<const OwnedMultiFabDenseState *>{nullptr});
+  });
+  expect_invalid_argument([&] {
+    OwnedMultiFabDenseState::linear_combination_of(
+        {std::numeric_limits<double>::quiet_NaN()},
+        std::vector<const OwnedMultiFabDenseState *>{compatible_source.get()});
+  });
+  expect_invalid_argument([&] {
+    OwnedMultiFabDenseState::linear_combination_of(
+        {1.0},
+        std::vector<const OwnedMultiFabDenseState *>{compatible_source.get(),
+                                                      compatible_source.get()});
+  });
+}
+
+} // namespace
+
+int main() {
+  test_copy_of_owns_values_and_copies_only_valid_interiors();
+  test_allocate_like_preserves_keys_and_layout_without_copying_values();
+  test_copy_of_rejects_invalid_views_before_allocation();
+  test_exact_key_and_layout_compatibility();
+  test_copy_through_dense_state_interface();
+  test_five_eight_and_nine_source_combinations_through_base_interface();
+  test_copy_and_combination_failures_prevalidate_before_mutation();
+  std::cout << "Owned MultiFab dense-state tests passed\n";
+  return 0;
+}

--- a/CarpetX/test/subcycling_dense_output_unit.cxx
+++ b/CarpetX/test/subcycling_dense_output_unit.cxx
@@ -1,0 +1,467 @@
+#include "subcycling_dense_output.hxx"
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using CarpetX::DenseCapability;
+using CarpetX::DenseInterval;
+using CarpetX::DenseIntervalBuilder;
+using CarpetX::DenseIntervalId;
+using CarpetX::DenseOutputProvider;
+using CarpetX::DenseOutputRegistry;
+using CarpetX::DenseStateVector;
+using CarpetX::SubcyclingODEMethod;
+using CarpetX::TableauFingerprint;
+using CarpetX::step_clock_t;
+
+static_assert(!std::is_copy_constructible_v<DenseIntervalBuilder>);
+static_assert(!std::is_copy_assignable_v<DenseIntervalBuilder>);
+static_assert(std::is_move_constructible_v<DenseIntervalBuilder>);
+static_assert(std::is_move_assignable_v<DenseIntervalBuilder>);
+static_assert(std::is_final_v<DenseOutputProvider>);
+
+template <typename Exception, typename Function>
+void expect_throw(Function &&function) {
+  bool threw = false;
+  try {
+    function();
+  } catch (const Exception &) {
+    threw = true;
+  }
+  assert(threw);
+}
+
+TableauFingerprint fingerprint(const std::uint8_t seed = 1) {
+  TableauFingerprint result{};
+  for (std::size_t i = 0; i < result.size(); ++i)
+    result[i] = static_cast<std::uint8_t>(seed + i);
+  return result;
+}
+
+DenseCapability capability(const int degree = 4) {
+  return DenseCapability{SubcyclingODEMethod::rk4,
+                         fingerprint(),
+                         degree,
+                         degree,
+                         4,
+                         1,
+                         degree + 1,
+                         true,
+                         true};
+}
+
+DenseIntervalId interval_id() {
+  return DenseIntervalId{2,
+                         step_clock_t(5, 8),
+                         step_clock_t(7, 8),
+                         1.25,
+                         2.5,
+                         SubcyclingODEMethod::rk4,
+                         fingerprint()};
+}
+
+class ScalarState final : public DenseStateVector {
+public:
+  explicit ScalarState(const double value = 0.0, const int shape = 1,
+                       int *destructor_count = nullptr)
+      : value(value), shape(shape), destructor_count(destructor_count) {}
+
+  ~ScalarState() override {
+    if (destructor_count != nullptr)
+      ++*destructor_count;
+  }
+
+  bool compatible(const DenseStateVector &other) const noexcept override {
+    const auto *scalar = dynamic_cast<const ScalarState *>(&other);
+    return scalar != nullptr && scalar->shape == shape;
+  }
+
+  void copy_from(const DenseStateVector &other) override {
+    const auto *scalar = dynamic_cast<const ScalarState *>(&other);
+    if (scalar == nullptr || scalar->shape != shape)
+      throw std::invalid_argument("incompatible scalar copy");
+    value = scalar->value;
+    ++copy_calls;
+  }
+
+  void linear_combination(
+      const std::vector<double> &weights,
+      const std::vector<const DenseStateVector *> &sources) override {
+    if (weights.size() != sources.size())
+      throw std::invalid_argument("weight/source mismatch");
+    double result = 0.0;
+    for (std::size_t i = 0; i < weights.size(); ++i) {
+      const auto *scalar = dynamic_cast<const ScalarState *>(sources[i]);
+      if (scalar == nullptr || scalar->shape != shape)
+        throw std::invalid_argument("incompatible scalar combination");
+      result += weights[i] * scalar->value;
+    }
+    value = result;
+    ++linear_combination_calls;
+  }
+
+  double value;
+  int shape;
+  int *destructor_count;
+  int copy_calls{0};
+  int linear_combination_calls{0};
+};
+
+std::unique_ptr<DenseStateVector> scalar_control(const double value,
+                                                const int shape = 1,
+                                                int *destroyed = nullptr) {
+  return std::make_unique<ScalarState>(value, shape, destroyed);
+}
+
+double binomial(const int n, const int k) {
+  if (k < 0 || k > n)
+    return 0.0;
+  double result = 1.0;
+  for (int i = 1; i <= k; ++i)
+    result *= static_cast<double>(n - k + i) / static_cast<double>(i);
+  return result;
+}
+
+void test_empty_registry_and_capability_rejections() {
+  DenseOutputRegistry registry;
+  expect_throw<std::out_of_range>([&] {
+    registry.require(SubcyclingODEMethod::rk4, fingerprint());
+  });
+
+  auto invalid = capability();
+  invalid.verified = false;
+  expect_throw<std::invalid_argument>([&] {
+    registry.register_provider(
+        std::make_shared<DenseOutputProvider>(invalid));
+  });
+
+  invalid = capability();
+  invalid.dense_uniform_order = invalid.endpoint_order - 1;
+  expect_throw<std::invalid_argument>([&] {
+    registry.register_provider(
+        std::make_shared<DenseOutputProvider>(invalid));
+  });
+
+  invalid = capability();
+  invalid.endpoint_order = 0;
+  expect_throw<std::invalid_argument>([&] {
+    registry.register_provider(
+        std::make_shared<DenseOutputProvider>(invalid));
+  });
+
+  invalid = capability();
+  invalid.arbitrary_theta = false;
+  expect_throw<std::invalid_argument>([&] {
+    registry.register_provider(
+        std::make_shared<DenseOutputProvider>(invalid));
+  });
+
+  invalid = capability();
+  invalid.tableau_fingerprint = TableauFingerprint{};
+  expect_throw<std::invalid_argument>([&] {
+    registry.register_provider(
+        std::make_shared<DenseOutputProvider>(invalid));
+  });
+
+  invalid = capability();
+  invalid.stage_count = 0;
+  expect_throw<std::invalid_argument>([&] {
+    registry.register_provider(
+        std::make_shared<DenseOutputProvider>(invalid));
+  });
+
+  invalid = capability();
+  invalid.extra_rhs_evaluations = -1;
+  expect_throw<std::invalid_argument>([&] {
+    registry.register_provider(
+        std::make_shared<DenseOutputProvider>(invalid));
+  });
+
+  invalid = capability();
+  invalid.persistent_vector_count = 0;
+  expect_throw<std::invalid_argument>([&] {
+    registry.register_provider(
+        std::make_shared<DenseOutputProvider>(invalid));
+  });
+
+  invalid = capability();
+  invalid.persistent_vector_count = invalid.dense_uniform_order;
+  expect_throw<std::invalid_argument>([&] {
+    registry.register_provider(
+        std::make_shared<DenseOutputProvider>(invalid));
+  });
+
+  expect_throw<std::invalid_argument>(
+      [&] { registry.register_provider(nullptr); });
+}
+
+void test_exact_lookup_and_duplicate_method_rejection() {
+  DenseOutputRegistry registry;
+  auto caller_capability = capability();
+  auto provider =
+      std::make_shared<DenseOutputProvider>(caller_capability);
+  registry.register_provider(provider);
+  assert(registry.require(SubcyclingODEMethod::rk4, fingerprint()) == provider);
+
+  caller_capability.method = SubcyclingODEMethod::dp87_order8;
+  caller_capability.tableau_fingerprint = fingerprint(9);
+  caller_capability.verified = false;
+  assert(provider->capability().method == SubcyclingODEMethod::rk4);
+  assert(provider->capability().tableau_fingerprint == fingerprint());
+  assert(provider->capability().verified);
+  assert(provider->begin_interval(interval_id()) != nullptr);
+
+  expect_throw<std::out_of_range>([&] {
+    registry.require(SubcyclingODEMethod::rk4, fingerprint(2));
+  });
+  expect_throw<std::out_of_range>([&] {
+    registry.require(SubcyclingODEMethod::dp87_order8, fingerprint());
+  });
+
+  auto duplicate = capability(5);
+  duplicate.tableau_fingerprint = fingerprint(7);
+  expect_throw<std::logic_error>([&] {
+    registry.register_provider(
+        std::make_shared<DenseOutputProvider>(duplicate));
+  });
+}
+
+void test_interval_id_validation() {
+  const auto provider = DenseOutputProvider(capability());
+  auto invalid = interval_id();
+
+  invalid.level = -1;
+  expect_throw<std::invalid_argument>([&] { provider.begin_interval(invalid); });
+  invalid = interval_id();
+  invalid.end_clock = invalid.begin_clock;
+  expect_throw<std::invalid_argument>([&] { provider.begin_interval(invalid); });
+  invalid = interval_id();
+  invalid.end_clock = step_clock_t(1, 2);
+  expect_throw<std::invalid_argument>([&] { provider.begin_interval(invalid); });
+  invalid = interval_id();
+  invalid.begin_time = std::numeric_limits<double>::quiet_NaN();
+  expect_throw<std::invalid_argument>([&] { provider.begin_interval(invalid); });
+  invalid = interval_id();
+  invalid.end_time = std::numeric_limits<double>::infinity();
+  expect_throw<std::invalid_argument>([&] { provider.begin_interval(invalid); });
+  invalid = interval_id();
+  invalid.end_time = invalid.begin_time;
+  expect_throw<std::invalid_argument>([&] { provider.begin_interval(invalid); });
+  invalid = interval_id();
+  invalid.method = SubcyclingODEMethod::rkf78_order7;
+  expect_throw<std::invalid_argument>([&] { provider.begin_interval(invalid); });
+  invalid = interval_id();
+  invalid.tableau_fingerprint = fingerprint(2);
+  expect_throw<std::invalid_argument>([&] { provider.begin_interval(invalid); });
+}
+
+void test_builder_state_machine_and_owned_lifetime() {
+  const auto provider = DenseOutputProvider(capability());
+  auto builder = provider.begin_interval(interval_id());
+
+  expect_throw<std::invalid_argument>(
+      [&] { builder->add_control(nullptr); });
+  builder->add_control(scalar_control(0.0));
+  expect_throw<std::invalid_argument>(
+      [&] { builder->add_control(scalar_control(1.0, 2)); });
+  expect_throw<std::logic_error>([&] { builder->seal(); });
+
+  builder->add_control(scalar_control(0.25));
+  builder->add_control(scalar_control(0.5));
+  builder->add_control(scalar_control(0.75));
+  builder->add_control(scalar_control(1.0));
+  expect_throw<std::length_error>(
+      [&] { builder->add_control(scalar_control(2.0)); });
+
+  auto interval = builder->seal();
+  static_assert(std::is_same_v<decltype(interval),
+                               std::shared_ptr<const CarpetX::DenseInterval>>);
+  expect_throw<std::logic_error>(
+      [&] { builder->add_control(scalar_control(3.0)); });
+  expect_throw<std::logic_error>([&] { builder->seal(); });
+
+  auto movable = provider.begin_interval(interval_id());
+  DenseIntervalBuilder moved = std::move(*movable);
+  expect_throw<std::logic_error>(
+      [&] { movable->add_control(scalar_control(0.0)); });
+  moved.add_control(scalar_control(0.0));
+
+  int destroyed = 0;
+  std::shared_ptr<const CarpetX::DenseInterval> retained;
+  {
+    auto lifetime_builder = provider.begin_interval(interval_id());
+    for (int i = 0; i < 5; ++i)
+      lifetime_builder->add_control(scalar_control(i, 1, &destroyed));
+    retained = lifetime_builder->seal();
+    assert(destroyed == 0);
+    auto second_reference = retained;
+    retained.reset();
+    assert(destroyed == 0);
+    retained = std::move(second_reference);
+  }
+  assert(destroyed == 0);
+  retained.reset();
+  assert(destroyed == 5);
+}
+
+void test_move_assignment_rejects_inactive_or_nonempty_builders() {
+  const auto provider = DenseOutputProvider(capability());
+
+  auto sealed_target = provider.begin_interval(interval_id());
+  for (int i = 0; i < 5; ++i)
+    sealed_target->add_control(scalar_control(i));
+  const auto retained_target = sealed_target->seal();
+  auto active_source = provider.begin_interval(interval_id());
+  expect_throw<std::logic_error>(
+      [&] { *sealed_target = std::move(*active_source); });
+  active_source->add_control(scalar_control(0.0));
+  assert(retained_target->control_count() == 5);
+
+  auto active_target = provider.begin_interval(interval_id());
+  auto sealed_source = provider.begin_interval(interval_id());
+  for (int i = 0; i < 5; ++i)
+    sealed_source->add_control(scalar_control(i));
+  const auto retained_source = sealed_source->seal();
+  expect_throw<std::logic_error>(
+      [&] { *active_target = std::move(*sealed_source); });
+  active_target->add_control(scalar_control(0.0));
+  assert(retained_source->control_count() == 5);
+
+  auto moved_target = provider.begin_interval(interval_id());
+  DenseIntervalBuilder target_owner = std::move(*moved_target);
+  auto second_active_source = provider.begin_interval(interval_id());
+  expect_throw<std::logic_error>(
+      [&] { *moved_target = std::move(*second_active_source); });
+  second_active_source->add_control(scalar_control(0.0));
+  target_owner.add_control(scalar_control(0.0));
+
+  auto second_active_target = provider.begin_interval(interval_id());
+  auto moved_source = provider.begin_interval(interval_id());
+  DenseIntervalBuilder source_owner = std::move(*moved_source);
+  expect_throw<std::logic_error>(
+      [&] { *second_active_target = std::move(*moved_source); });
+  second_active_target->add_control(scalar_control(0.0));
+  source_owner.add_control(scalar_control(0.0));
+
+  auto nonempty_target = provider.begin_interval(interval_id());
+  nonempty_target->add_control(scalar_control(0.0));
+  auto third_active_source = provider.begin_interval(interval_id());
+  expect_throw<std::logic_error>(
+      [&] { *nonempty_target = std::move(*third_active_source); });
+  third_active_source->add_control(scalar_control(0.0));
+
+  auto empty_target = provider.begin_interval(interval_id());
+  auto populated_source = provider.begin_interval(interval_id());
+  populated_source->add_control(scalar_control(0.0));
+  *empty_target = std::move(*populated_source);
+  empty_target->add_control(scalar_control(0.25));
+  expect_throw<std::logic_error>(
+      [&] { populated_source->add_control(scalar_control(1.0)); });
+}
+
+void test_bernstein_reproduces_monomials() {
+  for (const int degree : {4, 7, 8}) {
+    auto cap = capability(degree);
+    DenseOutputProvider provider(cap);
+    for (int power = 0; power <= degree; ++power) {
+      auto builder = provider.begin_interval(interval_id());
+      for (int k = 0; k <= degree; ++k) {
+        const auto coefficient =
+            k < power ? 0.0 : binomial(k, power) / binomial(degree, power);
+        builder->add_control(scalar_control(coefficient));
+      }
+      const auto interval = builder->seal();
+      for (const double theta : {0.0, 0.13, 0.5, 0.87, 1.0}) {
+        ScalarState result;
+        interval->evaluate(theta, result);
+        assert(std::abs(result.value - std::pow(theta, power)) < 2.0e-12);
+      }
+    }
+  }
+}
+
+void test_endpoint_and_interior_dispatch_and_theta_validation() {
+  DenseOutputProvider provider(capability());
+  auto builder = provider.begin_interval(interval_id());
+  for (int i = 0; i < 5; ++i)
+    builder->add_control(scalar_control(static_cast<double>(i)));
+  const auto interval = builder->seal();
+
+  ScalarState destination;
+  interval->evaluate(0.0, destination);
+  assert(destination.value == 0.0);
+  assert(destination.copy_calls == 1);
+  assert(destination.linear_combination_calls == 0);
+  interval->evaluate(1.0, destination);
+  assert(destination.value == 4.0);
+  assert(destination.copy_calls == 2);
+  assert(destination.linear_combination_calls == 0);
+  interval->evaluate(0.5, destination);
+  assert(destination.value == 2.0);
+  assert(destination.copy_calls == 2);
+  assert(destination.linear_combination_calls == 1);
+
+  expect_throw<std::invalid_argument>([&] {
+    interval->evaluate(std::numeric_limits<double>::quiet_NaN(), destination);
+  });
+  expect_throw<std::out_of_range>([&] { interval->evaluate(-0.01, destination); });
+  expect_throw<std::out_of_range>([&] { interval->evaluate(1.01, destination); });
+
+  ScalarState incompatible(0.0, 2);
+  expect_throw<std::invalid_argument>(
+      [&] { interval->evaluate(0.5, incompatible); });
+}
+
+void test_exact_rational_theta_overload_and_validation() {
+  const auto exact_overload = static_cast<void (DenseInterval::*)(
+      step_clock_t, DenseStateVector &) const>(&DenseInterval::evaluate);
+  assert(exact_overload != nullptr);
+
+  DenseOutputProvider provider(capability());
+  auto builder = provider.begin_interval(interval_id());
+  for (int i = 0; i < 5; ++i)
+    builder->add_control(scalar_control(static_cast<double>(i)));
+  const auto interval = builder->seal();
+
+  ScalarState destination;
+  interval->evaluate(step_clock_t(0), destination);
+  assert(destination.value == 0.0);
+  interval->evaluate(step_clock_t(1), destination);
+  assert(destination.value == 4.0);
+  interval->evaluate(step_clock_t(1, 4), destination);
+  assert(std::abs(destination.value - 1.0) < 1.0e-12);
+
+  expect_throw<std::out_of_range>(
+      [&] { interval->evaluate(step_clock_t(-1, 4), destination); });
+  expect_throw<std::out_of_range>(
+      [&] { interval->evaluate(step_clock_t(5, 4), destination); });
+  const step_clock_t zero_denominator(
+      1, 0, step_clock_t::no_normalize{});
+  expect_throw<std::invalid_argument>(
+      [&] { interval->evaluate(zero_denominator, destination); });
+}
+
+} // namespace
+
+int main() {
+  test_empty_registry_and_capability_rejections();
+  test_exact_lookup_and_duplicate_method_rejection();
+  test_interval_id_validation();
+  test_builder_state_machine_and_owned_lifetime();
+  test_move_assignment_rejects_inactive_or_nonempty_builders();
+  test_bernstein_reproduces_monomials();
+  test_endpoint_and_interior_dispatch_and_theta_validation();
+  test_exact_rational_theta_overload_and_validation();
+  std::cout << "Subcycling dense-output contract tests passed\n";
+  return 0;
+}

--- a/CarpetX/test/subcycling_dense_stencil_unit.cxx
+++ b/CarpetX/test/subcycling_dense_stencil_unit.cxx
@@ -1,0 +1,315 @@
+#include "subcycling_dense_stencil.hxx"
+
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using CarpetX::DenseSampleConstraint;
+using CarpetX::DenseSampleKind;
+using CarpetX::DenseStencil;
+using CarpetX::DenseStencilSpecification;
+using CarpetX::SubcyclingODEMethod;
+
+static_assert(!std::is_copy_assignable_v<DenseStencil>);
+static_assert(!std::is_move_assignable_v<DenseStencil>);
+
+template <typename Exception, typename Function>
+void expect_throw(Function &&function) {
+  bool threw = false;
+  try {
+    function();
+  } catch (const Exception &) {
+    threw = true;
+  }
+  assert(threw);
+}
+
+double binomial(const int n, const int k) {
+  if (k < 0 || k > n)
+    return 0.0;
+  const int smaller = k < n - k ? k : n - k;
+  double result = 1.0;
+  for (int j = 1; j <= smaller; ++j)
+    result *= static_cast<double>(n - smaller + j) / static_cast<double>(j);
+  return result;
+}
+
+double evaluate_bernstein(const std::vector<double> &controls,
+                          const double theta) {
+  const int degree = static_cast<int>(controls.size()) - 1;
+  double result = 0.0;
+  for (int i = 0; i <= degree; ++i)
+    result += controls[static_cast<std::size_t>(i)] * binomial(degree, i) *
+              std::pow(theta, i) * std::pow(1.0 - theta, degree - i);
+  return result;
+}
+
+double evaluate_bernstein_derivative(const std::vector<double> &controls,
+                                     const double theta) {
+  const int degree = static_cast<int>(controls.size()) - 1;
+  if (degree == 0)
+    return 0.0;
+  double result = 0.0;
+  for (int i = 0; i < degree; ++i)
+    result += static_cast<double>(degree) *
+              (controls[static_cast<std::size_t>(i + 1)] -
+               controls[static_cast<std::size_t>(i)]) *
+              binomial(degree - 1, i) * std::pow(theta, i) *
+              std::pow(1.0 - theta, degree - 1 - i);
+  return result;
+}
+
+DenseStencilSpecification valid_rk4_specification() {
+  return DenseStencilSpecification{
+      SubcyclingODEMethod::rk4,
+      4,
+      4,
+      4,
+      4,
+      {{0.0, DenseSampleKind::value},
+       {0.0, DenseSampleKind::scaled_derivative},
+       {0.5, DenseSampleKind::value},
+       {1.0, DenseSampleKind::value},
+       {1.0, DenseSampleKind::scaled_derivative}}};
+}
+
+void assert_constraint(const DenseSampleConstraint &constraint,
+                       const double theta, const DenseSampleKind kind) {
+  assert(constraint.theta == theta);
+  assert(constraint.kind == kind);
+}
+
+void test_exact_reference_method_specifications() {
+  const auto &rk4 =
+      CarpetX::reference_dense_stencil(SubcyclingODEMethod::rk4);
+  const auto &rk4_spec = rk4.specification();
+  assert(rk4_spec.endpoint_order == 4);
+  assert(rk4_spec.dense_uniform_order == 4);
+  assert(rk4_spec.stage_count == 4);
+  assert(rk4_spec.extra_rhs_evaluations == 4);
+  assert(rk4_spec.constraints.size() == 5);
+  assert_constraint(rk4_spec.constraints[0], 0.0, DenseSampleKind::value);
+  assert_constraint(rk4_spec.constraints[1], 0.0,
+                    DenseSampleKind::scaled_derivative);
+  assert_constraint(rk4_spec.constraints[2], 0.5, DenseSampleKind::value);
+  assert_constraint(rk4_spec.constraints[3], 1.0, DenseSampleKind::value);
+  assert_constraint(rk4_spec.constraints[4], 1.0,
+                    DenseSampleKind::scaled_derivative);
+
+  const auto &rkf78 =
+      CarpetX::reference_dense_stencil(SubcyclingODEMethod::rkf78_order7);
+  const auto &rkf78_spec = rkf78.specification();
+  assert(rkf78_spec.endpoint_order == 7);
+  assert(rkf78_spec.dense_uniform_order == 7);
+  assert(rkf78_spec.stage_count == 11);
+  assert(rkf78_spec.extra_rhs_evaluations == 23);
+  assert(rkf78_spec.constraints.size() == 8);
+  for (std::size_t i = 0; i < 4; ++i) {
+    const double theta = static_cast<double>(i) / 3.0;
+    assert_constraint(rkf78_spec.constraints[2 * i], theta,
+                      DenseSampleKind::value);
+    assert_constraint(rkf78_spec.constraints[2 * i + 1], theta,
+                      DenseSampleKind::scaled_derivative);
+  }
+
+  const auto &dp87 =
+      CarpetX::reference_dense_stencil(SubcyclingODEMethod::dp87_order8);
+  const auto &dp87_spec = dp87.specification();
+  assert(dp87_spec.endpoint_order == 8);
+  assert(dp87_spec.dense_uniform_order == 8);
+  assert(dp87_spec.stage_count == 13);
+  assert(dp87_spec.extra_rhs_evaluations == 39);
+  assert(dp87_spec.constraints.size() == 9);
+  assert_constraint(dp87_spec.constraints[0], 0.0, DenseSampleKind::value);
+  assert_constraint(dp87_spec.constraints[1], 0.0,
+                    DenseSampleKind::scaled_derivative);
+  assert_constraint(dp87_spec.constraints[2], 0.25, DenseSampleKind::value);
+  assert_constraint(dp87_spec.constraints[3], 0.25,
+                    DenseSampleKind::scaled_derivative);
+  assert_constraint(dp87_spec.constraints[4], 0.5, DenseSampleKind::value);
+  assert_constraint(dp87_spec.constraints[5], 0.5,
+                    DenseSampleKind::scaled_derivative);
+  assert_constraint(dp87_spec.constraints[6], 0.75, DenseSampleKind::value);
+  assert_constraint(dp87_spec.constraints[7], 1.0, DenseSampleKind::value);
+  assert_constraint(dp87_spec.constraints[8], 1.0,
+                    DenseSampleKind::scaled_derivative);
+  for (const auto &constraint : dp87_spec.constraints)
+    assert(!(constraint.theta == 0.75 &&
+             constraint.kind == DenseSampleKind::scaled_derivative));
+
+  assert(&rk4 == &CarpetX::reference_dense_stencil(SubcyclingODEMethod::rk4));
+  assert(&rkf78 ==
+         &CarpetX::reference_dense_stencil(SubcyclingODEMethod::rkf78_order7));
+  assert(&dp87 ==
+         &CarpetX::reference_dense_stencil(SubcyclingODEMethod::dp87_order8));
+}
+
+void test_invalid_specifications_fail_closed() {
+  auto spec = valid_rk4_specification();
+  spec.constraints[2] = {0.0, DenseSampleKind::value};
+  expect_throw<std::invalid_argument>([&] { DenseStencil stencil(spec); });
+
+  spec = valid_rk4_specification();
+  spec.constraints.insert(spec.constraints.begin() + 2,
+                          {0.0, DenseSampleKind::scaled_derivative});
+  spec.constraints.pop_back();
+  expect_throw<std::invalid_argument>([&] { DenseStencil stencil(spec); });
+
+  spec = valid_rk4_specification();
+  std::swap(spec.constraints[2], spec.constraints[3]);
+  expect_throw<std::invalid_argument>([&] { DenseStencil stencil(spec); });
+
+  spec = valid_rk4_specification();
+  std::swap(spec.constraints[0], spec.constraints[1]);
+  expect_throw<std::invalid_argument>([&] { DenseStencil stencil(spec); });
+
+  spec = valid_rk4_specification();
+  spec.constraints[2].theta = std::numeric_limits<double>::quiet_NaN();
+  expect_throw<std::invalid_argument>([&] { DenseStencil stencil(spec); });
+
+  for (const double invalid_theta : {-0.01, 1.01}) {
+    spec = valid_rk4_specification();
+    spec.constraints[2].theta = invalid_theta;
+    expect_throw<std::invalid_argument>([&] { DenseStencil stencil(spec); });
+  }
+
+  spec = valid_rk4_specification();
+  spec.endpoint_order = 0;
+  expect_throw<std::invalid_argument>([&] { DenseStencil stencil(spec); });
+  spec = valid_rk4_specification();
+  spec.dense_uniform_order = 0;
+  expect_throw<std::invalid_argument>([&] { DenseStencil stencil(spec); });
+  spec = valid_rk4_specification();
+  spec.dense_uniform_order = 3;
+  expect_throw<std::invalid_argument>([&] { DenseStencil stencil(spec); });
+  spec = valid_rk4_specification();
+  spec.dense_uniform_order = std::numeric_limits<int>::max();
+  expect_throw<std::invalid_argument>([&] { DenseStencil stencil(spec); });
+  spec = valid_rk4_specification();
+  spec.constraints.pop_back();
+  expect_throw<std::invalid_argument>([&] { DenseStencil stencil(spec); });
+
+  spec = valid_rk4_specification();
+  spec.constraints[0].theta = 0.25;
+  expect_throw<std::invalid_argument>([&] { DenseStencil stencil(spec); });
+  spec = valid_rk4_specification();
+  spec.constraints[3].theta = 0.75;
+  spec.constraints[4].theta = 0.75;
+  expect_throw<std::invalid_argument>([&] { DenseStencil stencil(spec); });
+
+  spec = valid_rk4_specification();
+  spec.stage_count = 0;
+  expect_throw<std::invalid_argument>([&] { DenseStencil stencil(spec); });
+  spec = valid_rk4_specification();
+  spec.extra_rhs_evaluations = -1;
+  expect_throw<std::invalid_argument>([&] { DenseStencil stencil(spec); });
+  spec = valid_rk4_specification();
+  spec.method = static_cast<SubcyclingODEMethod>(99);
+  expect_throw<std::invalid_argument>([&] { DenseStencil stencil(spec); });
+  spec = valid_rk4_specification();
+  spec.constraints[2].kind = static_cast<DenseSampleKind>(99);
+  expect_throw<std::invalid_argument>([&] { DenseStencil stencil(spec); });
+}
+
+std::vector<double> monomial_samples(const DenseStencil &stencil,
+                                     const int power) {
+  std::vector<double> samples;
+  for (const auto &constraint : stencil.specification().constraints) {
+    if (constraint.kind == DenseSampleKind::value) {
+      samples.push_back(std::pow(constraint.theta, power));
+    } else if (power == 0) {
+      samples.push_back(0.0);
+    } else {
+      samples.push_back(static_cast<double>(power) *
+                        std::pow(constraint.theta, power - 1));
+    }
+  }
+  return samples;
+}
+
+void test_monomial_values_and_derivatives_are_reproduced() {
+  for (const auto method : {SubcyclingODEMethod::rk4,
+                            SubcyclingODEMethod::rkf78_order7,
+                            SubcyclingODEMethod::dp87_order8}) {
+    const auto &stencil = CarpetX::reference_dense_stencil(method);
+    const int degree = stencil.specification().dense_uniform_order;
+    for (int power = 0; power <= degree; ++power) {
+      const auto controls = stencil.make_controls(monomial_samples(stencil, power));
+      for (const double theta : {0.0, 0.07, 0.23, 0.5, 0.81, 1.0})
+        assert(std::abs(evaluate_bernstein(controls, theta) -
+                        std::pow(theta, power)) < 2.0e-11);
+      for (const auto &constraint : stencil.specification().constraints) {
+        const double expected =
+            power == 0
+                ? 0.0
+                : static_cast<double>(power) *
+                      std::pow(constraint.theta, power - 1);
+        assert(std::abs(evaluate_bernstein_derivative(
+                            controls, constraint.theta) -
+                        expected) < 2.0e-10);
+      }
+    }
+  }
+}
+
+void test_weight_matrix_is_finite_immutable_and_endpoint_exact() {
+  for (const auto method : {SubcyclingODEMethod::rk4,
+                            SubcyclingODEMethod::rkf78_order7,
+                            SubcyclingODEMethod::dp87_order8}) {
+    const auto &stencil = CarpetX::reference_dense_stencil(method);
+    const std::size_t count = stencil.sample_count();
+    assert(stencil.control_count() == count);
+    assert(stencil.weights().size() == count * count);
+    for (const double weight : stencil.weights())
+      assert(std::isfinite(weight));
+
+    const auto &constraints = stencil.specification().constraints;
+    std::size_t begin_value = count;
+    std::size_t end_value = count;
+    for (std::size_t j = 0; j < count; ++j) {
+      if (constraints[j].theta == 0.0 &&
+          constraints[j].kind == DenseSampleKind::value)
+        begin_value = j;
+      if (constraints[j].theta == 1.0 &&
+          constraints[j].kind == DenseSampleKind::value)
+        end_value = j;
+    }
+    assert(begin_value < count);
+    assert(end_value < count);
+    for (std::size_t j = 0; j < count; ++j) {
+      assert(stencil.weight(0, j) == (j == begin_value ? 1.0 : 0.0));
+      assert(stencil.weight(count - 1, j) ==
+             (j == end_value ? 1.0 : 0.0));
+    }
+
+    const auto first_weights = stencil.weights();
+    const auto second_controls =
+        CarpetX::reference_dense_stencil(method).make_controls(
+            std::vector<double>(count, 1.25));
+    assert(stencil.weights() == first_weights);
+    assert(second_controls.size() == count);
+    expect_throw<std::out_of_range>([&] { stencil.weight(count, 0); });
+    expect_throw<std::out_of_range>([&] { stencil.weight(0, count); });
+    expect_throw<std::invalid_argument>(
+        [&] { stencil.make_controls(std::vector<double>(count - 1, 0.0)); });
+  }
+}
+
+} // namespace
+
+int main() {
+  test_exact_reference_method_specifications();
+  test_invalid_specifications_fail_closed();
+  test_monomial_values_and_derivatives_are_reproduced();
+  test_weight_matrix_is_finite_immutable_and_endpoint_exact();
+  std::cout << "Subcycling dense-stencil tests passed\n";
+  return 0;
+}

--- a/CarpetX/test/subcycling_native_gate_contract_unit.cxx
+++ b/CarpetX/test/subcycling_native_gate_contract_unit.cxx
@@ -1,0 +1,84 @@
+#include "../src/subcycling_native_gate.hxx"
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+void check(const bool condition, const char *message) {
+  if (!condition)
+    throw std::runtime_error(message);
+}
+
+template <class Function> void rejects(Function &&function) {
+  bool rejected = false;
+  try {
+    function();
+  } catch (const std::invalid_argument &) {
+    rejected = true;
+  }
+  check(rejected, "unsupported gate iteration was accepted");
+}
+
+} // namespace
+
+int main() {
+  const auto rk4 = CarpetX::native_gate_method_contract(1);
+  check(rk4.method == CarpetX::SubcyclingODEMethod::rk4, "RK4 method");
+  check(std::string(rk4.ode_parameter_value) == "RK4", "RK4 name");
+  check(rk4.extra_rhs_evaluations == 4, "RK4 RHS count");
+  check(rk4.control_count == 5, "RK4 controls");
+
+  const auto rkf78 = CarpetX::native_gate_method_contract(2);
+  check(rkf78.method == CarpetX::SubcyclingODEMethod::rkf78_order7,
+        "RKF78 method");
+  check(std::string(rkf78.ode_parameter_value) == "RKF78", "RKF78 name");
+  check(rkf78.extra_rhs_evaluations == 23, "RKF78 RHS count");
+  check(rkf78.control_count == 8, "RKF78 controls");
+
+  const auto dp87 = CarpetX::native_gate_method_contract(3);
+  check(dp87.method == CarpetX::SubcyclingODEMethod::dp87_order8,
+        "DP87 method");
+  check(std::string(dp87.ode_parameter_value) == "DP87", "DP87 name");
+  check(dp87.extra_rhs_evaluations == 39, "DP87 RHS count");
+  check(dp87.control_count == 9, "DP87 controls");
+
+  rejects([] { (void)CarpetX::native_gate_method_contract(0); });
+  rejects([] { (void)CarpetX::native_gate_method_contract(4); });
+
+  const CarpetX::native_gate_detail::PatchContextInput patch{
+      0, 1, 0, 1, 2, 1, CarpetX::step_clock_t(2),
+      CarpetX::step_clock_t(1), 1.25, 0.125};
+  const auto context = CarpetX::native_gate_detail::make_patch_step_context(
+      patch, CarpetX::SubcyclingODEMethod::rkf78_order7);
+  check(context.level == 0, "patch level");
+  check(context.begin_clock == CarpetX::step_clock_t(1),
+        "patch begin clock");
+  check(context.end_clock == CarpetX::step_clock_t(2), "patch end clock");
+  check(context.begin_time == 1.125, "patch begin time");
+  check(context.end_time == 1.25, "patch end time");
+  check(context.method == CarpetX::SubcyclingODEMethod::rkf78_order7,
+        "patch method");
+
+  auto bad_active_levels = patch;
+  bad_active_levels.active_max_level = 2;
+  rejects([&] {
+    (void)CarpetX::native_gate_detail::make_patch_step_context(
+        bad_active_levels, CarpetX::SubcyclingODEMethod::rk4);
+  });
+  auto bad_clock = patch;
+  bad_clock.level_iteration = CarpetX::step_clock_t(3);
+  rejects([&] {
+    (void)CarpetX::native_gate_detail::make_patch_step_context(
+        bad_clock, CarpetX::SubcyclingODEMethod::rk4);
+  });
+  auto bad_timefac = patch;
+  bad_timefac.time_refinement_factor = 2;
+  rejects([&] {
+    (void)CarpetX::native_gate_detail::make_patch_step_context(
+        bad_timefac, CarpetX::SubcyclingODEMethod::rk4);
+  });
+  std::cout << "Phase 8D native gate contract tests passed\n";
+  return 0;
+}

--- a/CarpetX/test/subcycling_runtime_clock_unit.cxx
+++ b/CarpetX/test/subcycling_runtime_clock_unit.cxx
@@ -1,5 +1,6 @@
 #include "subcycling_runtime_clock.hxx"
 
+#include <array>
 #include <cassert>
 #include <climits>
 #include <cmath>
@@ -13,11 +14,14 @@ namespace {
 
 using CarpetX::RuntimeClockMetadata;
 using CarpetX::StaticV1ClockEnvelope;
+using CarpetX::StaticV1RecoverySeedEnvelope;
+using CarpetX::StaticV1StepperSeed;
 using CarpetX::StepContext;
 using CarpetX::SubcyclingODEMethod;
 using CarpetX::candidate_runtime_clock;
 using CarpetX::full_sync_root_runtime_clock;
 using CarpetX::static_v1_base_delta_time;
+using CarpetX::static_v1_recovery_seed;
 using CarpetX::step_clock_t;
 using CarpetX::validate_static_v1_clock_envelope;
 
@@ -159,6 +163,83 @@ StaticV1ClockEnvelope valid_envelope() {
                                {7, 14}};
 }
 
+StaticV1RecoverySeedEnvelope valid_recovery_seed_envelope() {
+  return StaticV1RecoverySeedEnvelope{
+      2,
+      2,
+      true,
+      false,
+      2,
+      1,
+      0.025,
+      0.0125,
+      {step_clock_t(0), step_clock_t(0)},
+      {step_clock_t(1), step_clock_t(1, 2)}};
+}
+
+void test_strict_full_sync_recovery_seed_at_epoch_two() {
+  const StaticV1StepperSeed seed =
+      static_v1_recovery_seed(valid_recovery_seed_envelope());
+
+  assert(seed.initial_clock == step_clock_t(2));
+  assert(seed.initial_physical_time == 0.025);
+  assert(seed.initial_epoch == 2);
+  assert((seed.initial_accepted_steps ==
+          std::array<std::uint64_t, 2>{2, 4}));
+}
+
+void test_recovery_seed_rejects_desynchronized_rebuilt_state() {
+  auto envelope = valid_recovery_seed_envelope();
+  envelope.root_timefac = 2;
+  expect_throw<std::invalid_argument>(
+      [&] { static_cast<void>(static_v1_recovery_seed(envelope)); });
+
+  envelope = valid_recovery_seed_envelope();
+  envelope.rebuilt_level_clocks[1] = step_clock_t(1, 2);
+  expect_throw<std::invalid_argument>(
+      [&] { static_cast<void>(static_v1_recovery_seed(envelope)); });
+}
+
+void test_recovery_seed_rejects_malformed_or_nonfinite_state() {
+  auto rejects = [](StaticV1RecoverySeedEnvelope envelope) {
+    expect_throw<std::invalid_argument>(
+        [&] { static_cast<void>(static_v1_recovery_seed(envelope)); });
+  };
+
+  auto envelope = valid_recovery_seed_envelope();
+  envelope.level_count = 3;
+  rejects(envelope);
+
+  envelope = valid_recovery_seed_envelope();
+  envelope.refinement_ratio = 4;
+  rejects(envelope);
+
+  envelope = valid_recovery_seed_envelope();
+  envelope.strict_recovery = false;
+  rejects(envelope);
+
+  envelope = valid_recovery_seed_envelope();
+  envelope.dynamic_regrid = true;
+  rejects(envelope);
+
+  envelope = valid_recovery_seed_envelope();
+  envelope.root_iteration = -1;
+  rejects(envelope);
+
+  envelope = valid_recovery_seed_envelope();
+  envelope.level_delta_clocks[1] = step_clock_t(1, 4);
+  rejects(envelope);
+
+  envelope = valid_recovery_seed_envelope();
+  envelope.root_time = std::numeric_limits<double>::quiet_NaN();
+  rejects(envelope);
+
+  envelope = valid_recovery_seed_envelope();
+  envelope.base_delta_time =
+      std::numeric_limits<double>::infinity();
+  rejects(envelope);
+}
+
 void test_static_v1_envelope_fails_closed() {
   auto envelope = valid_envelope();
   envelope.refinement_ratio = 4;
@@ -216,6 +297,9 @@ int main() {
   test_full_sync_and_static_v1_envelope();
   test_base_dt_rejects_invalid_static_v1_inputs();
   test_candidate_rejects_invalid_level_clock_time_and_iteration();
+  test_strict_full_sync_recovery_seed_at_epoch_two();
+  test_recovery_seed_rejects_desynchronized_rebuilt_state();
+  test_recovery_seed_rejects_malformed_or_nonfinite_state();
   test_static_v1_envelope_fails_closed();
   std::cout << "subcycling_runtime_clock_unit: PASS\n";
 }

--- a/CarpetX/test/subcycling_runtime_clock_unit.cxx
+++ b/CarpetX/test/subcycling_runtime_clock_unit.cxx
@@ -1,0 +1,221 @@
+#include "subcycling_runtime_clock.hxx"
+
+#include <cassert>
+#include <climits>
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+
+namespace {
+
+using CarpetX::RuntimeClockMetadata;
+using CarpetX::StaticV1ClockEnvelope;
+using CarpetX::StepContext;
+using CarpetX::SubcyclingODEMethod;
+using CarpetX::candidate_runtime_clock;
+using CarpetX::full_sync_root_runtime_clock;
+using CarpetX::static_v1_base_delta_time;
+using CarpetX::step_clock_t;
+using CarpetX::validate_static_v1_clock_envelope;
+
+template <typename Exception, typename Function>
+void expect_throw(Function &&function) {
+  bool threw = false;
+  try {
+    function();
+  } catch (const Exception &) {
+    threw = true;
+  }
+  assert(threw);
+}
+
+void assert_metadata(const RuntimeClockMetadata &actual, const int iteration,
+                     const double end_time, const double base_delta_time,
+                     const int timefac) {
+  assert(actual.iteration == iteration);
+  assert(actual.end_time == end_time);
+  assert(actual.base_delta_time == base_delta_time);
+  assert(actual.timefac == timefac);
+}
+
+StepContext context(const int level, const step_clock_t begin_clock,
+                    const step_clock_t end_clock, const double begin_time,
+                    const double end_time,
+                    const std::uint64_t endpoint_accepted_step) {
+  return StepContext{level,
+                     begin_clock,
+                     end_clock,
+                     begin_time,
+                     end_time,
+                     SubcyclingODEMethod::rk4,
+                     level == 0,
+                     endpoint_accepted_step};
+}
+
+void test_base_dt_and_candidate_metadata() {
+  const double base_dt = static_v1_base_delta_time(0.125, 2);
+  assert(base_dt == 0.25);
+
+  assert_metadata(candidate_runtime_clock(
+                      context(0, step_clock_t(0), step_clock_t(1), 10.0,
+                              10.25, 1),
+                      base_dt),
+                  1, 10.25, 0.25, 1);
+  assert_metadata(candidate_runtime_clock(
+                      context(1, step_clock_t(0), step_clock_t(1, 2), 10.0,
+                              10.125, 1),
+                      base_dt),
+                  1, 10.125, 0.25, 2);
+  assert_metadata(candidate_runtime_clock(
+                      context(1, step_clock_t(1, 2), step_clock_t(1),
+                              10.125, 10.25, 2),
+                      base_dt),
+                  2, 10.25, 0.25, 2);
+}
+
+void test_full_sync_and_static_v1_envelope() {
+  assert_metadata(full_sync_root_runtime_clock(7, 42.5, 0.25), 7, 42.5,
+                  0.25, 1);
+
+  validate_static_v1_clock_envelope(StaticV1ClockEnvelope{
+      2,
+      2,
+      false,
+      false,
+      step_clock_t(7),
+      {step_clock_t(7), step_clock_t(7)},
+      {step_clock_t(1), step_clock_t(1, 2)},
+      7,
+      {7, 14}});
+}
+
+void test_base_dt_rejects_invalid_static_v1_inputs() {
+  expect_throw<std::invalid_argument>(
+      [] { static_cast<void>(static_v1_base_delta_time(0.125, 3)); });
+  expect_throw<std::invalid_argument>(
+      [] { static_cast<void>(static_v1_base_delta_time(0.0, 2)); });
+  expect_throw<std::invalid_argument>([] {
+    static_cast<void>(static_v1_base_delta_time(
+        std::numeric_limits<double>::quiet_NaN(), 2));
+  });
+  expect_throw<std::overflow_error>([] {
+    static_cast<void>(static_v1_base_delta_time(
+        std::numeric_limits<double>::max(), 2));
+  });
+}
+
+void test_candidate_rejects_invalid_level_clock_time_and_iteration() {
+  expect_throw<std::invalid_argument>([] {
+    static_cast<void>(candidate_runtime_clock(
+        context(2, step_clock_t(0), step_clock_t(1, 4), 10.0, 10.0625, 1),
+        0.25));
+  });
+  expect_throw<std::invalid_argument>([] {
+    static_cast<void>(candidate_runtime_clock(
+        context(1, step_clock_t(0), step_clock_t(1), 10.0, 10.125, 1),
+        0.25));
+  });
+  expect_throw<std::invalid_argument>([] {
+    static_cast<void>(candidate_runtime_clock(
+        context(1, step_clock_t(0), step_clock_t(1, 2), 10.0, 10.2, 1),
+        0.25));
+  });
+  expect_throw<std::invalid_argument>([] {
+    static_cast<void>(candidate_runtime_clock(
+        context(1, step_clock_t(0), step_clock_t(1, 2), 10.0, 10.125, 2),
+        0.25));
+  });
+  expect_throw<std::invalid_argument>([] {
+    static_cast<void>(candidate_runtime_clock(
+        context(0, step_clock_t(0), step_clock_t(1), 10.0,
+                std::numeric_limits<double>::infinity(), 1),
+        0.25));
+  });
+  expect_throw<std::invalid_argument>([] {
+    static_cast<void>(candidate_runtime_clock(
+        context(0, step_clock_t(0), step_clock_t(1), 10.0, 10.25, 0),
+        0.25));
+  });
+  expect_throw<std::overflow_error>([] {
+    static_cast<void>(candidate_runtime_clock(
+        context(0, step_clock_t(0), step_clock_t(1), 10.0, 10.25,
+                static_cast<std::uint64_t>(INT_MAX) + 1),
+        0.25));
+  });
+}
+
+StaticV1ClockEnvelope valid_envelope() {
+  return StaticV1ClockEnvelope{2,
+                               2,
+                               false,
+                               false,
+                               step_clock_t(7),
+                               {step_clock_t(7), step_clock_t(7)},
+                               {step_clock_t(1), step_clock_t(1, 2)},
+                               7,
+                               {7, 14}};
+}
+
+void test_static_v1_envelope_fails_closed() {
+  auto envelope = valid_envelope();
+  envelope.refinement_ratio = 4;
+  expect_throw<std::invalid_argument>(
+      [&] { validate_static_v1_clock_envelope(envelope); });
+
+  envelope = valid_envelope();
+  envelope.recovering = true;
+  expect_throw<std::invalid_argument>(
+      [&] { validate_static_v1_clock_envelope(envelope); });
+
+  envelope = valid_envelope();
+  envelope.dynamic_regrid = true;
+  expect_throw<std::invalid_argument>(
+      [&] { validate_static_v1_clock_envelope(envelope); });
+
+  envelope = valid_envelope();
+  envelope.synchronized_clock = step_clock_t(3, 2);
+  envelope.level_clocks = {step_clock_t(3, 2), step_clock_t(3, 2)};
+  expect_throw<std::invalid_argument>(
+      [&] { validate_static_v1_clock_envelope(envelope); });
+
+  envelope = valid_envelope();
+  envelope.level_clocks[1] = step_clock_t(1);
+  expect_throw<std::invalid_argument>(
+      [&] { validate_static_v1_clock_envelope(envelope); });
+
+  envelope = valid_envelope();
+  envelope.level_delta_clocks[1] = step_clock_t(1, 4);
+  expect_throw<std::invalid_argument>(
+      [&] { validate_static_v1_clock_envelope(envelope); });
+
+  envelope = valid_envelope();
+  envelope.accepted_steps[0] = 6;
+  expect_throw<std::invalid_argument>(
+      [&] { validate_static_v1_clock_envelope(envelope); });
+
+  envelope = valid_envelope();
+  envelope.accepted_steps[1] = 13;
+  expect_throw<std::invalid_argument>(
+      [&] { validate_static_v1_clock_envelope(envelope); });
+
+  envelope = valid_envelope();
+  envelope.accepted_steps = {static_cast<std::uint64_t>(INT_MAX),
+                             static_cast<std::uint64_t>(INT_MAX) * 2};
+  envelope.completed_epoch = static_cast<std::uint64_t>(INT_MAX);
+  expect_throw<std::overflow_error>(
+      [&] { validate_static_v1_clock_envelope(envelope); });
+}
+
+} // namespace
+
+int main() {
+  test_base_dt_and_candidate_metadata();
+  test_full_sync_and_static_v1_envelope();
+  test_base_dt_rejects_invalid_static_v1_inputs();
+  test_candidate_rejects_invalid_level_clock_time_and_iteration();
+  test_static_v1_envelope_fails_closed();
+  std::cout << "subcycling_runtime_clock_unit: PASS\n";
+}

--- a/CarpetX/test/subcycling_schedule_certification_unit.cxx
+++ b/CarpetX/test/subcycling_schedule_certification_unit.cxx
@@ -1,0 +1,1606 @@
+#define CARPETX_SUBCYCLING_SCHEDULE_CERTIFICATION_STANDALONE 1
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+using CCTK_INT = int;
+struct cGH {};
+enum cLanguage { LangNone, LangC, LangFortran };
+enum cFunctionType { FunctionNoArgs, FunctionOneArg, FunctionStandard };
+
+struct RDWR_entry {
+  int varindex;
+  int timelevel;
+  int where_wr;
+  int where_rd;
+  int where_inv;
+};
+
+struct cFunctionData {
+  cLanguage language;
+  int (*FortranCaller)(cGH *, void *);
+  cFunctionType type;
+  int n_SyncGroups;
+  int *SyncGroups;
+  int meta;
+  int meta_early;
+  int meta_late;
+  int global;
+  int global_early;
+  int global_late;
+  int level;
+  int singlemap;
+  int local;
+  int loop_meta;
+  int loop_global;
+  int loop_level;
+  int loop_singlemap;
+  int loop_local;
+  int tags;
+  int n_TriggerGroups;
+  int *TriggerGroups;
+  int n_WritesClauses;
+  const char **WritesClauses;
+  int n_ReadsClauses;
+  const char **ReadsClauses;
+  int n_InvalidatesClauses;
+  const char **InvalidatesClauses;
+  int n_RDWR;
+  RDWR_entry *RDWR;
+  char *where;
+  char *routine;
+  char *thorn;
+};
+
+struct cScheduleInventoryScope {
+  unsigned int abi_version;
+  std::size_t struct_size;
+  std::uint64_t item_ordinal;
+  std::uint64_t parent_local_ordinal;
+  const char *description;
+  const char *implementation;
+  const cFunctionData *function_data;
+  int n_storage_groups;
+  const int *storage_groups;
+  const int *storage_timelevels;
+  int n_communication_groups;
+  const int *communication_groups;
+  int n_ifs;
+  const char *const *ifs;
+  int n_whiles;
+  const char *const *whiles;
+};
+
+struct cScheduleInventoryRecord {
+  unsigned int abi_version;
+  std::size_t struct_size;
+  const char *root_group;
+  int entry_exit_included;
+  std::uint64_t traversal_ordinal;
+  std::uint64_t item_ordinal;
+  std::uint64_t parent_local_ordinal;
+  const char *description;
+  const char *implementation;
+  const cFunctionData *function_data;
+  int n_storage_groups;
+  const int *storage_groups;
+  const int *storage_timelevels;
+  int n_communication_groups;
+  const int *communication_groups;
+  int n_ifs;
+  const char *const *ifs;
+  int n_whiles;
+  const char *const *whiles;
+  std::size_t n_enclosing_groups;
+  const cScheduleInventoryScope *enclosing_groups;
+};
+
+using cScheduleInventoryCallback =
+    int (*)(const cScheduleInventoryRecord *, void *, void *);
+
+struct cGroup {
+  int grouptype;
+  int vartype;
+  int disttype;
+  int dim;
+  int numvars;
+  int numtimelevels;
+  int vectorgroup;
+  int vectorlength;
+  int tagstable;
+  int centeringtable;
+};
+
+constexpr unsigned int CCTK_SCHEDULE_INVENTORY_ABI_VERSION = 1U;
+constexpr int CCTK_SCHEDULE_INVENTORY_GROUP_NOT_FOUND = -1;
+constexpr int CCTK_VARIABLE_INT = 120;
+constexpr int CCTK_VARIABLE_REAL = 130;
+constexpr int CCTK_VARIABLE_STRING = 151;
+constexpr int CCTK_VARIABLE_POINTER = 160;
+constexpr int CCTK_VARIABLE_POINTER_TO_CONST = 161;
+constexpr int CCTK_VARIABLE_FPOINTER = 162;
+constexpr int CCTK_SCALAR = 401;
+constexpr int CCTK_GF = 402;
+constexpr int CCTK_ARRAY = 403;
+constexpr int CCTK_VALID_GHOSTS = 1;
+constexpr int CCTK_VALID_BOUNDARY = 2;
+constexpr int CCTK_VALID_INTERIOR = 4;
+constexpr int UTIL_TABLE_FLAGS_CASE_INSENSITIVE = 1;
+
+extern "C" {
+int CCTK_ScheduleInventoryDry(const char *, cScheduleInventoryCallback, void *);
+int CCTK_CallFunction(void *, cFunctionData *, cGH *);
+const char *CCTK_FullGroupName(int);
+int CCTK_GroupIndex(const char *);
+const char *CCTK_FullVarName(int);
+int CCTK_VarIndex(const char *);
+int CCTK_GroupIndexFromVarI(int);
+int CCTK_GroupData(int, cGroup *);
+int CCTK_VarTypeI(int);
+int CCTK_DeclaredTimeLevelsVI(int);
+int CCTK_VarTypeSize(int);
+int Util_TableQueryFlags(int);
+int Util_TableQueryNKeys(int);
+int Util_TableQueryMaxKeyLength(int);
+int Util_TableItCreate(int);
+int Util_TableItDestroy(int);
+int Util_TableItQueryKeyValueInfo(int, int, char *, CCTK_INT *, CCTK_INT *);
+int Util_TableGetGenericArray(int, int, int, void *, const char *);
+int Util_TableItAdvance(int);
+int Util_TableItQueryIsNull(int);
+int Util_TableClone(int);
+int Util_TableDestroy(int);
+}
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsubobject-linkage"
+#endif
+#include "../src/subcycling_schedule_certification.cxx"
+#include "../src/subcycling_schedule_certification_native_gate.hxx"
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+namespace fake {
+
+struct TagEntry {
+  std::string key;
+  int type{};
+  int count{};
+  std::vector<std::uint8_t> bytes;
+  std::optional<int> get_result;
+};
+
+struct Table {
+  int flags{UTIL_TABLE_FLAGS_CASE_INSENSITIVE};
+  std::vector<TagEntry> entries;
+  bool clone{};
+};
+
+struct Iterator {
+  int table{-1};
+  std::size_t index{};
+};
+
+enum class TableFailure {
+  none,
+  iterator_create,
+  iterator_query,
+  iterator_advance,
+  iterator_end_state,
+  clone,
+};
+
+struct GroupInfo {
+  std::string name;
+  cGroup data{};
+};
+
+struct VarInfo {
+  std::string name;
+  int group{};
+  int type{};
+  int timelevels{};
+};
+
+static std::map<int, Table> tables;
+static std::map<int, Iterator> iterators;
+static int next_table_handle = 100;
+static int next_iterator_handle = 1000;
+static int live_clones = 0;
+static int live_iterators = 0;
+static int poison_invocations = 0;
+static int &live_cloned_table_count = live_clones;
+static int &poison_invocation_count = poison_invocations;
+static bool throw_on_table_get = false;
+static TableFailure table_failure = TableFailure::none;
+static bool break_group_roundtrip = false;
+static bool break_var_roundtrip = false;
+static std::vector<std::string> inventory_calls;
+static std::vector<GroupInfo> group_infos;
+static std::vector<VarInfo> var_infos;
+
+template <class T> std::vector<std::uint8_t> bytes_of(const T &value) {
+  std::vector<std::uint8_t> bytes(sizeof(T));
+  std::memcpy(bytes.data(), &value, sizeof(T));
+  return bytes;
+}
+
+static int make_table(const bool reverse = false) {
+  const int integer_value = 9;
+  const double real_value = 1.5;
+  Table table;
+  table.entries = {{"Beta", CCTK_VARIABLE_INT, 1, bytes_of(integer_value), {}},
+                   {"alpha", CCTK_VARIABLE_REAL, 1, bytes_of(real_value), {}}};
+  if (reverse)
+    std::reverse(table.entries.begin(), table.entries.end());
+  const int handle = next_table_handle++;
+  tables.emplace(handle, std::move(table));
+  return handle;
+}
+
+struct FunctionFixture {
+  cFunctionData data{};
+  std::vector<int> sync_groups;
+  std::vector<int> trigger_groups;
+  std::vector<std::string> reads{"Test::u"};
+  std::vector<std::string> writes;
+  std::vector<std::string> invalidates;
+  std::vector<const char *> read_ptrs;
+  std::vector<const char *> write_ptrs;
+  std::vector<const char *> invalidate_ptrs;
+  std::vector<RDWR_entry> rdwr{{0, 0, 0, CCTK_VALID_GHOSTS, 0}};
+  std::string where;
+  std::string routine;
+  std::string thorn{"TestThorn"};
+
+  explicit FunctionFixture(const bool reverse_tags = false) {
+    data.language = LangC;
+    data.type = FunctionStandard;
+    data.tags = make_table(reverse_tags);
+    refresh();
+  }
+
+  void refresh() {
+    const auto pointers = [](const std::vector<std::string> &strings,
+                             std::vector<const char *> &result) {
+      result.clear();
+      for (const auto &value : strings)
+        result.push_back(value.c_str());
+    };
+    pointers(reads, read_ptrs);
+    pointers(writes, write_ptrs);
+    pointers(invalidates, invalidate_ptrs);
+    data.n_SyncGroups = static_cast<int>(sync_groups.size());
+    data.SyncGroups = sync_groups.empty() ? nullptr : sync_groups.data();
+    data.n_TriggerGroups = static_cast<int>(trigger_groups.size());
+    data.TriggerGroups = trigger_groups.empty() ? nullptr : trigger_groups.data();
+    data.n_ReadsClauses = static_cast<int>(read_ptrs.size());
+    data.ReadsClauses = read_ptrs.empty() ? nullptr : read_ptrs.data();
+    data.n_WritesClauses = static_cast<int>(write_ptrs.size());
+    data.WritesClauses = write_ptrs.empty() ? nullptr : write_ptrs.data();
+    data.n_InvalidatesClauses = static_cast<int>(invalidate_ptrs.size());
+    data.InvalidatesClauses =
+        invalidate_ptrs.empty() ? nullptr : invalidate_ptrs.data();
+    data.n_RDWR = static_cast<int>(rdwr.size());
+    data.RDWR = rdwr.empty() ? nullptr : rdwr.data();
+    data.where = where.empty() ? nullptr : where.data();
+    data.routine = routine.empty() ? nullptr : routine.data();
+    data.thorn = thorn.empty() ? nullptr : thorn.data();
+  }
+
+  void poison() {
+    where.assign("poisoned where");
+    routine.assign("poisoned routine");
+    thorn.assign("poisoned thorn");
+    if (!reads.empty())
+      reads.front().assign("poisoned read");
+    if (!writes.empty())
+      writes.front().assign("poisoned write");
+    if (!invalidates.empty())
+      invalidates.front().assign("poisoned invalidate");
+    if (!sync_groups.empty())
+      sync_groups.front() = 77;
+    if (!trigger_groups.empty())
+      trigger_groups.front() = 77;
+    if (!rdwr.empty())
+      rdwr.front().varindex = 77;
+    auto found = tables.find(data.tags);
+    if (found != tables.end() && !found->second.entries.empty())
+      found->second.entries.front().bytes.assign(sizeof(int), 0xffU);
+    refresh();
+  }
+};
+
+struct ScopeFixture {
+  std::uint64_t item_ordinal{5};
+  std::uint64_t parent_local_ordinal{};
+  std::string description;
+  std::string implementation{"ScopeImpl"};
+  FunctionFixture function;
+  std::vector<int> storage_groups;
+  std::vector<int> storage_timelevels;
+  std::vector<int> communication_groups;
+  std::vector<std::string> ifs;
+  std::vector<std::string> whiles;
+  std::vector<const char *> if_ptrs;
+  std::vector<const char *> while_ptrs;
+  cScheduleInventoryScope view{};
+
+  explicit ScopeFixture(const std::string &root) : description(root + " scope") {
+    function.where = root + "::scope_where";
+    function.routine = root + "::scope_routine";
+    function.refresh();
+  }
+
+  void refresh() {
+    function.refresh();
+    if_ptrs.clear();
+    while_ptrs.clear();
+    for (const auto &value : ifs)
+      if_ptrs.push_back(value.c_str());
+    for (const auto &value : whiles)
+      while_ptrs.push_back(value.c_str());
+    view = {CCTK_SCHEDULE_INVENTORY_ABI_VERSION,
+            sizeof(cScheduleInventoryScope),
+            item_ordinal,
+            parent_local_ordinal,
+            description.c_str(),
+            implementation.c_str(),
+            &function.data,
+            static_cast<int>(storage_groups.size()),
+            storage_groups.empty() ? nullptr : storage_groups.data(),
+            storage_timelevels.empty() ? nullptr : storage_timelevels.data(),
+            static_cast<int>(communication_groups.size()),
+            communication_groups.empty() ? nullptr : communication_groups.data(),
+            static_cast<int>(if_ptrs.size()),
+            if_ptrs.empty() ? nullptr : if_ptrs.data(),
+            static_cast<int>(while_ptrs.size()),
+            while_ptrs.empty() ? nullptr : while_ptrs.data()};
+  }
+};
+
+struct RecordFixture {
+  std::uint64_t traversal_ordinal{};
+  std::uint64_t item_ordinal{10};
+  std::uint64_t parent_local_ordinal{};
+  std::string root;
+  std::string description;
+  std::string implementation{"TestImpl"};
+  FunctionFixture function;
+  std::vector<int> storage_groups;
+  std::vector<int> storage_timelevels;
+  std::vector<int> communication_groups;
+  std::vector<std::string> ifs;
+  std::vector<std::string> whiles;
+  std::vector<const char *> if_ptrs;
+  std::vector<const char *> while_ptrs;
+  std::vector<std::unique_ptr<ScopeFixture>> scopes;
+  std::vector<cScheduleInventoryScope> scope_views;
+  cScheduleInventoryRecord view{};
+  void *opaque_handle{};
+
+  explicit RecordFixture(std::string root_name, const bool reverse_tags = false)
+      : root(std::move(root_name)), description(root + " description"),
+        function(reverse_tags) {
+    function.where = root + "::where";
+    function.routine = root == "ODESolvers_RHS" ? "rhs_routine"
+                                                  : "post_routine";
+    opaque_handle = reinterpret_cast<void *>(
+        static_cast<std::uintptr_t>(root == "ODESolvers_RHS" ? 0x111U : 0x222U));
+    refresh();
+  }
+
+  void refresh() {
+    function.refresh();
+    if_ptrs.clear();
+    while_ptrs.clear();
+    scope_views.clear();
+    for (const auto &value : ifs)
+      if_ptrs.push_back(value.c_str());
+    for (const auto &value : whiles)
+      while_ptrs.push_back(value.c_str());
+    for (auto &scope : scopes) {
+      scope->refresh();
+      scope_views.push_back(scope->view);
+    }
+    view = {CCTK_SCHEDULE_INVENTORY_ABI_VERSION,
+            sizeof(cScheduleInventoryRecord),
+            root.c_str(),
+            0,
+            traversal_ordinal,
+            item_ordinal,
+            parent_local_ordinal,
+            description.c_str(),
+            implementation.c_str(),
+            &function.data,
+            static_cast<int>(storage_groups.size()),
+            storage_groups.empty() ? nullptr : storage_groups.data(),
+            storage_timelevels.empty() ? nullptr : storage_timelevels.data(),
+            static_cast<int>(communication_groups.size()),
+            communication_groups.empty() ? nullptr : communication_groups.data(),
+            static_cast<int>(if_ptrs.size()),
+            if_ptrs.empty() ? nullptr : if_ptrs.data(),
+            static_cast<int>(while_ptrs.size()),
+            while_ptrs.empty() ? nullptr : while_ptrs.data(),
+            scope_views.size(),
+            scope_views.empty() ? nullptr : scope_views.data()};
+  }
+
+  void poison() {
+    description.assign("poisoned description");
+    implementation.assign("poisoned implementation");
+    function.poison();
+    refresh();
+  }
+};
+
+struct InventoryGroup {
+  int result{};
+  bool poison_after_callback{};
+  std::vector<std::unique_ptr<RecordFixture>> records;
+};
+
+static std::map<std::string, InventoryGroup> inventory;
+
+static void reset() {
+  if (live_clones != 0)
+    throw std::runtime_error("clone leaked across test boundary");
+  if (live_iterators != 0 || !iterators.empty())
+    throw std::runtime_error("iterator leaked across test boundary");
+  tables.clear();
+  inventory.clear();
+  inventory_calls.clear();
+  poison_invocations = 0;
+  throw_on_table_get = false;
+  table_failure = TableFailure::none;
+  break_group_roundtrip = false;
+  break_var_roundtrip = false;
+  group_infos = {{"Test::gf", {CCTK_GF, CCTK_VARIABLE_REAL, 0, 3, 1, 1, 0, 1, -1, -1}},
+                 {"Test::scalar", {CCTK_SCALAR, CCTK_VARIABLE_REAL, 0, 0, 1, 1, 0, 1, -1, -1}},
+                 {"Test::array", {CCTK_ARRAY, CCTK_VARIABLE_REAL, 0, 1, 1, 1, 0, 1, -1, -1}}};
+  var_infos = {{"Test::u", 0, CCTK_VARIABLE_REAL, 1},
+               {"Test::s", 1, CCTK_VARIABLE_REAL, 1},
+               {"Test::a", 2, CCTK_VARIABLE_REAL, 1}};
+}
+
+static RecordFixture &add_body(const std::string &root,
+                               const bool reverse_tags = false) {
+  auto &group = inventory[root];
+  group.result = 0;
+  group.records.push_back(std::make_unique<RecordFixture>(root, reverse_tags));
+  return *group.records.back();
+}
+
+static void setup_valid(const bool reverse_post_tags = false) {
+  add_body("ODESolvers_RHS");
+  auto &post = add_body("ODESolvers_PostStep", reverse_post_tags);
+  post.function.data.local = 1;
+  post.refresh();
+}
+
+static void destroy_source_tables() {
+  for (auto it = tables.begin(); it != tables.end();) {
+    if (!it->second.clone)
+      it = tables.erase(it);
+    else
+      ++it;
+  }
+}
+
+} // namespace fake
+
+extern "C" int CCTK_ScheduleInventoryDry(const char *where,
+                                           cScheduleInventoryCallback callback,
+                                           void *user_data) {
+  const std::string name = where == nullptr ? std::string{} : where;
+  fake::inventory_calls.push_back(name);
+  const auto found = fake::inventory.find(name);
+  if (found == fake::inventory.end())
+    return CCTK_SCHEDULE_INVENTORY_GROUP_NOT_FOUND;
+  auto &group = found->second;
+  if (group.result != 0)
+    return group.result;
+  for (auto &record : group.records) {
+    record->refresh();
+    const int callback_result =
+        callback(&record->view, record->opaque_handle, user_data);
+    if (group.poison_after_callback)
+      record->poison();
+    if (callback_result != 0)
+      return callback_result;
+  }
+  return 0;
+}
+
+extern "C" int CCTK_CallFunction(void *, cFunctionData *, cGH *) {
+  ++fake::poison_invocations;
+  return 0;
+}
+
+extern "C" const char *CCTK_FullGroupName(const int index) {
+  return index >= 0 && static_cast<std::size_t>(index) < fake::group_infos.size()
+             ? fake::group_infos[static_cast<std::size_t>(index)].name.c_str()
+             : nullptr;
+}
+
+extern "C" int CCTK_GroupIndex(const char *name) {
+  if (name == nullptr || fake::break_group_roundtrip)
+    return -1;
+  for (std::size_t i = 0; i < fake::group_infos.size(); ++i)
+    if (fake::group_infos[i].name == name)
+      return static_cast<int>(i);
+  return -1;
+}
+
+extern "C" const char *CCTK_FullVarName(const int index) {
+  return index >= 0 && static_cast<std::size_t>(index) < fake::var_infos.size()
+             ? fake::var_infos[static_cast<std::size_t>(index)].name.c_str()
+             : nullptr;
+}
+
+extern "C" int CCTK_VarIndex(const char *name) {
+  if (name == nullptr || fake::break_var_roundtrip)
+    return -1;
+  for (std::size_t i = 0; i < fake::var_infos.size(); ++i)
+    if (fake::var_infos[i].name == name)
+      return static_cast<int>(i);
+  return -1;
+}
+
+extern "C" int CCTK_GroupIndexFromVarI(const int index) {
+  return index >= 0 && static_cast<std::size_t>(index) < fake::var_infos.size()
+             ? fake::var_infos[static_cast<std::size_t>(index)].group
+             : -1;
+}
+
+extern "C" int CCTK_GroupData(const int index, cGroup *group) {
+  if (group == nullptr || index < 0 ||
+      static_cast<std::size_t>(index) >= fake::group_infos.size())
+    return -1;
+  *group = fake::group_infos[static_cast<std::size_t>(index)].data;
+  return 0;
+}
+
+extern "C" int CCTK_VarTypeI(const int index) {
+  return index >= 0 && static_cast<std::size_t>(index) < fake::var_infos.size()
+             ? fake::var_infos[static_cast<std::size_t>(index)].type
+             : -1;
+}
+
+extern "C" int CCTK_DeclaredTimeLevelsVI(const int index) {
+  return index >= 0 && static_cast<std::size_t>(index) < fake::var_infos.size()
+             ? fake::var_infos[static_cast<std::size_t>(index)].timelevels
+             : -1;
+}
+
+extern "C" int CCTK_VarTypeSize(const int type) {
+  if (type == CCTK_VARIABLE_INT)
+    return static_cast<int>(sizeof(int));
+  if (type == CCTK_VARIABLE_REAL)
+    return static_cast<int>(sizeof(double));
+  if (type == CCTK_VARIABLE_POINTER || type == CCTK_VARIABLE_POINTER_TO_CONST ||
+      type == CCTK_VARIABLE_FPOINTER)
+    return static_cast<int>(sizeof(void *));
+  return -1;
+}
+
+extern "C" int Util_TableQueryFlags(const int handle) {
+  const auto found = fake::tables.find(handle);
+  return found == fake::tables.end() ? -1 : found->second.flags;
+}
+
+extern "C" int Util_TableQueryNKeys(const int handle) {
+  const auto found = fake::tables.find(handle);
+  return found == fake::tables.end()
+             ? -1
+             : static_cast<int>(found->second.entries.size());
+}
+
+extern "C" int Util_TableQueryMaxKeyLength(const int handle) {
+  const auto found = fake::tables.find(handle);
+  if (found == fake::tables.end())
+    return -1;
+  std::size_t length = 0;
+  for (const auto &entry : found->second.entries)
+    length = std::max(length, entry.key.size());
+  return static_cast<int>(length);
+}
+
+extern "C" int Util_TableItCreate(const int handle) {
+  if (fake::table_failure == fake::TableFailure::iterator_create)
+    return -1;
+  if (fake::tables.find(handle) == fake::tables.end())
+    return -1;
+  const int iterator = fake::next_iterator_handle++;
+  fake::iterators.emplace(iterator, fake::Iterator{handle, 0});
+  ++fake::live_iterators;
+  return iterator;
+}
+
+extern "C" int Util_TableItDestroy(const int handle) {
+  if (fake::iterators.erase(handle) != 1)
+    return -1;
+  --fake::live_iterators;
+  return 0;
+}
+
+extern "C" int Util_TableItQueryKeyValueInfo(const int iterator_handle,
+                                               const int capacity, char *key,
+                                               CCTK_INT *type,
+                                               CCTK_INT *count) {
+  if (fake::table_failure == fake::TableFailure::iterator_query)
+    return -1;
+  const auto iterator = fake::iterators.find(iterator_handle);
+  if (iterator == fake::iterators.end())
+    return -1;
+  const auto table = fake::tables.find(iterator->second.table);
+  if (table == fake::tables.end() ||
+      iterator->second.index >= table->second.entries.size())
+    return -1;
+  const auto &entry = table->second.entries[iterator->second.index];
+  if (capacity <= static_cast<int>(entry.key.size()) || key == nullptr ||
+      type == nullptr || count == nullptr)
+    return -1;
+  std::memcpy(key, entry.key.c_str(), entry.key.size() + 1U);
+  *type = entry.type;
+  *count = entry.count;
+  return static_cast<int>(entry.key.size());
+}
+
+extern "C" int Util_TableGetGenericArray(const int handle, const int type,
+                                          const int count, void *output,
+                                          const char *key) {
+  if (fake::throw_on_table_get) {
+    fake::throw_on_table_get = false;
+    throw std::runtime_error("injected table read exception");
+  }
+  const auto table = fake::tables.find(handle);
+  if (table == fake::tables.end() || key == nullptr)
+    return -1;
+  const auto lower = [](std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](const char c) {
+      return c >= 'A' && c <= 'Z' ? static_cast<char>(c - 'A' + 'a') : c;
+    });
+    return value;
+  };
+  const std::string wanted = lower(key);
+  for (const auto &entry : table->second.entries) {
+    if (lower(entry.key) != wanted)
+      continue;
+    if (entry.get_result.has_value())
+      return *entry.get_result;
+    if (entry.type != type || entry.count != count || output == nullptr)
+      return -1;
+    std::memcpy(output, entry.bytes.data(), entry.bytes.size());
+    return entry.count;
+  }
+  return -1;
+}
+
+extern "C" int Util_TableItAdvance(const int handle) {
+  if (fake::table_failure == fake::TableFailure::iterator_advance)
+    return -1;
+  const auto iterator = fake::iterators.find(handle);
+  if (iterator == fake::iterators.end())
+    return -1;
+  const auto table = fake::tables.find(iterator->second.table);
+  if (table == fake::tables.end())
+    return -1;
+  ++iterator->second.index;
+  return iterator->second.index < table->second.entries.size() ? 1 : 0;
+}
+
+extern "C" int Util_TableItQueryIsNull(const int handle) {
+  if (fake::table_failure == fake::TableFailure::iterator_end_state)
+    return 0;
+  const auto iterator = fake::iterators.find(handle);
+  if (iterator == fake::iterators.end())
+    return -1;
+  const auto table = fake::tables.find(iterator->second.table);
+  return table != fake::tables.end() &&
+                 iterator->second.index >= table->second.entries.size()
+             ? 1
+             : 0;
+}
+
+extern "C" int Util_TableClone(const int handle) {
+  if (fake::table_failure == fake::TableFailure::clone)
+    return -1;
+  const auto found = fake::tables.find(handle);
+  if (found == fake::tables.end())
+    return -1;
+  const int clone = fake::next_table_handle++;
+  auto value = found->second;
+  value.clone = true;
+  fake::tables.emplace(clone, std::move(value));
+  ++fake::live_clones;
+  return clone;
+}
+
+extern "C" int Util_TableDestroy(const int handle) {
+  const auto found = fake::tables.find(handle);
+  if (found == fake::tables.end())
+    return -1;
+  if (found->second.clone)
+    --fake::live_clones;
+  fake::tables.erase(found);
+  return 0;
+}
+
+namespace {
+
+class TestFailure : public std::runtime_error {
+public:
+  using std::runtime_error::runtime_error;
+};
+
+void check(const bool condition, const char *expression, const int line) {
+  if (!condition)
+    throw TestFailure(std::string("line ") + std::to_string(line) +
+                      ": " + expression);
+}
+
+#define CHECK(expression)                                                       \
+  check(static_cast<bool>(expression), #expression, __LINE__)
+
+CarpetX::ScheduleBuildProvenance valid_provenance() {
+  return {1,
+          CCTK_SCHEDULE_INVENTORY_ABI_VERSION,
+          std::string(40, 'a'),
+          std::string(64, 'b'),
+          std::string(40, 'c'),
+          {{"8B3A", std::string(64, 'd')}},
+          "GCC",
+          "13.2.0",
+          "x86_64-linux-gnu",
+          "itanium",
+          "little",
+          {{CCTK_VARIABLE_INT, static_cast<int>(sizeof(int))},
+           {CCTK_VARIABLE_REAL, static_cast<int>(sizeof(double))}},
+          std::string(64, 'e')};
+}
+
+std::vector<CarpetX::CanonicalTag> expected_tags() {
+  const double real_value = 1.5;
+  const int integer_value = 9;
+  return {{"alpha", CCTK_VARIABLE_REAL, 1, fake::bytes_of(real_value)},
+          {"beta", CCTK_VARIABLE_INT, 1, fake::bytes_of(integer_value)}};
+}
+
+CarpetX::CanonicalScheduleItem expected_item(const std::string &root,
+                                             const int local,
+                                             const bool scope = false) {
+  CarpetX::CanonicalScheduleItem item;
+  item.description = root + (scope ? " scope" : " description");
+  item.implementation = scope ? "ScopeImpl" : "TestImpl";
+  item.where = root + (scope ? "::scope_where" : "::where");
+  item.thorn = "TestThorn";
+  item.routine = scope ? root + "::scope_routine"
+                       : (root == "ODESolvers_RHS" ? "rhs_routine"
+                                                    : "post_routine");
+  item.language = LangC;
+  item.function_type = FunctionStandard;
+  item.execution_flags.local = local;
+  item.effective_mode = local == 0 ? CarpetX::CanonicalScheduleMode::default_local
+                                   : CarpetX::CanonicalScheduleMode::local;
+  item.tags = expected_tags();
+  item.reads_clauses = {"Test::u"};
+  item.accesses = {{"Test::u", 0, CCTK_VALID_GHOSTS, 0, 0}};
+  return item;
+}
+
+CarpetX::ScheduleCertificationExpectation valid_expectation() {
+  CarpetX::ScheduleCertificationExpectation expectation;
+  expectation.provenance = valid_provenance();
+  constexpr const char *roots[] = {"ODESolvers_RHS", "ODESolvers_PostStep"};
+  for (std::size_t i = 0; i < 2; ++i) {
+    auto &target = expectation.manifest.targets[i];
+    target.target = i == 0 ? CarpetX::SubcyclingScheduleTarget::rhs
+                           : CarpetX::SubcyclingScheduleTarget::post_step;
+    target.body_root = roots[i];
+    target.entry_state = CarpetX::SpecialScheduleGroupState::missing;
+    target.exit_state = CarpetX::SpecialScheduleGroupState::missing;
+    target.entry_exit_included = false;
+    target.records.push_back({0, 10, 0,
+                              expected_item(roots[i], i == 0 ? 0 : 1), {}});
+  }
+  return expectation;
+}
+
+CarpetX::ScheduleCertificationResult certify(
+    const CarpetX::ScheduleCertificationExpectation &expectation) {
+  return CarpetX::certify_local_subcycling_schedules(expectation,
+                                                      valid_provenance());
+}
+
+void check_failure(const CarpetX::ScheduleCertificationResult &result,
+                   const CarpetX::ScheduleCertificationErrorCode code) {
+  CHECK(!result);
+  CHECK(result.registry == nullptr);
+  CHECK(result.failure.has_value());
+  CHECK(result.failure->code == code);
+}
+
+void test_exact_six_call_order_and_two_body_targets() {
+  fake::setup_valid();
+  const auto result = certify(valid_expectation());
+  CHECK(result);
+  CHECK(result.registry->size(CarpetX::SubcyclingScheduleTarget::rhs) == 1);
+  CHECK(result.registry->size(CarpetX::SubcyclingScheduleTarget::post_step) == 1);
+  const std::vector<std::string> expected{
+      "ODESolvers_RHS$ENTRY", "ODESolvers_RHS", "ODESolvers_RHS$EXIT",
+      "ODESolvers_PostStep$ENTRY", "ODESolvers_PostStep",
+      "ODESolvers_PostStep$EXIT"};
+  CHECK(fake::inventory_calls == expected);
+}
+
+void test_missing_entry_and_exit_are_required() {
+  fake::setup_valid();
+  const auto result = certify(valid_expectation());
+  CHECK(result);
+  for (const auto &target : result.registry->manifest().targets) {
+    CHECK(target.entry_state == CarpetX::SpecialScheduleGroupState::missing);
+    CHECK(target.exit_state == CarpetX::SpecialScheduleGroupState::missing);
+    CHECK(!target.entry_exit_included);
+  }
+}
+
+void test_present_empty_entry_or_exit_rejects() {
+  {
+    fake::setup_valid();
+    fake::inventory["ODESolvers_RHS$ENTRY"].result = 0;
+    const auto result = certify(valid_expectation());
+    check_failure(result,
+                  CarpetX::ScheduleCertificationErrorCode::special_group_present);
+    CHECK(fake::live_clones == 0);
+  }
+  fake::reset();
+  {
+    fake::setup_valid();
+    fake::inventory["ODESolvers_RHS$EXIT"].result = 0;
+    const auto result = certify(valid_expectation());
+    check_failure(result,
+                  CarpetX::ScheduleCertificationErrorCode::special_group_present);
+    CHECK(fake::live_clones == 0);
+  }
+}
+
+void test_body_missing_or_error_rejects() {
+  {
+    fake::setup_valid();
+    fake::inventory.erase("ODESolvers_RHS");
+    const auto result = certify(valid_expectation());
+    check_failure(result, CarpetX::ScheduleCertificationErrorCode::inventory_error);
+  }
+  fake::reset();
+  {
+    fake::setup_valid();
+    fake::inventory["ODESolvers_RHS"].result = -7;
+    const auto result = certify(valid_expectation());
+    check_failure(result, CarpetX::ScheduleCertificationErrorCode::inventory_error);
+  }
+}
+
+void test_borrowed_metadata_is_deep_copied() {
+  fake::setup_valid();
+  fake::inventory["ODESolvers_RHS"].poison_after_callback = true;
+  fake::inventory["ODESolvers_PostStep"].poison_after_callback = true;
+  const auto result = certify(valid_expectation());
+  CHECK(result);
+  CHECK(result.registry->manifest() == valid_expectation().manifest);
+}
+
+void test_owned_function_data_rebinds_every_pointer() {
+  fake::RecordFixture record("ODESolvers_RHS");
+  record.function.sync_groups = {0};
+  record.function.trigger_groups = {0};
+  record.function.writes = {"write clause"};
+  record.function.invalidates = {"invalidate clause"};
+  record.storage_groups = {0};
+  record.storage_timelevels = {0};
+  record.communication_groups = {0};
+  record.ifs = {"if clause"};
+  record.whiles = {"while clause"};
+  record.refresh();
+  const auto *const source_sync = record.function.data.SyncGroups;
+  const auto *const source_trigger = record.function.data.TriggerGroups;
+  const auto *const source_rdwr = record.function.data.RDWR;
+  const auto *const source_reads = record.function.data.ReadsClauses;
+  const auto *const source_writes = record.function.data.WritesClauses;
+  const auto *const source_invalidates = record.function.data.InvalidatesClauses;
+  const auto *const source_where = record.function.data.where;
+  const auto *const source_routine = record.function.data.routine;
+  const auto *const source_thorn = record.function.data.thorn;
+  const int clone = Util_TableClone(record.function.data.tags);
+  CHECK(clone >= 0);
+  {
+    CarpetX::OwnedFunctionData owned;
+    owned.capture(record.function.data, CarpetX::TableHandle(clone),
+                  record.opaque_handle, record.view);
+    CHECK(owned.data.SyncGroups != source_sync);
+    CHECK(owned.data.TriggerGroups != source_trigger);
+    CHECK(owned.data.RDWR != source_rdwr);
+    CHECK(owned.data.ReadsClauses != source_reads);
+    CHECK(owned.data.WritesClauses != source_writes);
+    CHECK(owned.data.InvalidatesClauses != source_invalidates);
+    CHECK(owned.data.ReadsClauses[0] != source_reads[0]);
+    CHECK(owned.data.WritesClauses[0] != source_writes[0]);
+    CHECK(owned.data.InvalidatesClauses[0] != source_invalidates[0]);
+    CHECK(owned.data.where != source_where);
+    CHECK(owned.data.routine != source_routine);
+    CHECK(owned.data.thorn != source_thorn);
+    CHECK(owned.data.tags == clone);
+    CHECK(owned.opaque_call_handle == record.opaque_handle);
+    CHECK(owned.storage_group_indices == std::vector<int>{0});
+    CHECK(owned.storage_timelevels == std::vector<int>{0});
+    CHECK(owned.communication_group_indices == std::vector<int>{0});
+    CHECK(owned.if_strings == std::vector<std::string>{"if clause"});
+    CHECK(owned.while_strings == std::vector<std::string>{"while clause"});
+    record.function.poison();
+    CHECK(std::string(owned.data.where) == "ODESolvers_RHS::where");
+    CHECK(std::string(owned.data.routine) == "rhs_routine");
+    CHECK(std::string(owned.data.thorn) == "TestThorn");
+    CHECK(std::string(owned.data.ReadsClauses[0]) == "Test::u");
+    CHECK(std::string(owned.data.WritesClauses[0]) == "write clause");
+    CHECK(std::string(owned.data.InvalidatesClauses[0]) == "invalidate clause");
+    CHECK(owned.data.RDWR[0].varindex == 0);
+  }
+  CHECK(fake::live_clones == 0);
+}
+
+void test_leaf_tag_clone_and_scope_tag_copy_lifetimes() {
+  fake::setup_valid();
+  for (const char *root : {"ODESolvers_RHS", "ODESolvers_PostStep"}) {
+    auto &record = *fake::inventory[root].records.front();
+    record.scopes.push_back(std::make_unique<fake::ScopeFixture>(root));
+    record.refresh();
+  }
+  auto expectation = valid_expectation();
+  for (std::size_t i = 0; i < 2; ++i) {
+    const std::string root = i == 0 ? "ODESolvers_RHS" : "ODESolvers_PostStep";
+    expectation.manifest.targets[i].records[0].ancestry.push_back(
+        {5, 0, expected_item(root, 0, true)});
+  }
+  {
+    const auto result = certify(expectation);
+    CHECK(result);
+    CHECK(fake::live_clones == 2);
+    fake::destroy_source_tables();
+    CHECK(result.registry->manifest() == expectation.manifest);
+    CHECK(fake::live_clones == 2);
+  }
+  CHECK(fake::live_clones == 0);
+}
+
+CarpetX::ScheduleCertificationExpectation setup_two_record_rhs_ancestry() {
+  fake::setup_valid();
+  auto &first = *fake::inventory["ODESolvers_RHS"].records.front();
+  first.scopes.push_back(
+      std::make_unique<fake::ScopeFixture>("ODESolvers_RHS"));
+  first.refresh();
+
+  auto &second = fake::add_body("ODESolvers_RHS");
+  second.traversal_ordinal = 1;
+  second.item_ordinal = 11;
+  second.parent_local_ordinal = 1;
+  second.scopes.push_back(
+      std::make_unique<fake::ScopeFixture>("ODESolvers_RHS"));
+  second.refresh();
+
+  auto expectation = valid_expectation();
+  expectation.manifest.targets[0].records[0].ancestry.push_back(
+      {5, 0, expected_item("ODESolvers_RHS", 0, true)});
+  expectation.manifest.targets[0].records.push_back(
+      {1,
+       11,
+       1,
+       expected_item("ODESolvers_RHS", 0),
+       {{5, 0, expected_item("ODESolvers_RHS", 0, true)}}});
+  return expectation;
+}
+
+void test_multi_record_ancestry_uses_sibling_local_ordinals() {
+  const auto result = certify(setup_two_record_rhs_ancestry());
+  CHECK(result);
+  CHECK(result.registry->manifest().targets[0].records[1]
+            .parent_local_ordinal == 1);
+  CHECK(result.registry->manifest().targets[0].records[1]
+            .ancestry[0]
+            .parent_local_ordinal == 0);
+}
+
+void test_contradictory_multi_record_ancestry_rejects_exact_fields() {
+  const std::vector<std::string> expected_fields{
+      "record.ancestry[0].item_identity",
+      "record.ancestry[0].parent_path",
+      "record.ancestry[0].parent_local_ordinal",
+      "record.ancestry[0].parent_local_ordinal",
+      "record.ancestry[0].parent_local_ordinal"};
+  for (int which = 0; which < 5; ++which) {
+    if (which != 0)
+      fake::reset();
+    auto expectation = setup_two_record_rhs_ancestry();
+    auto &second = *fake::inventory["ODESolvers_RHS"].records[1];
+    auto &expected_second = expectation.manifest.targets[0].records[1];
+    if (which == 0) {
+      second.scopes[0]->function.routine = "contradictory_scope_routine";
+      expected_second.ancestry[0].item.routine =
+          "contradictory_scope_routine";
+    } else if (which == 1) {
+      auto &first = *fake::inventory["ODESolvers_RHS"].records[0];
+      first.scopes.clear();
+      auto first_outer =
+          std::make_unique<fake::ScopeFixture>("ODESolvers_RHS");
+      first_outer->item_ordinal = 4;
+      first.scopes.push_back(std::move(first_outer));
+      first.scopes.push_back(
+          std::make_unique<fake::ScopeFixture>("ODESolvers_RHS"));
+      first.refresh();
+      second.parent_local_ordinal = 0;
+      second.scopes.clear();
+      auto repeated =
+          std::make_unique<fake::ScopeFixture>("ODESolvers_RHS");
+      repeated->item_ordinal = 5;
+      repeated->parent_local_ordinal = 1;
+      second.scopes.push_back(std::move(repeated));
+      expectation.manifest.targets[0].records[0].ancestry = {
+          {4, 0, expected_item("ODESolvers_RHS", 0, true)},
+          {5, 0, expected_item("ODESolvers_RHS", 0, true)}};
+      expected_second.parent_local_ordinal = 0;
+      expected_second.ancestry = {
+          {5, 1, expected_item("ODESolvers_RHS", 0, true)}};
+    } else if (which == 2) {
+      second.scopes[0]->parent_local_ordinal = 1;
+      expected_second.ancestry[0].parent_local_ordinal = 1;
+    } else {
+      second.item_ordinal = 21;
+      second.scopes[0]->item_ordinal = 11;
+      second.scopes[0]->parent_local_ordinal = which == 3 ? 0 : 2;
+      expected_second.item_ordinal = 21;
+      expected_second.ancestry[0].item_ordinal = 11;
+      expected_second.ancestry[0].parent_local_ordinal = which == 3 ? 0 : 2;
+    }
+    second.refresh();
+    const auto result = certify(expectation);
+    check_failure(result,
+                  CarpetX::ScheduleCertificationErrorCode::malformed_record);
+    CHECK(result.failure->target == CarpetX::SubcyclingScheduleTarget::rhs);
+    CHECK(result.failure->traversal_ordinal == 1);
+    CHECK(result.failure->field ==
+          expected_fields[static_cast<std::size_t>(which)]);
+  }
+}
+
+void test_repeated_item_cannot_change_from_leaf_to_scope() {
+  fake::setup_valid();
+  auto &second = fake::add_body("ODESolvers_RHS");
+  second.traversal_ordinal = 1;
+  second.item_ordinal = 11;
+  second.parent_local_ordinal = 0;
+  auto replayed_leaf =
+      std::make_unique<fake::ScopeFixture>("ODESolvers_RHS");
+  replayed_leaf->item_ordinal = 10;
+  replayed_leaf->parent_local_ordinal = 0;
+  replayed_leaf->description = "ODESolvers_RHS description";
+  replayed_leaf->implementation = "TestImpl";
+  replayed_leaf->function.where = "ODESolvers_RHS::where";
+  replayed_leaf->function.routine = "rhs_routine";
+  second.scopes.push_back(std::move(replayed_leaf));
+  second.refresh();
+
+  auto expectation = valid_expectation();
+  expectation.manifest.targets[0].records.push_back(
+      {1,
+       11,
+       0,
+       expected_item("ODESolvers_RHS", 0),
+       {{10, 0, expected_item("ODESolvers_RHS", 0)}}});
+  const auto result = certify(expectation);
+  check_failure(result,
+                CarpetX::ScheduleCertificationErrorCode::malformed_record);
+  CHECK(result.failure->target == CarpetX::SubcyclingScheduleTarget::rhs);
+  CHECK(result.failure->traversal_ordinal == 1);
+  CHECK(result.failure->field == "record.ancestry[0].node_kind");
+}
+
+void test_new_scope_item_ordinal_cannot_move_backwards_across_records() {
+  fake::setup_valid();
+  auto &second = fake::add_body("ODESolvers_RHS");
+  second.traversal_ordinal = 1;
+  second.item_ordinal = 11;
+  second.parent_local_ordinal = 0;
+  second.scopes.push_back(
+      std::make_unique<fake::ScopeFixture>("ODESolvers_RHS"));
+  second.scopes[0]->parent_local_ordinal = 1;
+  second.refresh();
+
+  auto expectation = valid_expectation();
+  expectation.manifest.targets[0].records.push_back(
+      {1,
+       11,
+       0,
+       expected_item("ODESolvers_RHS", 0),
+       {{5, 1, expected_item("ODESolvers_RHS", 0, true)}}});
+  const auto result = certify(expectation);
+  check_failure(result,
+                CarpetX::ScheduleCertificationErrorCode::malformed_record);
+  CHECK(result.failure->target == CarpetX::SubcyclingScheduleTarget::rhs);
+  CHECK(result.failure->traversal_ordinal == 1);
+  CHECK(result.failure->field == "record.ancestry[0].item_ordinal");
+}
+
+void test_table_boundary_failures_release_iterators_and_clones() {
+  const std::vector<std::pair<fake::TableFailure, std::string>> cases{
+      {fake::TableFailure::iterator_create, "record.item.tags.iterator"},
+      {fake::TableFailure::iterator_query, "record.item.tags.iterator"},
+      {fake::TableFailure::iterator_advance, "record.item.tags.iterator"},
+      {fake::TableFailure::iterator_end_state, "record.item.tags.iterator"},
+      {fake::TableFailure::clone, "record.item.tags.clone"}};
+  for (std::size_t i = 0; i < cases.size(); ++i) {
+    if (i != 0)
+      fake::reset();
+    fake::setup_valid();
+    fake::table_failure = cases[i].first;
+    const auto result = certify(valid_expectation());
+    check_failure(result, CarpetX::ScheduleCertificationErrorCode::tag_error);
+    CHECK(result.failure->field == cases[i].second);
+    CHECK(fake::live_iterators == 0);
+    CHECK(fake::iterators.empty());
+    CHECK(fake::live_clones == 0);
+  }
+}
+
+void test_late_second_target_failure_discards_first_target() {
+  fake::setup_valid();
+  auto &post = *fake::inventory["ODESolvers_PostStep"].records.front();
+  fake::tables.at(post.function.data.tags).flags = 0;
+  const auto result = certify(valid_expectation());
+  check_failure(result, CarpetX::ScheduleCertificationErrorCode::tag_error);
+  CHECK(fake::live_clones == 0);
+  CHECK(fake::inventory_calls.size() == 5);
+}
+
+void test_poison_handles_are_never_invoked() {
+  fake::setup_valid();
+  fake::inventory["ODESolvers_RHS"].records.front()->opaque_handle =
+      reinterpret_cast<void *>(static_cast<std::uintptr_t>(0xdeadU));
+  fake::inventory["ODESolvers_PostStep"].records.front()->opaque_handle =
+      reinterpret_cast<void *>(static_cast<std::uintptr_t>(0xbeefU));
+  const auto result = certify(valid_expectation());
+  CHECK(result);
+  CHECK(fake::poison_invocations == 0);
+}
+
+void test_default_local_and_explicit_local_c_gf_real_tl0_pass() {
+  fake::setup_valid();
+  const auto result = certify(valid_expectation());
+  CHECK(result);
+  const auto &targets = result.registry->manifest().targets;
+  CHECK(targets[0].records[0].item.effective_mode ==
+        CarpetX::CanonicalScheduleMode::default_local);
+  CHECK(targets[1].records[0].item.effective_mode ==
+        CarpetX::CanonicalScheduleMode::local);
+  CHECK(targets[0].records[0].item.accesses[0].variable_name == "Test::u");
+}
+
+void test_random_tag_iteration_order_has_equal_manifest() {
+  fake::setup_valid(true);
+  const auto result = certify(valid_expectation());
+  CHECK(result);
+  CHECK(result.registry->manifest().targets[0].records[0].item.tags ==
+        result.registry->manifest().targets[1].records[0].item.tags);
+}
+
+void test_tag_flags_types_counts_values_and_duplicates_fail_closed() {
+  const auto run_case = [](const int which) {
+    fake::setup_valid();
+    auto &record = *fake::inventory["ODESolvers_RHS"].records.front();
+    auto &table = fake::tables.at(record.function.data.tags);
+    if (which == 0)
+      table.flags = 0;
+    else if (which == 1)
+      table.entries[0].type = CCTK_VARIABLE_POINTER;
+    else if (which == 2)
+      table.entries[0].count = 0;
+    else if (which == 3)
+      table.entries[0].get_result = 0;
+    else
+      table.entries = {{"Dup", CCTK_VARIABLE_INT, 1,
+                        fake::bytes_of(1), {}},
+                       {"dUP", CCTK_VARIABLE_INT, 1,
+                        fake::bytes_of(2), {}}};
+    const auto result = certify(valid_expectation());
+    check_failure(result, CarpetX::ScheduleCertificationErrorCode::tag_error);
+    CHECK(fake::live_clones == 0);
+  };
+  for (int which = 0; which < 5; ++which) {
+    if (which != 0)
+      fake::reset();
+    run_case(which);
+  }
+}
+
+void test_group_and_variable_full_name_roundtrip_is_required() {
+  {
+    fake::setup_valid();
+    fake::break_var_roundtrip = true;
+    const auto result = certify(valid_expectation());
+    check_failure(
+        result, CarpetX::ScheduleCertificationErrorCode::name_resolution_error);
+  }
+  fake::reset();
+  {
+    fake::setup_valid();
+    fake::break_group_roundtrip = true;
+    const auto result = certify(valid_expectation());
+    check_failure(
+        result, CarpetX::ScheduleCertificationErrorCode::name_resolution_error);
+  }
+}
+
+void test_scalar_array_tl1_and_unknown_region_bits_reject() {
+  for (int which = 0; which < 4; ++which) {
+    if (which != 0)
+      fake::reset();
+    fake::setup_valid();
+    auto &record = *fake::inventory["ODESolvers_RHS"].records.front();
+    if (which == 0)
+      record.function.rdwr[0].varindex = 1;
+    else if (which == 1)
+      record.function.rdwr[0].varindex = 2;
+    else if (which == 2)
+      record.function.rdwr[0].timelevel = 1;
+    else
+      record.function.rdwr[0].where_rd = 8;
+    record.refresh();
+    const auto result = certify(valid_expectation());
+    check_failure(
+        result, CarpetX::ScheduleCertificationErrorCode::unsupported_metadata);
+  }
+}
+
+void test_nonlocal_early_late_singlemap_and_loop_modes_reject() {
+  using FlagCase = std::pair<int cFunctionData::*, int>;
+  const std::vector<FlagCase> flags{{&cFunctionData::local, 2},
+                                    {&cFunctionData::meta, 1},
+                                    {&cFunctionData::meta_early, 1},
+                                    {&cFunctionData::meta_late, 1},
+                                    {&cFunctionData::global, 1},
+                                    {&cFunctionData::global_early, 1},
+                                    {&cFunctionData::global_late, 1},
+                                    {&cFunctionData::level, 1},
+                                    {&cFunctionData::singlemap, 1},
+                                    {&cFunctionData::loop_meta, 1},
+                                    {&cFunctionData::loop_global, 1},
+                                    {&cFunctionData::loop_level, 1},
+                                    {&cFunctionData::loop_singlemap, 1},
+                                    {&cFunctionData::loop_local, 1}};
+  for (std::size_t i = 0; i < flags.size(); ++i) {
+    if (i != 0)
+      fake::reset();
+    fake::setup_valid();
+    auto &data = fake::inventory["ODESolvers_RHS"].records.front()->function.data;
+    data.*flags[i].first = flags[i].second;
+    const auto result = certify(valid_expectation());
+    check_failure(
+        result, CarpetX::ScheduleCertificationErrorCode::unsupported_metadata);
+  }
+}
+
+void test_if_while_storage_communication_sync_and_trigger_reject() {
+  for (int which = 0; which < 6; ++which) {
+    if (which != 0)
+      fake::reset();
+    fake::setup_valid();
+    auto &record = *fake::inventory["ODESolvers_RHS"].records.front();
+    if (which == 0)
+      record.ifs = {"condition"};
+    else if (which == 1)
+      record.whiles = {"condition"};
+    else if (which == 2) {
+      record.storage_groups = {0};
+      record.storage_timelevels = {0};
+    } else if (which == 3)
+      record.communication_groups = {0};
+    else if (which == 4)
+      record.function.sync_groups = {0};
+    else
+      record.function.trigger_groups = {0};
+    record.refresh();
+    const auto result = certify(valid_expectation());
+    check_failure(
+        result, CarpetX::ScheduleCertificationErrorCode::unsupported_metadata);
+  }
+}
+
+void test_raw_and_normalized_access_contradiction_rejects() {
+  for (int which = 0; which < 2; ++which) {
+    if (which != 0)
+      fake::reset();
+    fake::setup_valid();
+    auto &function =
+        fake::inventory["ODESolvers_RHS"].records.front()->function;
+    if (which == 0)
+      function.reads.clear();
+    else
+      function.rdwr[0].where_rd = 0;
+    function.refresh();
+    const auto result = certify(valid_expectation());
+    check_failure(result,
+                  CarpetX::ScheduleCertificationErrorCode::malformed_record);
+  }
+}
+
+void test_extra_missing_reordered_or_changed_manifest_rejects() {
+  const std::vector<std::string> expected_fields{
+      "manifest.targets[0].records.size",
+      "manifest.targets[0].records.size",
+      "manifest.targets[0].target",
+      "manifest.targets[1].records[0].item.routine"};
+  for (int which = 0; which < 4; ++which) {
+    if (which != 0)
+      fake::reset();
+    fake::setup_valid();
+    auto expectation = valid_expectation();
+    if (which == 0)
+      expectation.manifest.targets[0].records.push_back(
+          expectation.manifest.targets[0].records[0]);
+    else if (which == 1)
+      expectation.manifest.targets[0].records.clear();
+    else if (which == 2)
+      std::swap(expectation.manifest.targets[0],
+                expectation.manifest.targets[1]);
+    else
+      expectation.manifest.targets[1].records[0].item.routine = "changed";
+    const auto result = certify(expectation);
+    check_failure(result,
+                  CarpetX::ScheduleCertificationErrorCode::manifest_mismatch);
+    CHECK(result.failure->field ==
+          expected_fields[static_cast<std::size_t>(which)]);
+    CHECK(fake::live_clones == 0);
+  }
+}
+
+void test_pointer_and_table_handle_values_do_not_affect_equality() {
+  fake::setup_valid();
+  const auto expectation = valid_expectation();
+  CarpetX::CanonicalScheduleBundle first_manifest;
+  {
+    const auto first = certify(expectation);
+    CHECK(first);
+    first_manifest = first.registry->manifest();
+  }
+  CHECK(fake::live_clones == 0);
+  fake::reset();
+  fake::setup_valid(true);
+  fake::inventory["ODESolvers_RHS"].records.front()->opaque_handle =
+      reinterpret_cast<void *>(static_cast<std::uintptr_t>(0x123456U));
+  fake::inventory["ODESolvers_PostStep"].records.front()->opaque_handle =
+      reinterpret_cast<void *>(static_cast<std::uintptr_t>(0x654321U));
+  const auto second = certify(expectation);
+  CHECK(second);
+  CHECK(first_manifest == second.registry->manifest());
+}
+
+void test_invalid_or_mismatched_build_provenance_rejects() {
+  {
+    fake::setup_valid();
+    auto expectation = valid_expectation();
+    expectation.provenance.executable_sha256 = "bad";
+    const auto result = CarpetX::certify_local_subcycling_schedules(
+        expectation, valid_provenance());
+    check_failure(
+        result, CarpetX::ScheduleCertificationErrorCode::provenance_mismatch);
+    CHECK(result.failure->field == "provenance.executable_sha256");
+    CHECK(fake::inventory_calls.empty());
+  }
+  fake::reset();
+  {
+    fake::setup_valid();
+    auto observed = valid_provenance();
+    observed.compiler_version = "different";
+    const auto result = CarpetX::certify_local_subcycling_schedules(
+        valid_expectation(), observed);
+    check_failure(
+        result, CarpetX::ScheduleCertificationErrorCode::provenance_mismatch);
+    CHECK(result.failure->field == "provenance.compiler_version");
+    CHECK(fake::inventory_calls.empty());
+  }
+  fake::reset();
+  {
+    fake::setup_valid();
+    auto expectation = valid_expectation();
+    std::transform(expectation.provenance.cactus_flesh_parent.begin(),
+                   expectation.provenance.cactus_flesh_parent.end(),
+                   expectation.provenance.cactus_flesh_parent.begin(),
+                   [](const char) { return 'A'; });
+    const auto result = CarpetX::certify_local_subcycling_schedules(
+        expectation, valid_provenance());
+    CHECK(result);
+  }
+}
+
+void test_provenance_type_sizes_match_live_build_and_cover_observed_tags() {
+  {
+    fake::setup_valid();
+    auto expectation = valid_expectation();
+    expectation.provenance.cctk_type_sizes[0].second += 1;
+    const auto result = CarpetX::certify_local_subcycling_schedules(
+        expectation, expectation.provenance);
+    check_failure(
+        result, CarpetX::ScheduleCertificationErrorCode::provenance_mismatch);
+    CHECK(result.failure->field == "provenance.cctk_type_sizes[0].size");
+    CHECK(fake::inventory_calls.empty());
+  }
+  fake::reset();
+  {
+    fake::setup_valid();
+    auto expectation = valid_expectation();
+    expectation.provenance.cctk_type_sizes.pop_back();
+    const auto result = CarpetX::certify_local_subcycling_schedules(
+        expectation, expectation.provenance);
+    check_failure(
+        result, CarpetX::ScheduleCertificationErrorCode::provenance_mismatch);
+    CHECK(result.failure->field ==
+          "provenance.cctk_type_sizes.missing[130]");
+    CHECK(fake::inventory_calls.size() == 6);
+  }
+}
+
+void test_registry_publishes_only_after_both_targets_match() {
+  {
+    fake::setup_valid();
+    auto expectation = valid_expectation();
+    expectation.manifest.targets[1].records[0].item.routine = "wrong";
+    const auto result = certify(expectation);
+    check_failure(result,
+                  CarpetX::ScheduleCertificationErrorCode::manifest_mismatch);
+    CHECK(fake::live_clones == 0);
+  }
+  fake::reset();
+  {
+    fake::setup_valid();
+    const auto result = certify(valid_expectation());
+    CHECK(result);
+    CHECK(result.registry != nullptr);
+    CHECK(result.registry->size(CarpetX::SubcyclingScheduleTarget::rhs) == 1);
+    CHECK(result.registry->size(CarpetX::SubcyclingScheduleTarget::post_step) == 1);
+  }
+}
+
+void test_native_gate_observation_returns_only_canonical_expectation() {
+  fake::setup_valid();
+  const auto observed =
+      CarpetX::observe_local_subcycling_schedules_for_native_gate(
+          valid_provenance());
+  CHECK(observed);
+  CHECK(!observed.failure.has_value());
+  CHECK(observed.expectation.has_value());
+  CHECK(observed.expectation.value().manifest == valid_expectation().manifest);
+  CHECK(observed.expectation.value().provenance == valid_provenance());
+  CHECK(fake::inventory_calls.size() == 6);
+  CHECK(fake::live_clones == 0);
+}
+
+void test_callback_exception_is_contained_and_rolls_back() {
+  fake::setup_valid();
+  fake::throw_on_table_get = true;
+  const auto result = certify(valid_expectation());
+  check_failure(
+      result,
+      CarpetX::ScheduleCertificationErrorCode::callback_internal_error);
+  CHECK(result.failure->field == "record.exception");
+  CHECK(fake::live_clones == 0);
+}
+
+using TestFunction = void (*)();
+
+int run_test(const char *name, TestFunction test) {
+  std::string failure_message;
+  try {
+    fake::reset();
+    test();
+  } catch (const std::exception &error) {
+    failure_message = error.what();
+  }
+  const auto record_failure = [&](const std::string &message) {
+    if (!failure_message.empty())
+      failure_message += "; ";
+    failure_message += message;
+  };
+  if (fake::poison_invocation_count != 0)
+    record_failure("opaque schedule handle was invoked");
+  if (fake::live_cloned_table_count != 0)
+    record_failure("owned tag clone leaked past test lifetime");
+  if (fake::live_iterators != 0 || !fake::iterators.empty())
+    record_failure("tag-table iterator leaked past test lifetime");
+  if (!failure_message.empty()) {
+    std::cerr << "[FAIL] " << name << ": " << failure_message << '\n';
+    return 1;
+  }
+  std::cout << "[PASS] " << name << '\n';
+  return 0;
+}
+
+} // namespace
+
+int main() {
+  const std::vector<std::pair<const char *, TestFunction>> tests{
+      {"exact six-call order and two body targets",
+       test_exact_six_call_order_and_two_body_targets},
+      {"missing entry and exit are required",
+       test_missing_entry_and_exit_are_required},
+      {"present empty entry or exit rejects",
+       test_present_empty_entry_or_exit_rejects},
+      {"body missing or error rejects", test_body_missing_or_error_rejects},
+      {"borrowed metadata is deep copied",
+       test_borrowed_metadata_is_deep_copied},
+      {"owned function data rebinds every pointer",
+       test_owned_function_data_rebinds_every_pointer},
+      {"leaf tag clone and scope tag copy lifetimes",
+       test_leaf_tag_clone_and_scope_tag_copy_lifetimes},
+      {"multi-record ancestry uses sibling-local ordinals",
+       test_multi_record_ancestry_uses_sibling_local_ordinals},
+      {"contradictory multi-record ancestry rejects exact fields",
+       test_contradictory_multi_record_ancestry_rejects_exact_fields},
+      {"repeated item cannot change from leaf to scope",
+       test_repeated_item_cannot_change_from_leaf_to_scope},
+      {"new scope item ordinal cannot move backwards across records",
+       test_new_scope_item_ordinal_cannot_move_backwards_across_records},
+      {"table boundary failures release iterators and clones",
+       test_table_boundary_failures_release_iterators_and_clones},
+      {"late second target failure discards first target",
+       test_late_second_target_failure_discards_first_target},
+      {"poison handles are never invoked",
+       test_poison_handles_are_never_invoked},
+      {"default local and explicit local C GF REAL TL0 pass",
+       test_default_local_and_explicit_local_c_gf_real_tl0_pass},
+      {"random tag iteration order has equal manifest",
+       test_random_tag_iteration_order_has_equal_manifest},
+      {"tag flags types counts values and duplicates fail closed",
+       test_tag_flags_types_counts_values_and_duplicates_fail_closed},
+      {"group and variable full name roundtrip is required",
+       test_group_and_variable_full_name_roundtrip_is_required},
+      {"scalar array TL1 and unknown region bits reject",
+       test_scalar_array_tl1_and_unknown_region_bits_reject},
+      {"nonlocal early late singlemap and loop modes reject",
+       test_nonlocal_early_late_singlemap_and_loop_modes_reject},
+      {"if while storage communication sync and trigger reject",
+       test_if_while_storage_communication_sync_and_trigger_reject},
+      {"raw and normalized access contradiction rejects",
+       test_raw_and_normalized_access_contradiction_rejects},
+      {"extra missing reordered or changed manifest rejects",
+       test_extra_missing_reordered_or_changed_manifest_rejects},
+      {"pointer and table handle values do not affect equality",
+       test_pointer_and_table_handle_values_do_not_affect_equality},
+      {"invalid or mismatched build provenance rejects",
+       test_invalid_or_mismatched_build_provenance_rejects},
+      {"provenance type sizes match live build and cover observed tags",
+       test_provenance_type_sizes_match_live_build_and_cover_observed_tags},
+      {"registry publishes only after both targets match",
+       test_registry_publishes_only_after_both_targets_match},
+      {"native gate observation returns only canonical expectation",
+       test_native_gate_observation_returns_only_canonical_expectation},
+      {"callback exception is contained and rolls back",
+       test_callback_exception_is_contained_and_rolls_back}};
+  int failures = 0;
+  for (const auto &test : tests)
+    failures += run_test(test.first, test.second);
+  if (failures != 0)
+    std::cerr << failures << " test(s) failed\n";
+  else
+    std::cout << "Phase 8B3B schedule certification tests passed\n";
+  return failures == 0 ? 0 : 1;
+}

--- a/CarpetX/test/subcycling_schedule_certification_unit.cxx
+++ b/CarpetX/test/subcycling_schedule_certification_unit.cxx
@@ -1325,6 +1325,30 @@ void test_if_while_storage_communication_sync_and_trigger_reject() {
   }
 }
 
+void test_wavetoy_global_sync_is_explicitly_rejected() {
+  fake::setup_valid();
+  auto &function =
+      fake::inventory["ODESolvers_RHS"].records.front()->function;
+  function.thorn = "WaveToyX";
+  function.routine = "WaveToyX_Boundaries";
+  function.sync_groups = {0};
+  function.data.global = 1;
+  function.refresh();
+
+  const auto result = certify(valid_expectation());
+  check_failure(
+      result, CarpetX::ScheduleCertificationErrorCode::unsupported_metadata);
+  CHECK(result.failure->target ==
+        CarpetX::SubcyclingScheduleTarget::rhs);
+  CHECK(result.failure->traversal_ordinal == 0);
+  CHECK(result.failure->field == "record.item.execution_mode");
+  CHECK(result.failure->detail ==
+        "only default-local or explicit local is supported");
+  CHECK(result.registry == nullptr);
+  CHECK(fake::poison_invocation_count == 0);
+  CHECK(fake::live_cloned_table_count == 0);
+}
+
 void test_raw_and_normalized_access_contradiction_rejects() {
   for (int which = 0; which < 2; ++which) {
     if (which != 0)
@@ -1579,6 +1603,8 @@ int main() {
        test_nonlocal_early_late_singlemap_and_loop_modes_reject},
       {"if while storage communication sync and trigger reject",
        test_if_while_storage_communication_sync_and_trigger_reject},
+      {"WaveToyX global SYNC is explicitly rejected",
+       test_wavetoy_global_sync_is_explicitly_rejected},
       {"raw and normalized access contradiction rejects",
        test_raw_and_normalized_access_contradiction_rejects},
       {"extra missing reordered or changed manifest rejects",

--- a/CarpetX/test/subcycling_schedule_state_unit.cxx
+++ b/CarpetX/test/subcycling_schedule_state_unit.cxx
@@ -1,0 +1,117 @@
+#include "subcycling_schedule_state.hxx"
+
+#include <cassert>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+namespace Internal = CarpetX::ScheduleInternal;
+
+struct ActiveRange {
+  int first;
+  int last;
+};
+
+struct FakeGH {
+  int cctk_iteration{};
+  double cctk_time{};
+  double cctk_delta_time{};
+  int cctk_timefac{};
+};
+
+void assert_metadata(const FakeGH &gh, const int iteration, const double time,
+                     const double delta_time, const int timefac) {
+  assert(gh.cctk_iteration == iteration);
+  assert(gh.cctk_time == time);
+  assert(gh.cctk_delta_time == delta_time);
+  assert(gh.cctk_timefac == timefac);
+}
+
+void test_scoped_active_levels_restore_nested_and_exceptional_state() {
+  std::optional<ActiveRange> active(ActiveRange{0, 5});
+  {
+    Internal::ScopedActiveLevels<ActiveRange> outer(active,
+                                                     ActiveRange{1, 4});
+    assert(active->first == 1 && active->last == 4);
+    {
+      Internal::ScopedActiveLevels<ActiveRange> inner(active,
+                                                       ActiveRange{2, 3});
+      assert(active->first == 2 && active->last == 3);
+    }
+    assert(active->first == 1 && active->last == 4);
+  }
+  assert(active->first == 0 && active->last == 5);
+
+  try {
+    Internal::ScopedActiveLevels<ActiveRange> scope(active,
+                                                     ActiveRange{3, 3});
+    throw std::runtime_error("requested unwind");
+  } catch (const std::runtime_error &) {
+  }
+  assert(active->first == 0 && active->last == 5);
+}
+
+void test_level_time_metadata_copies_timefac_and_scope_restores_every_field() {
+  FakeGH source{7, 1.25, 0.5, 8};
+  FakeGH target{2, 0.25, 1.0, 1};
+  Internal::copy_level_time_metadata(target, source);
+  assert_metadata(target, 7, 1.25, 0.5, 8);
+
+  std::vector<Internal::LevelTimeMetadata<double>> propagated;
+  auto propagate = [&propagated](FakeGH &gh) noexcept {
+    propagated.push_back(Internal::capture_level_time_metadata(gh));
+  };
+  const Internal::LevelTimeMetadata<double> scoped{11, 2.5, 0.125, 16};
+  {
+    Internal::ScopedLevelTimeMetadata<FakeGH, decltype(propagate)> scope(
+        target, scoped, propagate);
+    assert_metadata(target, 11, 2.5, 0.125, 16);
+  }
+
+  assert_metadata(target, 7, 1.25, 0.5, 8);
+  assert(propagated.size() == 2);
+  assert(propagated.front() == scoped);
+  const Internal::LevelTimeMetadata<double> restored{7, 1.25, 0.5, 8};
+  assert(propagated.back() == restored);
+}
+
+void test_group_domain_router_preserves_legacy_order_and_filters_splits() {
+  const auto classify = [](const int group) {
+    return group == 0 || group == 2
+               ? Internal::TimelevelGroupKind::level_grid_function
+               : Internal::TimelevelGroupKind::synchronized_global;
+  };
+  const auto record = [&](const Internal::TimelevelDomain domain) {
+    std::vector<std::string> events;
+    Internal::for_each_timelevel_group(
+        4, domain, classify,
+        [&events](const int group, const Internal::TimelevelGroupKind kind) {
+          events.push_back(
+              std::string(kind ==
+                                  Internal::TimelevelGroupKind::level_grid_function
+                              ? "L"
+                              : "G") +
+              std::to_string(group));
+        });
+    return events;
+  };
+
+  assert(record(Internal::TimelevelDomain::legacy_all) ==
+         std::vector<std::string>({"L0", "G1", "L2", "G3"}));
+  assert(record(Internal::TimelevelDomain::level_grid_functions) ==
+         std::vector<std::string>({"L0", "L2"}));
+  assert(record(Internal::TimelevelDomain::synchronized_globals) ==
+         std::vector<std::string>({"G1", "G3"}));
+}
+
+} // namespace
+
+int main() {
+  test_scoped_active_levels_restore_nested_and_exceptional_state();
+  test_level_time_metadata_copies_timefac_and_scope_restores_every_field();
+  test_group_domain_router_preserves_legacy_order_and_filters_splits();
+}

--- a/CarpetX/test/subcycling_scratch_adapter_mpi_unit.cxx
+++ b/CarpetX/test/subcycling_scratch_adapter_mpi_unit.cxx
@@ -1,0 +1,247 @@
+#include "subcycling_scratch_adapter_internal.hxx"
+
+#include <AMReX_MultiFab.H>
+#include <mpi.h>
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace CarpetX;
+using namespace CarpetX::subcycling_detail;
+
+struct Source {
+  amrex::MultiFab multifab;
+  std::vector<ScratchValidity> validity;
+  int token;
+  Source(const int rank, const bool ok = true)
+      : multifab(2, true, ok, 100 + rank),
+        validity{{true, false, true}, {false, true, false}},
+        token(100 + rank) {}
+};
+
+struct RecordingMpiCollective final : CollectiveOps {
+  MpiCollectiveOps mpi;
+  std::vector<std::int64_t> events;
+  explicit RecordingMpiCollective(MPI_Comm &comm) : mpi(&comm) {}
+  std::int64_t reduce_min(const ScratchCollectivePhase phase,
+                          const std::size_t ordinal,
+                          const std::int64_t local) override {
+    events.push_back(100000 + static_cast<std::int64_t>(phase) * 1000 +
+                     static_cast<std::int64_t>(ordinal));
+    return mpi.reduce_min(phase, ordinal, local);
+  }
+  std::int64_t reduce_max(const ScratchCollectivePhase phase,
+                          const std::size_t ordinal,
+                          const std::int64_t local) override {
+    events.push_back(200000 + static_cast<std::int64_t>(phase) * 1000 +
+                     static_cast<std::int64_t>(ordinal));
+    return mpi.reduce_max(phase, ordinal, local);
+  }
+  bool reduce_and(const ScratchCollectivePhase phase,
+                  const std::size_t ordinal, const bool local) override {
+    events.push_back(300000 + static_cast<std::int64_t>(phase) * 1000 +
+                     static_cast<std::int64_t>(ordinal));
+    return mpi.reduce_and(phase, ordinal, local);
+  }
+};
+
+LocalScratchEntry entry(Source &source, const int group,
+                        std::vector<std::int64_t> fields = {}) {
+  if (fields.empty())
+    fields = {83, 0, 1, group, 2, 2, 1, 0, 0, 4, 4, 4,
+              7, 7, 7, 2, 0, 1, 1, 8, 8, 8, 0, 1, 1, 0, 1};
+  const auto field_count = static_cast<std::int64_t>(fields.size());
+  return LocalScratchEntry{ScratchGFKey{83, 1, 0, group}, &source.token,
+                           &source.multifab, source.validity,
+                           std::move(fields), field_count};
+}
+
+LocalScratchBatch batch(Source &source, const int group = 1) {
+  return LocalScratchBatch{ScratchAdapterFailure::none, 83, 0, 1,
+                           {entry(source, group)}, 1};
+}
+
+bool transact(LocalScratchBatch &local, RecordingMpiCollective &collective,
+              const std::int64_t epoch, const bool fail_copy) {
+  try {
+    static_cast<void>(run_certification_transaction(
+        local, collective, [epoch] { return epoch; },
+        [fail_copy](const UncertifiedScratchLevelManifest &manifest,
+                    const std::vector<ScratchGFView> &views) {
+          if (fail_copy)
+            throw std::runtime_error("rank-local copy failure");
+          return ScratchLevelFrame::copy_tl0(manifest, views);
+        }));
+    return true;
+  } catch (const ScratchAdapterCollectiveError &) {
+    return false;
+  }
+}
+
+void require_all(MPI_Comm comm, const bool local, const bool expected) {
+  int value = local ? 1 : 0;
+  int minimum = 0;
+  int maximum = 0;
+  MPI_Allreduce(&value, &minimum, 1, MPI_INT, MPI_MIN, comm);
+  MPI_Allreduce(&value, &maximum, 1, MPI_INT, MPI_MAX, comm);
+  assert(minimum == maximum);
+  assert((minimum != 0) == expected);
+}
+
+void require_same_event_trace(
+    MPI_Comm comm, const std::vector<std::int64_t> &local_events) {
+  const int local_count = static_cast<int>(local_events.size());
+  int minimum_count = 0;
+  int maximum_count = 0;
+  MPI_Allreduce(&local_count, &minimum_count, 1, MPI_INT, MPI_MIN, comm);
+  MPI_Allreduce(&local_count, &maximum_count, 1, MPI_INT, MPI_MAX, comm);
+  assert(minimum_count == maximum_count);
+  std::vector<std::int64_t> peer(local_events.size());
+  const int rank = [&] {
+    int value = -1;
+    MPI_Comm_rank(comm, &value);
+    return value;
+  }();
+  MPI_Sendrecv(local_events.data(), local_count, MPI_INT64_T, 1 - rank, 9,
+               peer.data(), local_count, MPI_INT64_T, 1 - rank, 9, comm,
+               MPI_STATUS_IGNORE);
+  assert(peer == local_events);
+}
+
+void require_outcome_and_trace(MPI_Comm comm, const bool local_result,
+                               const bool expected,
+                               const RecordingMpiCollective &collective) {
+  require_all(comm, local_result, expected);
+  require_same_event_trace(comm, collective.events);
+}
+
+void test_agreed_success(MPI_Comm comm, const int rank) {
+  Source source(rank);
+  auto local = batch(source);
+  RecordingMpiCollective collective(comm);
+  require_outcome_and_trace(comm, transact(local, collective, 83, false),
+                            true, collective);
+}
+
+void test_one_rank_preflight_failure(MPI_Comm comm, const int rank) {
+  Source source(rank);
+  auto local = batch(source);
+  if (rank == 1)
+    local.preflight_status = ScratchAdapterFailure::invalid_tl0;
+  RecordingMpiCollective collective(comm);
+  require_outcome_and_trace(comm, transact(local, collective, 83, false),
+                            false, collective);
+
+  auto invalid_size = batch(source);
+  if (rank == 1)
+    invalid_size.entries[0].prevalidated_schema_length = -1;
+  RecordingMpiCollective size_collective(comm);
+  require_outcome_and_trace(
+      comm, transact(invalid_size, size_collective, 83, false), false,
+      size_collective);
+}
+
+void test_one_rank_count_schema_ok_epoch_copy_failures(MPI_Comm comm,
+                                                       const int rank) {
+  {
+    Source source(rank), extra(rank + 10);
+    auto local = batch(source);
+    if (rank == 1) {
+      local.entries.push_back(entry(extra, 2));
+      local.prevalidated_entry_count = 2;
+    }
+    RecordingMpiCollective collective(comm);
+    require_outcome_and_trace(comm, transact(local, collective, 83, false),
+                              false, collective);
+  }
+  {
+    Source source(rank);
+    auto local = batch(source);
+    if (rank == 1) {
+      local.entries[0].schema_fields.push_back(101);
+      ++local.entries[0].prevalidated_schema_length;
+    }
+    RecordingMpiCollective collective(comm);
+    require_outcome_and_trace(comm, transact(local, collective, 83, false),
+                              false, collective);
+  }
+  {
+    Source source(rank);
+    auto local = batch(source);
+    if (rank == 1)
+      local.entries[0].schema_fields[4] = 99;
+    RecordingMpiCollective collective(comm);
+    require_outcome_and_trace(comm, transact(local, collective, 83, false),
+                              false, collective);
+  }
+  {
+    Source source(rank, rank == 0);
+    auto local = batch(source);
+    RecordingMpiCollective collective(comm);
+    require_outcome_and_trace(comm, transact(local, collective, 83, false),
+                              false, collective);
+  }
+  {
+    Source source(rank);
+    auto local = batch(source);
+    RecordingMpiCollective collective(comm);
+    require_outcome_and_trace(
+        comm, transact(local, collective, rank == 0 ? 83 : 84, false), false,
+        collective);
+  }
+  {
+    Source source(rank);
+    auto local = batch(source);
+    RecordingMpiCollective collective(comm);
+    require_outcome_and_trace(
+        comm, transact(local, collective, 83, rank == 1), false, collective);
+  }
+}
+
+void test_one_rank_box_processor_validity_mismatch(MPI_Comm comm,
+                                                   const int rank) {
+  for (const std::size_t ordinal : {9U, 20U, 25U}) {
+    Source source(rank);
+    auto local = batch(source);
+    if (rank == 1)
+      local.entries[0].schema_fields[ordinal] += 1;
+    RecordingMpiCollective collective(comm);
+    require_outcome_and_trace(comm, transact(local, collective, 83, false),
+                              false, collective);
+  }
+}
+
+void test_collective_event_order(MPI_Comm comm, const int rank) {
+  Source source(rank);
+  auto local = batch(source);
+  RecordingMpiCollective collective(comm);
+  require_outcome_and_trace(comm, transact(local, collective, 83, false),
+                            true, collective);
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  MPI_Init(&argc, &argv);
+  int rank = -1;
+  int size = -1;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  assert(size == 2);
+  MPI_Comm comm = MPI_COMM_WORLD;
+  test_agreed_success(comm, rank);
+  test_one_rank_preflight_failure(comm, rank);
+  test_one_rank_count_schema_ok_epoch_copy_failures(comm, rank);
+  test_one_rank_box_processor_validity_mismatch(comm, rank);
+  test_collective_event_order(comm, rank);
+  if (rank == 0)
+    std::cout << "Phase 8B1 two-rank MPI protocol tests passed\n";
+  MPI_Finalize();
+}

--- a/CarpetX/test/subcycling_scratch_adapter_unit.cxx
+++ b/CarpetX/test/subcycling_scratch_adapter_unit.cxx
@@ -1,0 +1,307 @@
+#define private public
+#include "subcycling_scratch_adapter.hxx"
+#undef private
+#include "subcycling_scratch_adapter_internal.hxx"
+
+#include <AMReX_MultiFab.H>
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace CarpetX;
+using namespace CarpetX::subcycling_detail;
+
+struct ScriptedCollective final : CollectiveOps {
+  struct Override {
+    ScratchCollectivePhase phase;
+    std::size_t ordinal;
+    char operation;
+    std::int64_t value;
+  };
+  std::vector<std::string> events;
+  std::vector<Override> overrides;
+
+  std::int64_t reduce_min(const ScratchCollectivePhase phase,
+                          const std::size_t ordinal,
+                          const std::int64_t local) override {
+    events.push_back("min:" + std::to_string(static_cast<int>(phase)) + ":" +
+                     std::to_string(ordinal));
+    return replacement(phase, ordinal, 'm', local);
+  }
+  std::int64_t reduce_max(const ScratchCollectivePhase phase,
+                          const std::size_t ordinal,
+                          const std::int64_t local) override {
+    events.push_back("max:" + std::to_string(static_cast<int>(phase)) + ":" +
+                     std::to_string(ordinal));
+    return replacement(phase, ordinal, 'M', local);
+  }
+  bool reduce_and(const ScratchCollectivePhase phase,
+                  const std::size_t ordinal, const bool local) override {
+    events.push_back("and:" + std::to_string(static_cast<int>(phase)) + ":" +
+                     std::to_string(ordinal));
+    return replacement(phase, ordinal, 'a', local ? 1 : 0) != 0;
+  }
+
+private:
+  std::int64_t replacement(const ScratchCollectivePhase phase,
+                           const std::size_t ordinal, const char operation,
+                           const std::int64_t local) const {
+    for (const auto &entry : overrides)
+      if (entry.phase == phase && entry.ordinal == ordinal &&
+          entry.operation == operation)
+        return entry.value;
+    return local;
+  }
+};
+
+struct Source {
+  amrex::MultiFab multifab;
+  std::vector<ScratchValidity> validity;
+  int token;
+  Source(const int components, const bool source_ok, const int id)
+      : multifab(components, true, source_ok, id), token(id) {
+    for (int component = 0; component < components; ++component)
+      validity.push_back(
+          ScratchValidity{component % 2 == 0, component % 3 == 0,
+                          component % 2 != 0});
+  }
+};
+
+LocalScratchEntry make_entry(const int group, Source &source,
+                             std::vector<std::int64_t> schema = {}) {
+  if (schema.empty())
+    schema = {77, 2, 0, group, source.multifab.nComp(),
+              static_cast<std::int64_t>(source.validity.size()), group + 10};
+  const auto schema_length = static_cast<std::int64_t>(schema.size());
+  return LocalScratchEntry{ScratchGFKey{77, 2, 0, group}, &source.token,
+                           &source.multifab, source.validity,
+                           std::move(schema), schema_length};
+}
+
+LocalScratchBatch make_batch(std::vector<LocalScratchEntry> entries) {
+  const auto entry_count = static_cast<std::int64_t>(entries.size());
+  return LocalScratchBatch{ScratchAdapterFailure::none, 77, 0, 2,
+                           std::move(entries), entry_count};
+}
+
+ScratchLevelFrame run(LocalScratchBatch &batch, ScriptedCollective &collective,
+                      const std::int64_t current_epoch = 77,
+                      const bool fail_copy = false) {
+  return run_certification_transaction(
+      batch, collective, [current_epoch] { return current_epoch; },
+      [fail_copy](const UncertifiedScratchLevelManifest &manifest,
+                  const std::vector<ScratchGFView> &views) {
+        if (fail_copy)
+          throw std::runtime_error("requested copy failure");
+        return ScratchLevelFrame::copy_tl0(manifest, views);
+      });
+}
+
+template <typename F> void expect_collective_rejection(F &&function) {
+  bool rejected = false;
+  try {
+    function();
+  } catch (const ScratchAdapterCollectiveError &) {
+    rejected = true;
+  }
+  assert(rejected);
+}
+
+void test_multiple_groups_and_exact_validity() {
+  Source first(2, true, 11), second(3, true, 13);
+  auto batch = make_batch(
+      {make_entry(2, first), make_entry(7, second)});
+  ScriptedCollective collective;
+  auto frame = run(batch, collective);
+  assert(frame.entry_count() == 2);
+  assert(frame.key(0).group_index == 2);
+  assert(frame.key(1).group_index == 7);
+  assert(frame.validity(0).size() == first.validity.size());
+  assert(frame.validity(1)[2].interior == second.validity[2].interior);
+  assert(first.multifab.ok_call_count() == 1);
+  assert(second.multifab.ok_call_count() == 1);
+}
+
+void test_preflight_failure_still_reaches_collective() {
+  Source source(1, true, 17);
+  auto batch = make_batch({make_entry(1, source)});
+  batch.preflight_status = ScratchAdapterFailure::invalid_tl0;
+  ScriptedCollective collective;
+  expect_collective_rejection([&] { static_cast<void>(run(batch, collective)); });
+  assert(collective.events.size() == 4);
+}
+
+void test_prevalidated_size_failures_reach_fixed_collective_block() {
+  Source source(1, true, 18);
+  {
+    auto batch = make_batch({make_entry(1, source)});
+    batch.prevalidated_entry_count = -1;
+    ScriptedCollective collective;
+    expect_collective_rejection(
+        [&] { static_cast<void>(run(batch, collective)); });
+    assert(collective.events.size() == 4);
+  }
+  {
+    auto batch = make_batch({make_entry(1, source)});
+    batch.entries[0].prevalidated_schema_length = -1;
+    ScriptedCollective collective;
+    expect_collective_rejection(
+        [&] { static_cast<void>(run(batch, collective)); });
+    assert(collective.events.size() == 4);
+  }
+  {
+    auto batch = make_batch({make_entry(1, source)});
+    batch.entries[0].prevalidated_schema_length += 1;
+    ScriptedCollective collective;
+    expect_collective_rejection(
+        [&] { static_cast<void>(run(batch, collective)); });
+    assert(collective.events.size() == 4);
+  }
+}
+
+void test_count_and_schema_mismatch() {
+  Source source(1, true, 19);
+  auto batch = make_batch({make_entry(1, source)});
+  ScriptedCollective count;
+  count.overrides.push_back(
+      {ScratchCollectivePhase::entry_count, 0, 'M', 2});
+  expect_collective_rejection([&] { static_cast<void>(run(batch, count)); });
+
+  ScriptedCollective schema;
+  schema.overrides.push_back(
+      {ScratchCollectivePhase::schema_fields, 3, 'M', 999});
+  expect_collective_rejection([&] { static_cast<void>(run(batch, schema)); });
+}
+
+void test_box_processor_and_validity_mismatch() {
+  Source source(2, true, 23);
+  auto batch = make_batch({make_entry(1, source,
+      {77, 0, 2, 1, 2, 2, 1, 0, 0, 7, 7, 7, 9, 9, 9,
+       2, 0, 1, 2, 8, 8, 8, 0, 1, 1, 0, 1})});
+  for (const std::size_t ordinal : {9U, 20U, 25U}) {
+    ScriptedCollective collective;
+    collective.overrides.push_back(
+        {ScratchCollectivePhase::schema_fields, ordinal, 'M', 12345});
+    expect_collective_rejection(
+        [&] { static_cast<void>(run(batch, collective)); });
+  }
+}
+
+void test_duplicate_omitted_and_extra_groups() {
+  Source first(1, true, 29), second(1, true, 31);
+  for (const auto failure : {ScratchAdapterFailure::duplicate_group,
+                             ScratchAdapterFailure::omitted_group,
+                             ScratchAdapterFailure::extra_group}) {
+    auto batch = make_batch({make_entry(1, first), make_entry(2, second)});
+    batch.preflight_status = failure;
+    ScriptedCollective collective;
+    expect_collective_rejection(
+        [&] { static_cast<void>(run(batch, collective)); });
+  }
+}
+
+void test_all_sources_checked_after_false() {
+  Source first(1, false, 37), second(1, true, 41), third(1, false, 43);
+  auto batch = make_batch(
+      {make_entry(1, first), make_entry(2, second), make_entry(3, third)});
+  ScriptedCollective collective;
+  expect_collective_rejection([&] { static_cast<void>(run(batch, collective)); });
+  assert(first.multifab.ok_call_count() == 1);
+  assert(second.multifab.ok_call_count() == 1);
+  assert(third.multifab.ok_call_count() == 1);
+}
+
+void test_epoch_change() {
+  Source source(1, true, 47);
+  auto batch = make_batch({make_entry(1, source)});
+  ScriptedCollective collective;
+  expect_collective_rejection(
+      [&] { static_cast<void>(run(batch, collective, 78)); });
+}
+
+void test_copy_failure_discards_local_success() {
+  Source source(1, true, 53);
+  auto batch = make_batch({make_entry(1, source)});
+  ScriptedCollective local_failure;
+  expect_collective_rejection(
+      [&] { static_cast<void>(run(batch, local_failure, 77, true)); });
+
+  ScriptedCollective peer_failure;
+  peer_failure.overrides.push_back(
+      {ScratchCollectivePhase::copy_success, 0, 'a', 0});
+  const int before = amrex::MultiFab::owned_live_count();
+  expect_collective_rejection(
+      [&] { static_cast<void>(run(batch, peer_failure)); });
+  assert(amrex::MultiFab::owned_live_count() == before);
+}
+
+void test_stable_record_view_lifetimes() {
+  Source first(1, true, 59), second(1, true, 61);
+  auto batch = make_batch({make_entry(1, first), make_entry(2, second)});
+  const auto *first_validity = batch.entries[0].validity.data();
+  ScriptedCollective collective;
+  auto frame = run(batch, collective);
+  assert(batch.entries[0].validity.data() == first_validity);
+  assert(frame.validity(0)[0].interior == first.validity[0].interior);
+}
+
+void test_move_contract() {
+  static_assert(!std::is_copy_constructible_v<CertifiedScratchLevelFrame>);
+  static_assert(!std::is_copy_assignable_v<CertifiedScratchLevelFrame>);
+  static_assert(
+      std::is_nothrow_move_constructible_v<CertifiedScratchLevelFrame>);
+  static_assert(std::is_nothrow_move_assignable_v<CertifiedScratchLevelFrame>);
+  Source source(1, true, 67);
+  auto batch = make_batch({make_entry(1, source)});
+  ScriptedCollective collective;
+  auto certified = CertifiedScratchLevelFrame(0, run(batch, collective));
+  auto moved = std::move(certified);
+  assert(certified.patch() == -1);
+  assert(certified.frame().hierarchy_epoch() == -1);
+  assert(moved.patch() == 0);
+  Source replacement_source(1, true, 69);
+  auto replacement_batch = make_batch({make_entry(2, replacement_source)});
+  ScriptedCollective replacement_collective;
+  auto assigned = CertifiedScratchLevelFrame(
+      0, run(replacement_batch, replacement_collective));
+  assigned = std::move(moved);
+  assert(moved.patch() == -1);
+  auto *self = &assigned;
+  assigned = std::move(*self);
+  assert(assigned.patch() == 0);
+}
+
+void test_pointer_identities_never_enter_schema() {
+  // Contract marker: pointer identities never enter schema.
+  Source source(1, true, 71);
+  auto entry = make_entry(1, source);
+  for (const auto field : entry.schema_fields)
+    assert(field != reinterpret_cast<std::intptr_t>(entry.source_storage_identity));
+}
+
+} // namespace
+
+int main() {
+  test_multiple_groups_and_exact_validity();
+  test_preflight_failure_still_reaches_collective();
+  test_prevalidated_size_failures_reach_fixed_collective_block();
+  test_count_and_schema_mismatch();
+  test_box_processor_and_validity_mismatch();
+  test_duplicate_omitted_and_extra_groups();
+  test_all_sources_checked_after_false();
+  test_epoch_change();
+  test_copy_failure_discards_local_success();
+  test_stable_record_view_lifetimes();
+  test_move_contract();
+  test_pointer_identities_never_enter_schema();
+  std::cout << "Phase 8B1 certified TL0 transaction tests passed\n";
+}

--- a/CarpetX/test/subcycling_scratch_local_gh_unit.cxx
+++ b/CarpetX/test/subcycling_scratch_local_gh_unit.cxx
@@ -1,0 +1,472 @@
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <tuple>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace amrex {
+struct IntVect {
+  std::array<int, 3> v{};
+  int operator[](int d) const { return v.at(static_cast<std::size_t>(d)); }
+};
+struct IndexType { IntVect value; IntVect toIntVect() const { return value; } };
+struct Box {
+  IntVect lo, hi;
+  IntVect smallEnd() const { return lo; }
+  IntVect bigEnd() const { return hi; }
+};
+class BoxArray {
+public:
+  std::vector<Box> boxes;
+  IndexType type{{{{0, 0, 0}}}};
+  int size() const { return static_cast<int>(boxes.size()); }
+  const Box &operator[](int i) const { return boxes.at(static_cast<std::size_t>(i)); }
+  IndexType ixType() const { return type; }
+};
+class DistributionMapping {
+public:
+  std::vector<int> processors;
+  const std::vector<int> &ProcessorMap() const { return processors; }
+};
+struct TileRecord { int index; Box valid, tile; };
+class FabArrayBase { public: std::vector<TileRecord> tiles; };
+class MFItInfo { public: MFItInfo &EnableTiling() { return *this; } };
+class MFIter {
+public:
+  MFIter(const FabArrayBase &fab, const MFItInfo &) : fab_(&fab) {}
+  bool isValid() const { return pos_ < fab_->tiles.size(); }
+  MFIter &operator++() { ++pos_; return *this; }
+  int index() const { return fab_->tiles.at(pos_).index; }
+  Box validbox() const { return fab_->tiles.at(pos_).valid; }
+  Box tilebox() const { return fab_->tiles.at(pos_).tile; }
+private:
+  const FabArrayBase *fab_;
+  std::size_t pos_{0};
+};
+template <typename T> class Array4 {
+public:
+  Array4(T *data, Box allocation, int components)
+      : data_(data), box_(allocation), components_(components) {}
+  T *ptr(int i, int j, int k, int component) const {
+    const auto lo = box_.smallEnd();
+    const auto hi = box_.bigEnd();
+    if (i < lo[0] || i > hi[0] || j < lo[1] || j > hi[1] ||
+        k < lo[2] || k > hi[2] || component < 0 || component >= components_)
+      return nullptr;
+    const std::size_t nx = static_cast<std::size_t>(hi[0] - lo[0] + 1);
+    const std::size_t ny = static_cast<std::size_t>(hi[1] - lo[1] + 1);
+    const std::size_t nz = static_cast<std::size_t>(hi[2] - lo[2] + 1);
+    const std::size_t point = static_cast<std::size_t>(i - lo[0]) +
+        nx * (static_cast<std::size_t>(j - lo[1]) +
+              ny * static_cast<std::size_t>(k - lo[2]));
+    return data_ + point + nx * ny * nz * static_cast<std::size_t>(component);
+  }
+private:
+  T *data_;
+  Box box_;
+  int components_;
+};
+class MultiFab {
+public:
+  MultiFab(BoxArray ba, DistributionMapping dm, IntVect grow, int components,
+           bool defined = true, bool alias_copy = false)
+      : ba_(std::move(ba)), dm_(std::move(dm)), grow_(grow),
+        components_(components), defined_(defined), alias_copy_(alias_copy),
+        data_(std::make_shared<std::vector<std::vector<double>>>()) {
+    data_->resize(static_cast<std::size_t>(ba_.size()));
+    for (int i = 0; i < ba_.size(); ++i) {
+      const auto lo = ba_[i].smallEnd(); const auto hi = ba_[i].bigEnd();
+      std::size_t points = 1;
+      for (int d = 0; d < 3; ++d)
+        points *= static_cast<std::size_t>(hi[d] - lo[d] + 1 + 2 * grow_[d]);
+      (*data_)[static_cast<std::size_t>(i)].assign(
+          points * static_cast<std::size_t>(components_), 1000.0 + i);
+    }
+  }
+  MultiFab deepCopy() const {
+    MultiFab result(ba_, dm_, grow_, components_, defined_, false);
+    if (alias_copy_) result.data_ = data_;
+    else *result.data_ = *data_;
+    return result;
+  }
+  bool isDefined() const { return defined_; }
+  int nComp() const { return components_; }
+  const BoxArray &boxArray() const { return ba_; }
+  const DistributionMapping &DistributionMap() const { return dm_; }
+  IntVect nGrowVect() const { return grow_; }
+  Array4<double> array(int index) {
+    auto box = ba_[index];
+    for (int d = 0; d < 3; ++d) { box.lo.v[d] -= grow_[d]; box.hi.v[d] += grow_[d]; }
+    return Array4<double>((*data_)[static_cast<std::size_t>(index)].data(), box,
+                          components_);
+  }
+  void set_defined(bool value) { defined_ = value; }
+  void set_components(int value) { components_ = value; }
+  void set_grow(IntVect value) { grow_ = value; }
+  void set_processors(std::vector<int> value) { dm_.processors = std::move(value); }
+  void set_index_type(IntVect value) { ba_.type.value = value; }
+  void set_box_hi(int index, IntVect value) { ba_.boxes.at(index).hi = value; }
+private:
+  BoxArray ba_;
+  DistributionMapping dm_;
+  IntVect grow_;
+  int components_;
+  bool defined_;
+  bool alias_copy_;
+  std::shared_ptr<std::vector<std::vector<double>>> data_;
+};
+} // namespace amrex
+
+using CCTK_REAL = double;
+constexpr int CCTK_GF = 1;
+struct cGroup { int grouptype; int numvars; };
+struct cGH {
+  int cctk_dim{}, cctk_iteration{};
+  int *cctk_gsh{}, *cctk_lsh{}, *cctk_lbnd{}, *cctk_ubnd{};
+  int cctk_level{}, cctk_patch{}, cctk_npatches{}, cctk_component{};
+  int *cctk_tile_min{}, *cctk_tile_max{}, *cctk_ash{};
+  int cctk_alignment{}, cctk_alignment_offset{};
+  int *cctk_to{}, *cctk_from{};
+  CCTK_REAL cctk_delta_time{};
+  CCTK_REAL *cctk_delta_space{}, *cctk_origin_space{};
+  int *cctk_bbox{}, *cctk_levfac{}, *cctk_levoff{}, *cctk_levoffdenom{};
+  int cctk_timefac{}, cctk_convlevel{}, cctk_convfac{};
+  int *cctk_nghostzones{};
+  CCTK_REAL cctk_time{};
+  const void *current_scheduled_function{};
+  const char *identity{};
+  void ***data{};
+  void **extensions{};
+  void *GroupData{};
+};
+static std::int64_t current_epoch = 7;
+static std::array<int, 8> declared_tls{{1, 2, 2, 1, 1, 2, 2, 1}};
+int CCTK_NumVars() { return static_cast<int>(declared_tls.size()); }
+int CCTK_DeclaredTimeLevelsVI(int vi) { return declared_tls.at(vi); }
+int CCTK_FirstVarIndexI(int gi) { return gi == 0 ? 1 : (gi == 2 ? 5 : -1); }
+int CCTK_GroupData(int gi, cGroup *group) {
+  if ((gi == 0 || gi == 2) && group != nullptr) {
+    group->grouptype = CCTK_GF; group->numvars = 2; return 0;
+  }
+  return 1;
+}
+extern "C" std::int64_t CarpetX_GetEpoch() { return current_epoch; }
+
+namespace CarpetX {
+inline constexpr int dim = 3;
+struct TemplateGeometry {
+  std::array<int, 3> gsh{{20, 20, 20}}, lsh{{8, 8, 8}}, lbnd{{0, 0, 0}},
+      ubnd{{7, 7, 7}}, tile_min{{0, 0, 0}}, tile_max{{3, 7, 7}},
+      ash{{12, 12, 12}}, to{{0, 0, 0}}, from{{0, 0, 0}},
+      levfac{{2, 2, 2}}, levoff{{0, 0, 0}}, levoffdenom{{1, 1, 1}},
+      nghostzones{{2, 2, 2}};
+  std::array<int, 6> bbox{{1, 1, 1, 1, 1, 1}};
+  std::array<double, 3> delta{{0.25, 0.25, 0.25}}, origin{{0, 0, 0}};
+};
+class GHExt {
+public:
+  struct LocalGHPtr {
+    LocalGHPtr() = default;
+    LocalGHPtr(std::unique_ptr<cGH> value) : value_(std::move(value)) {}
+    LocalGHPtr(LocalGHPtr &&) noexcept = default;
+    LocalGHPtr &operator=(LocalGHPtr &&) noexcept = default;
+    LocalGHPtr(const LocalGHPtr &) = delete;
+    LocalGHPtr &operator=(const LocalGHPtr &) = delete;
+    cGH *get() const { return value_.get(); }
+  private:
+    std::unique_ptr<cGH> value_;
+  };
+  struct PatchData {
+    struct LevelData {
+      struct GroupData {
+        int groupindex{}, firstvarindex{}, numvars{}, patch{}, level{};
+        std::array<int, 3> indextype{{0, 0, 0}}, nghostzones{{1, 1, 1}};
+        std::vector<std::unique_ptr<amrex::MultiFab>> mfab;
+        std::vector<std::vector<int>> valid;
+      };
+      int patch{}, level{};
+      std::unique_ptr<amrex::FabArrayBase> fab;
+      std::vector<LocalGHPtr> local_cctkGHs;
+      std::vector<std::unique_ptr<TemplateGeometry>> geometry;
+      std::vector<std::unique_ptr<GroupData>> groupdata;
+    };
+    std::vector<LevelData> leveldata;
+  };
+  std::vector<PatchData> patchdata;
+};
+struct MFPointer {
+  explicit MFPointer(const amrex::MFIter &mfi)
+      : index_(mfi.index()), valid_(mfi.validbox()), tile_(mfi.tilebox()) {}
+  int index() const { return index_; }
+  amrex::Box validbox() const { return valid_; }
+  amrex::Box tilebox() const { return tile_; }
+  int index_; amrex::Box valid_, tile_;
+};
+struct GridPtrDesc1 {
+  GridPtrDesc1(const GHExt::PatchData::LevelData &,
+               const GHExt::PatchData::LevelData::GroupData &group,
+               const MFPointer &mfp) : mfp_(mfp), group_(group) {}
+  template <typename T> T *ptr(const amrex::Array4<T> &vars, int vi) const {
+    const auto lo = mfp_.validbox().smallEnd();
+    return vars.ptr(lo[0] - group_.nghostzones[0],
+                    lo[1] - group_.nghostzones[1],
+                    lo[2] - group_.nghostzones[2], vi);
+  }
+  MFPointer mfp_;
+  const GHExt::PatchData::LevelData::GroupData &group_;
+};
+} // namespace CarpetX
+
+#define CARPETX_SUBCYCLING_SCRATCH_LOCAL_GH_UNIT
+#define CARPETX_SUBCYCLING_SCRATCH_LOCAL_GH_STANDALONE
+#define private public
+#include "../src/subcycling_scratch_state.cxx"
+#undef private
+#include "../src/subcycling_scratch_adapter.hxx"
+
+namespace CarpetX {
+CertifiedScratchLevelFrame::CertifiedScratchLevelFrame(int patch,
+                                                       ScratchLevelFrame frame)
+    : patch_(patch), frame_(std::move(frame)) {}
+CertifiedScratchLevelFrame::CertifiedScratchLevelFrame(
+    CertifiedScratchLevelFrame &&other) noexcept
+    : patch_(other.patch_), frame_(std::move(other.frame_)) { other.patch_ = -1; }
+CertifiedScratchLevelFrame &CertifiedScratchLevelFrame::operator=(
+    CertifiedScratchLevelFrame &&other) noexcept {
+  if (this != &other) { patch_ = other.patch_; frame_ = std::move(other.frame_); other.patch_ = -1; }
+  return *this;
+}
+int CertifiedScratchLevelFrame::patch() const noexcept { return patch_; }
+const ScratchLevelFrame &CertifiedScratchLevelFrame::frame() const noexcept { return frame_; }
+} // namespace CarpetX
+
+#include "../src/subcycling_scratch_local_gh.cxx"
+
+namespace CarpetX {
+class ScratchLocalLevelBindingTestAccess {
+public:
+  static CertifiedScratchLevelFrame certify(int patch, ScratchLevelFrame frame) {
+    return CertifiedScratchLevelFrame(patch, std::move(frame));
+  }
+  static ScratchLevelFrame &frame(CertifiedScratchLevelFrame &certified) {
+    return certified.frame_;
+  }
+  static ScratchLevelFrame &frame(ScratchLocalLevelBinding &binding) {
+    return binding.frame_.frame_;
+  }
+  static const cGH &gh(const ScratchLocalLevelBinding &binding, std::size_t i) {
+    return binding.contexts_.at(i)->gh;
+  }
+  static int live_storage_count() {
+    return ScratchLocalLevelBinding::Storage::live_count;
+  }
+};
+} // namespace CarpetX
+
+namespace {
+using namespace CarpetX;
+amrex::Box box(std::array<int, 3> lo, std::array<int, 3> hi) {
+  return amrex::Box{amrex::IntVect{lo}, amrex::IntVect{hi}};
+}
+amrex::BoxArray boxes() {
+  amrex::BoxArray ba;
+  for (int i = 0; i < 6; ++i) ba.boxes.push_back(box({i * 8, 0, 0}, {i * 8 + 7, 7, 7}));
+  return ba;
+}
+std::unique_ptr<cGH> make_template(TemplateGeometry &g, int component,
+                                   std::array<int, 3> tile_lo,
+                                   std::array<int, 3> tile_hi) {
+  g.tile_min = tile_lo; g.tile_max = tile_hi;
+  auto gh = std::make_unique<cGH>();
+  gh->cctk_dim = 3; gh->cctk_level = 0; gh->cctk_patch = 0;
+  gh->cctk_npatches = 1; gh->cctk_component = component;
+  gh->cctk_alignment = 64; gh->cctk_alignment_offset = 0;
+  gh->cctk_convlevel = 2; gh->cctk_convfac = 4;
+  gh->cctk_gsh=g.gsh.data(); gh->cctk_lsh=g.lsh.data(); gh->cctk_lbnd=g.lbnd.data();
+  gh->cctk_ubnd=g.ubnd.data(); gh->cctk_tile_min=g.tile_min.data();
+  gh->cctk_tile_max=g.tile_max.data(); gh->cctk_ash=g.ash.data();
+  gh->cctk_to=g.to.data(); gh->cctk_from=g.from.data(); gh->cctk_delta_space=g.delta.data();
+  gh->cctk_origin_space=g.origin.data(); gh->cctk_bbox=g.bbox.data();
+  gh->cctk_levfac=g.levfac.data(); gh->cctk_levoff=g.levoff.data();
+  gh->cctk_levoffdenom=g.levoffdenom.data(); gh->cctk_nghostzones=g.nghostzones.data();
+  gh->identity="live"; gh->extensions=reinterpret_cast<void **>(0x1);
+  gh->GroupData=reinterpret_cast<void *>(0x2); gh->current_scheduled_function=reinterpret_cast<void *>(0x3);
+  return gh;
+}
+GHExt make_ghext(bool alias_copy = false) {
+  GHExt result; result.patchdata.resize(1); result.patchdata[0].leveldata.resize(1);
+  auto &level = result.patchdata[0].leveldata[0]; level.patch=0; level.level=0;
+  level.fab=std::make_unique<amrex::FabArrayBase>();
+  level.fab->tiles = {{2, box({16,0,0},{23,7,7}), box({16,0,0},{19,7,7})},
+                      {2, box({16,0,0},{23,7,7}), box({20,0,0},{23,7,7})},
+                      {5, box({40,0,0},{47,7,7}), box({40,0,0},{47,7,7})}};
+  for (const auto &tile : level.fab->tiles) {
+    auto geometry=std::make_unique<TemplateGeometry>();
+    auto gh=make_template(*geometry, tile.index, tile.tile.lo.v, tile.tile.hi.v);
+    level.geometry.push_back(std::move(geometry)); level.local_cctkGHs.push_back(std::move(gh));
+  }
+  level.groupdata.resize(3);
+  const amrex::DistributionMapping dm{{0,0,0,0,0,0}}; const amrex::IntVect grow{{2,2,2}};
+  for (int gi : {0,2}) {
+    auto group=std::make_unique<GHExt::PatchData::LevelData::GroupData>();
+    group->groupindex=gi; group->firstvarindex=(gi==0?1:5); group->numvars=2;
+    group->patch=0; group->level=0; group->valid={{1,1}};
+    group->mfab.push_back(std::make_unique<amrex::MultiFab>(boxes(),dm,grow,2,true,alias_copy));
+    level.groupdata[static_cast<std::size_t>(gi)]=std::move(group);
+  }
+  return result;
+}
+CertifiedScratchLevelFrame make_certified(const GHExt &ghext) {
+  const auto &level=ghext.patchdata[0].leveldata[0];
+  UncertifiedScratchLevelManifest manifest{current_epoch,0,{}};
+  std::vector<ScratchGFView> views; std::vector<std::vector<ScratchValidity>> validity(2);
+  int ordinal=0;
+  for (int gi : {0,2}) {
+    auto &group=*level.groupdata[static_cast<std::size_t>(gi)];
+    validity[ordinal].assign(2,ScratchValidity{true,true,true});
+    ScratchGFKey key{current_epoch,0,0,gi}; const void *identity=group.mfab[0].get();
+    manifest.entries.push_back({key,identity});
+    views.push_back({key,0,identity,group.mfab[0].get(),&validity[ordinal]}); ++ordinal;
+  }
+  return ScratchLocalLevelBindingTestAccess::certify(
+      0,ScratchLevelFrame::copy_tl0(manifest,views));
+}
+template <typename F> void expect_reject(F &&f) {
+  bool rejected=false; try { f(); } catch (const std::invalid_argument &) { rejected=true; }
+  assert(rejected);
+}
+void test_two_noncontiguous_groups_and_complete_null_table() {
+  auto ghext=make_ghext(); auto certified=make_certified(ghext);
+  auto binding=ScratchLocalLevelBinding::bind(ghext,std::move(certified));
+  assert(binding->local_context_count()==3); const auto &gh=ScratchLocalLevelBindingTestAccess::gh(*binding,0);
+  for (int vi=0;vi<CCTK_NumVars();++vi) for(int tl=0;tl<CCTK_DeclaredTimeLevelsVI(vi);++tl)
+    assert(((vi==1||vi==2||vi==5||vi==6)&&tl==0) ? gh.data[vi][tl]!=nullptr : gh.data[vi][tl]==nullptr);
+}
+void test_local_ordinal_is_not_fab_index_and_repeated_tiles() {
+  auto ghext=make_ghext(); auto certified=make_certified(ghext);
+  auto binding=ScratchLocalLevelBinding::bind(ghext,std::move(certified));
+  assert(ScratchLocalLevelBindingTestAccess::gh(*binding,0).cctk_component==2);
+  assert(ScratchLocalLevelBindingTestAccess::gh(*binding,1).cctk_component==2);
+  assert(ScratchLocalLevelBindingTestAccess::gh(*binding,2).cctk_component==5);
+  assert(ScratchLocalLevelBindingTestAccess::gh(*binding,0).cctk_tile_min[0]!=
+         ScratchLocalLevelBindingTestAccess::gh(*binding,1).cctk_tile_min[0]);
+}
+void test_grid_ptr_mapping_and_scratch_isolation() {
+  auto ghext=make_ghext(); auto certified=make_certified(ghext);
+  auto binding=ScratchLocalLevelBinding::bind(ghext,std::move(certified));
+  auto &level=ghext.patchdata[0].leveldata[0];
+  auto &scratch_frame=ScratchLocalLevelBindingTestAccess::frame(*binding);
+  std::size_t ordinal=0;
+  const auto mfitinfo=amrex::MFItInfo().EnableTiling();
+  for (amrex::MFIter mfi(*level.fab,mfitinfo);mfi.isValid();++mfi,++ordinal) {
+    const auto &gh=ScratchLocalLevelBindingTestAccess::gh(*binding,ordinal);
+    std::size_t frame_index=0;
+    for (int gi : {0,2}) {
+      auto &group=*level.groupdata[static_cast<std::size_t>(gi)];
+      auto scratch_vars=scratch_frame.mutable_multifab(frame_index).array(mfi.index());
+      auto live_vars=group.mfab[0]->array(mfi.index());
+      GridPtrDesc1 grid(level,group,MFPointer(mfi));
+      for(int vi=0;vi<group.numvars;++vi) {
+        auto *expected=grid.ptr(scratch_vars,vi);
+        auto *live=grid.ptr(live_vars,vi);
+        assert(gh.data[group.firstvarindex+vi][0]==expected);
+        assert(expected!=nullptr && expected!=live);
+      }
+      ++frame_index;
+    }
+  }
+  auto *live=level.groupdata[0]->mfab[0]->array(2).ptr(15,-1,-1,0);
+  auto *scratch=static_cast<double *>(
+      ScratchLocalLevelBindingTestAccess::gh(*binding,0).data[1][0]);
+  const double before=*live; *scratch=42.0; assert(*live==before);
+}
+void test_geometry_is_deep_owned_and_aliases_are_null() {
+  auto ghext=make_ghext(); auto certified=make_certified(ghext);
+  auto binding=ScratchLocalLevelBinding::bind(ghext,std::move(certified));
+  const auto &gh=ScratchLocalLevelBindingTestAccess::gh(*binding,0); int copied=gh.cctk_gsh[0];
+  ghext.patchdata[0].leveldata[0].local_cctkGHs.at(0).get()->cctk_gsh[0]=999;
+  assert(gh.cctk_gsh[0]==copied && gh.identity==nullptr && gh.extensions==nullptr &&
+         gh.GroupData==nullptr && gh.current_scheduled_function==nullptr);
+  assert(gh.cctk_iteration==-1 && gh.cctk_timefac==0 && std::isnan(gh.cctk_time) && std::isnan(gh.cctk_delta_time));
+}
+void test_stale_and_incomplete_frames_reject() {
+  { auto g=make_ghext(); auto c=make_certified(g); ++current_epoch;
+    expect_reject([&]{ (void)ScratchLocalLevelBinding::bind(g,std::move(c)); }); --current_epoch; }
+  { auto g=make_ghext(); auto c=make_certified(g);
+    ScratchLocalLevelBindingTestAccess::frame(c).entries_.pop_back();
+    expect_reject([&]{ (void)ScratchLocalLevelBinding::bind(g,std::move(c)); }); }
+}
+void test_duplicate_and_extra_frames_reject() {
+  { auto g=make_ghext(); auto c=make_certified(g); auto &frame=ScratchLocalLevelBindingTestAccess::frame(c);
+    frame.entries_[1].key=frame.entries_[0].key;
+    expect_reject([&]{ (void)ScratchLocalLevelBinding::bind(g,std::move(c)); }); }
+  { auto g=make_ghext(); auto c=make_certified(g); auto &frame=ScratchLocalLevelBindingTestAccess::frame(c);
+    const auto &source=frame.entries_.back();
+    auto owned=std::make_unique<amrex::MultiFab>(source.multifab->deepCopy());
+    frame.entries_.push_back(ScratchLevelFrame::Entry{
+        ScratchGFKey{current_epoch,0,0,3},std::move(owned),source.validity});
+    expect_reject([&]{ (void)ScratchLocalLevelBinding::bind(g,std::move(c)); }); }
+}
+void test_group_ranges_and_time_levels_reject() {
+  { auto g=make_ghext(); auto c=make_certified(g); g.patchdata[0].leveldata[0].groupdata[2]->firstvarindex=2;
+    expect_reject([&]{ (void)ScratchLocalLevelBinding::bind(g,std::move(c)); }); }
+  { auto g=make_ghext(); auto c=make_certified(g); declared_tls[5]=0;
+    expect_reject([&]{ (void)ScratchLocalLevelBinding::bind(g,std::move(c)); }); declared_tls[5]=2; }
+}
+void test_layout_distribution_grow_component_and_validity_reject() {
+  { auto g=make_ghext(); auto c=make_certified(g); ScratchLocalLevelBindingTestAccess::frame(c).mutable_multifab(0).set_grow({{{3,2,2}}});
+    expect_reject([&]{ (void)ScratchLocalLevelBinding::bind(g,std::move(c)); }); }
+  { auto g=make_ghext(); auto c=make_certified(g); g.patchdata[0].leveldata[0].groupdata[0]->valid[0].pop_back();
+    expect_reject([&]{ (void)ScratchLocalLevelBinding::bind(g,std::move(c)); }); }
+  { auto g=make_ghext(); auto c=make_certified(g); ScratchLocalLevelBindingTestAccess::frame(c).mutable_validity(0).pop_back();
+    expect_reject([&]{ (void)ScratchLocalLevelBinding::bind(g,std::move(c)); }); }
+  { auto g=make_ghext(); auto c=make_certified(g); ScratchLocalLevelBindingTestAccess::frame(c).mutable_multifab(0).set_processors({0,0,1,0,0,0});
+    expect_reject([&]{ (void)ScratchLocalLevelBinding::bind(g,std::move(c)); }); }
+  { auto g=make_ghext(); auto c=make_certified(g); ScratchLocalLevelBindingTestAccess::frame(c).mutable_multifab(0).set_box_hi(0,{{{8,7,7}}});
+    expect_reject([&]{ (void)ScratchLocalLevelBinding::bind(g,std::move(c)); }); }
+  { auto g=make_ghext(); auto c=make_certified(g); ScratchLocalLevelBindingTestAccess::frame(c).mutable_multifab(0).set_index_type({{{1,0,0}}});
+    expect_reject([&]{ (void)ScratchLocalLevelBinding::bind(g,std::move(c)); }); }
+  { auto g=make_ghext(); auto c=make_certified(g); ScratchLocalLevelBindingTestAccess::frame(c).mutable_multifab(0).set_components(3);
+    expect_reject([&]{ (void)ScratchLocalLevelBinding::bind(g,std::move(c)); }); }
+  { auto g=make_ghext(); auto c=make_certified(g); ScratchLocalLevelBindingTestAccess::frame(c).mutable_multifab(0).set_defined(false);
+    expect_reject([&]{ (void)ScratchLocalLevelBinding::bind(g,std::move(c)); }); }
+}
+void test_cached_context_mismatch_and_pointer_alias_reject() {
+  { auto g=make_ghext(); auto c=make_certified(g); g.patchdata[0].leveldata[0].local_cctkGHs.at(0).get()->cctk_component=0;
+    expect_reject([&]{ (void)ScratchLocalLevelBinding::bind(g,std::move(c)); }); }
+  { auto g=make_ghext(true); auto c=make_certified(g);
+    expect_reject([&]{ (void)ScratchLocalLevelBinding::bind(g,std::move(c)); }); }
+}
+void test_later_context_failure_destroys_partial_storage_without_publication() {
+  assert(ScratchLocalLevelBindingTestAccess::live_storage_count()==0);
+  auto g=make_ghext(); auto c=make_certified(g);
+  g.patchdata[0].leveldata[0].local_cctkGHs.at(1).get()->cctk_gsh=nullptr;
+  std::unique_ptr<ScratchLocalLevelBinding> published;
+  expect_reject([&]{ published=ScratchLocalLevelBinding::bind(g,std::move(c)); });
+  assert(!published);
+  assert(ScratchLocalLevelBindingTestAccess::live_storage_count()==0);
+}
+} // namespace
+
+int main() {
+  static_assert(!std::is_copy_constructible_v<ScratchLocalLevelBinding>);
+  static_assert(!std::is_move_constructible_v<ScratchLocalLevelBinding>);
+  test_two_noncontiguous_groups_and_complete_null_table();
+  test_local_ordinal_is_not_fab_index_and_repeated_tiles();
+  test_grid_ptr_mapping_and_scratch_isolation();
+  test_geometry_is_deep_owned_and_aliases_are_null();
+  test_stale_and_incomplete_frames_reject();
+  test_duplicate_and_extra_frames_reject();
+  test_group_ranges_and_time_levels_reject();
+  test_layout_distribution_grow_component_and_validity_reject();
+  test_cached_context_mismatch_and_pointer_alias_reject();
+  test_later_context_failure_destroys_partial_storage_without_publication();
+  std::cout << "Phase 8B2 scratch local cGH tests passed\n";
+}

--- a/CarpetX/test/subcycling_scratch_schedule_executor_unit.cxx
+++ b/CarpetX/test/subcycling_scratch_schedule_executor_unit.cxx
@@ -1,0 +1,887 @@
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cassert>
+#include <cmath>
+#include <condition_variable>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <numeric>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+// Keep the production StepContext header but avoid pulling a generated cctk.h
+// into this bounded standalone test.
+#define CARPETX_ARITH_RATIONAL_HXX
+namespace Arith {
+template <typename I> struct rational {
+  I num{0};
+  I den{1};
+  constexpr rational() = default;
+  constexpr rational(I value) : num(value), den(1) {}
+  constexpr rational(I numerator, I denominator)
+      : num(numerator), den(denominator) {
+    if (den < 0) {
+      num = -num;
+      den = -den;
+    }
+    const I divisor = std::gcd(num, den);
+    num /= divisor;
+    den /= divisor;
+  }
+  friend constexpr rational operator-(const rational &a,
+                                      const rational &b) {
+    return rational(a.num * b.den - a.den * b.num, a.den * b.den);
+  }
+  friend constexpr rational operator/(const rational &a, I divisor) {
+    return rational(a.num, a.den * divisor);
+  }
+  friend constexpr bool operator==(const rational &a, const rational &b) {
+    return a.num * b.den == a.den * b.num;
+  }
+  friend constexpr bool operator!=(const rational &a, const rational &b) {
+    return !(a == b);
+  }
+  friend constexpr bool operator<(const rational &a, const rational &b) {
+    return a.num * b.den < a.den * b.num;
+  }
+  friend constexpr bool operator>(const rational &a, const rational &b) {
+    return b < a;
+  }
+  explicit constexpr operator double() const {
+    return static_cast<double>(num) / static_cast<double>(den);
+  }
+};
+} // namespace Arith
+
+// Reuse the already validated Phase 8B2 standalone geometry/MultiFab fixture
+// verbatim. Its main is renamed; this test adds only executor behavior.
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wreturn-type"
+#endif
+#define main phase8b2_imported_main
+#include "subcycling_scratch_local_gh_unit.cxx"
+#undef main
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+#define CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_UNIT
+#define CARPETX_SUBCYCLING_SCRATCH_SCHEDULE_EXECUTOR_STANDALONE
+
+constexpr int CCTK_VARIABLE_REAL = 10;
+constexpr int CCTK_VALID_GHOSTS = 1;
+constexpr int CCTK_VALID_BOUNDARY = 2;
+constexpr int CCTK_VALID_INTERIOR = 4;
+
+namespace {
+
+std::array<std::string, 8> variable_names{
+    "Other::a", "Test::u", "Test::v", "Other::b",
+    "Other::c", "Test::w", "Test::z", "Other::d"};
+bool break_var_roundtrip = false;
+
+} // namespace
+
+int CCTK_VarIndex(const char *name) {
+  if (name == nullptr)
+    return -1;
+  for (std::size_t i = 0; i < variable_names.size(); ++i)
+    if (variable_names[i] == name)
+      return static_cast<int>(i);
+  return -1;
+}
+
+const char *CCTK_FullVarName(int vi) {
+  if (vi < 0 || static_cast<std::size_t>(vi) >= variable_names.size())
+    return nullptr;
+  if (break_var_roundtrip && vi == 1)
+    return "Test::changed";
+  return variable_names[static_cast<std::size_t>(vi)].c_str();
+}
+
+int CCTK_GroupIndexFromVarI(int vi) {
+  if (vi == 1 || vi == 2)
+    return 0;
+  if (vi == 5 || vi == 6)
+    return 2;
+  return -1;
+}
+
+int CCTK_VarTypeI(int vi) {
+  return CCTK_GroupIndexFromVarI(vi) >= 0 ? CCTK_VARIABLE_REAL : -1;
+}
+
+#include "../src/subcycling_schedule_certification.hxx"
+#include "../src/subcycling_scratch_schedule_executor.hxx"
+#include "../src/subcycling_step_context.cxx"
+
+namespace {
+
+using namespace CarpetX;
+
+struct FakeRoutine {
+  CanonicalScheduleRecord record;
+  void *handle{};
+};
+
+struct CallEvent {
+  void *handle{};
+  std::size_t context{};
+  int epoch{};
+  int iteration{};
+  double time{};
+  double base_dt{};
+  int timefac{};
+};
+
+struct MetadataObservation {
+  int iteration{};
+  double time{};
+  double delta_time{};
+  int timefac{};
+  const void *scheduled_function{};
+};
+
+struct CallControl {
+  std::mutex mutex;
+  std::condition_variable worker_cv;
+  std::vector<cGH *> contexts;
+  std::vector<CallEvent> events;
+  std::atomic<int> barrier_count{0};
+  std::atomic<bool> metadata_ok{true};
+  std::atomic<bool> poison{false};
+  std::optional<std::size_t> throw_context;
+  std::optional<std::size_t> nonzero_context;
+  std::optional<int> throw_barrier;
+  int expected_iteration{64};
+  double expected_time{0.25};
+  double expected_base_dt{1.0};
+  int expected_timefac{2};
+  CertifiedScratchStageExecutor *reenter_executor{};
+  const StepContext *reenter_step{};
+  const ScratchStageCoordinates *reenter_coordinates{};
+  std::optional<ScratchScheduleExecutionErrorCode> reentry_code;
+  bool hold_first_worker{};
+  bool first_worker_entered{};
+  bool release_first_worker{};
+  bool record_metadata_snapshots{};
+  std::vector<MetadataObservation> metadata_snapshots;
+  bool hold_after_idle_publish{};
+  bool after_idle_publish_entered{};
+  bool release_after_idle_publish{};
+
+  void reset() {
+    std::lock_guard<std::mutex> lock(mutex);
+    contexts.clear();
+    events.clear();
+    barrier_count.store(0);
+    metadata_ok.store(true);
+    poison.store(false);
+    throw_context.reset();
+    nonzero_context.reset();
+    throw_barrier.reset();
+    reenter_executor = nullptr;
+    reenter_step = nullptr;
+    reenter_coordinates = nullptr;
+    reentry_code.reset();
+    hold_first_worker = false;
+    first_worker_entered = false;
+    release_first_worker = false;
+    record_metadata_snapshots = false;
+    metadata_snapshots.clear();
+    hold_after_idle_publish = false;
+    after_idle_publish_entered = false;
+    release_after_idle_publish = false;
+  }
+};
+
+CallControl calls;
+int post_handle_0 = 10;
+int post_handle_1 = 11;
+int rhs_handle_0 = 20;
+int rhs_handle_1 = 21;
+
+std::size_t context_ordinal(cGH *gh) {
+  const auto found = std::find(calls.contexts.begin(), calls.contexts.end(), gh);
+  if (found == calls.contexts.end())
+    throw std::runtime_error("unknown scratch context");
+  return static_cast<std::size_t>(found - calls.contexts.begin());
+}
+
+int invoke_fake_handle(void *handle, cGH *gh) {
+  const auto ordinal = context_ordinal(gh);
+  const int epoch = calls.barrier_count.load();
+  if (gh->cctk_iteration != calls.expected_iteration ||
+      gh->cctk_time != calls.expected_time ||
+      gh->cctk_delta_time != calls.expected_base_dt ||
+      gh->cctk_timefac != calls.expected_timefac)
+    calls.metadata_ok.store(false);
+  gh->current_scheduled_function = handle;
+  {
+    std::unique_lock<std::mutex> lock(calls.mutex);
+    calls.events.push_back(CallEvent{handle, ordinal, epoch,
+                                     gh->cctk_iteration, gh->cctk_time,
+                                     gh->cctk_delta_time, gh->cctk_timefac});
+    if (calls.hold_first_worker && ordinal == 0 &&
+        handle == &post_handle_0) {
+      calls.first_worker_entered = true;
+      calls.worker_cv.notify_all();
+      calls.worker_cv.wait(lock, [] { return calls.release_first_worker; });
+    }
+  }
+  if (gh->data != nullptr && gh->data[1] != nullptr && gh->data[1][0] != nullptr)
+    *static_cast<double *>(gh->data[1][0]) += 1.0;
+  if (calls.reenter_executor != nullptr && ordinal == 0 &&
+      handle == &post_handle_0) {
+    try {
+      (void)calls.reenter_executor->execute_rhs(
+          *calls.reenter_step, *calls.reenter_coordinates);
+    } catch (const ScratchScheduleExecutionError &error) {
+      calls.reentry_code = error.code();
+      throw;
+    }
+  }
+  if (calls.throw_context == ordinal)
+    throw std::runtime_error("fake worker failure");
+  gh->current_scheduled_function = nullptr;
+  return calls.nonzero_context == ordinal ? 9 : 0;
+}
+
+} // namespace
+
+namespace CarpetX {
+
+struct CertifiedLocalScheduleRegistry::Storage {
+  CanonicalScheduleBundle manifest;
+  ScheduleBuildProvenance provenance;
+  std::array<std::vector<FakeRoutine>, 2> functions;
+};
+
+CertifiedLocalScheduleRegistry::CertifiedLocalScheduleRegistry(
+    std::unique_ptr<Storage> storage)
+    : storage_(std::move(storage)) {}
+CertifiedLocalScheduleRegistry::~CertifiedLocalScheduleRegistry() = default;
+const CanonicalScheduleBundle &
+CertifiedLocalScheduleRegistry::manifest() const noexcept {
+  return storage_->manifest;
+}
+const ScheduleBuildProvenance &
+CertifiedLocalScheduleRegistry::provenance() const noexcept {
+  return storage_->provenance;
+}
+std::size_t CertifiedLocalScheduleRegistry::size(
+    SubcyclingScheduleTarget target) const noexcept {
+  const std::size_t index =
+      target == SubcyclingScheduleTarget::rhs ? 0U : 1U;
+  return storage_->functions[index].size();
+}
+const CanonicalScheduleRecord &CertifiedLocalScheduleRegistry::record_for_executor(
+    SubcyclingScheduleTarget target, std::size_t ordinal) const {
+  const std::size_t index =
+      target == SubcyclingScheduleTarget::rhs ? 0U : 1U;
+  return storage_->functions.at(index).at(ordinal).record;
+}
+int CertifiedLocalScheduleRegistry::invoke_for_executor(
+    SubcyclingScheduleTarget target, std::size_t ordinal, cGH *scratch_gh) const {
+  const std::size_t index =
+      target == SubcyclingScheduleTarget::rhs ? 0U : 1U;
+  const auto &routine = storage_->functions.at(index).at(ordinal);
+  return invoke_fake_handle(routine.handle, scratch_gh);
+}
+
+class CertifiedLocalScheduleRegistryExecutorTestAccess {
+public:
+  static std::unique_ptr<CertifiedLocalScheduleRegistry> make(
+      std::vector<FakeRoutine> post_step, std::vector<FakeRoutine> rhs) {
+    auto storage = std::make_unique<CertifiedLocalScheduleRegistry::Storage>();
+    storage->functions[0] = std::move(rhs);
+    storage->functions[1] = std::move(post_step);
+    return std::unique_ptr<CertifiedLocalScheduleRegistry>(
+        new CertifiedLocalScheduleRegistry(std::move(storage)));
+  }
+};
+
+bool subcycling_scratch_executor_poison_enabled_for_test() noexcept {
+  return calls.poison.load();
+}
+
+void subcycling_scratch_executor_synchronize_for_test() {
+  const int ordinal = calls.barrier_count.fetch_add(1);
+  if (calls.throw_barrier == ordinal)
+    throw std::runtime_error("fake device barrier failure");
+}
+
+void subcycling_scratch_executor_metadata_snapshotted_for_test() {
+  std::lock_guard<std::mutex> lock(calls.mutex);
+  if (!calls.record_metadata_snapshots || calls.contexts.empty())
+    return;
+  const cGH *const gh = calls.contexts.front();
+  calls.metadata_snapshots.push_back(MetadataObservation{
+      gh->cctk_iteration, gh->cctk_time, gh->cctk_delta_time,
+      gh->cctk_timefac, gh->current_scheduled_function});
+}
+
+void subcycling_scratch_executor_after_idle_publish_for_test() {
+  std::unique_lock<std::mutex> lock(calls.mutex);
+  if (!calls.hold_after_idle_publish || calls.after_idle_publish_entered)
+    return;
+  calls.after_idle_publish_entered = true;
+  calls.worker_cv.notify_all();
+  calls.worker_cv.wait(lock,
+                       [] { return calls.release_after_idle_publish; });
+}
+
+} // namespace CarpetX
+
+#include "../src/subcycling_scratch_schedule_executor.cxx"
+
+namespace {
+
+using namespace CarpetX;
+
+CanonicalAccess access(std::string variable, int read, int write,
+                       int invalidate) {
+  return CanonicalAccess{std::move(variable), 0, read, write, invalidate};
+}
+
+FakeRoutine routine(std::uint64_t ordinal, const char *name, void *handle,
+                    std::vector<CanonicalAccess> accesses) {
+  CanonicalScheduleRecord record;
+  record.traversal_ordinal = ordinal;
+  record.item_ordinal = ordinal + 100;
+  record.item.routine = name;
+  record.item.accesses = std::move(accesses);
+  return FakeRoutine{std::move(record), handle};
+}
+
+std::unique_ptr<CertifiedLocalScheduleRegistry>
+make_registry(const bool invalidate_next_read = false) {
+  std::vector<FakeRoutine> post;
+  post.push_back(routine(
+      0, "Post0", &post_handle_0,
+      {access("Test::u", CCTK_VALID_INTERIOR, 0, 0),
+       access("Test::v", 0, CCTK_VALID_INTERIOR,
+              invalidate_next_read ? CCTK_VALID_INTERIOR
+                                   : CCTK_VALID_GHOSTS)}));
+  post.push_back(routine(
+      1, "Post1", &post_handle_1,
+      {access("Test::v", CCTK_VALID_INTERIOR, 0, 0),
+       access("Test::u", 0, CCTK_VALID_GHOSTS, CCTK_VALID_BOUNDARY)}));
+  std::vector<FakeRoutine> rhs;
+  rhs.push_back(routine(
+      0, "Rhs0", &rhs_handle_0,
+      {access("Test::u", CCTK_VALID_GHOSTS, 0, 0),
+       access("Test::w", 0, CCTK_VALID_INTERIOR, CCTK_VALID_BOUNDARY)}));
+  rhs.push_back(routine(
+      1, "Rhs1", &rhs_handle_1,
+      {access("Test::w", CCTK_VALID_INTERIOR, 0, 0),
+       access("Test::z", 0,
+              CCTK_VALID_INTERIOR | CCTK_VALID_GHOSTS,
+              CCTK_VALID_GHOSTS)}));
+  return CertifiedLocalScheduleRegistryExecutorTestAccess::make(
+      std::move(post), std::move(rhs));
+}
+
+class NoopPreparer final : public StagePreparer {
+public:
+  void prepare_stage(const StepContext &, const StagePoint &) override {}
+};
+
+struct Fixture {
+  GHExt ghext;
+  std::unique_ptr<ScratchLocalLevelBinding> binding;
+  std::unique_ptr<CertifiedLocalScheduleRegistry> registry;
+  std::unique_ptr<CertifiedScratchStageExecutor> executor;
+  StepContext step{0, step_clock_t(0), step_clock_t(1, 2), 0.0, 0.5,
+                   SubcyclingODEMethod::rk4};
+  ScratchStageCoordinates coordinates{64, 0.25, step_clock_t(1), 1.0, 2};
+  NoopPreparer preparer;
+
+  explicit Fixture(bool zero_contexts = false,
+                   bool invalidate_next_read = false)
+      : ghext(make_ghext()) {
+    if (zero_contexts) {
+      auto &level = ghext.patchdata[0].leveldata[0];
+      level.fab->tiles.clear();
+      level.local_cctkGHs.clear();
+      level.geometry.clear();
+    }
+    auto certified = make_certified(ghext);
+    binding = ScratchLocalLevelBinding::bind(ghext, std::move(certified));
+    registry = make_registry(invalidate_next_read);
+    calls.reset();
+    for (std::size_t i = 0; i < binding->local_context_count(); ++i)
+      calls.contexts.push_back(const_cast<cGH *>(
+          &ScratchLocalLevelBindingTestAccess::gh(*binding, i)));
+    executor = CertifiedScratchStageExecutor::create(*registry, *binding);
+  }
+
+  ScratchScheduleExecutionReceipt post() {
+    ScopedStepContext scope(step, preparer);
+    return executor->execute_post_step(step, coordinates);
+  }
+  ScratchScheduleExecutionReceipt rhs() {
+    ScopedStepContext scope(step, preparer);
+    return executor->execute_rhs(step, coordinates);
+  }
+};
+
+template <typename F>
+ScratchScheduleExecutionErrorCode expect_execution_error(F &&call) {
+  try {
+    call();
+  } catch (const ScratchScheduleExecutionError &error) {
+    return error.code();
+  }
+  assert(false && "expected ScratchScheduleExecutionError");
+  return ScratchScheduleExecutionErrorCode::internal_failure;
+}
+
+std::vector<void *> handles() {
+  std::lock_guard<std::mutex> lock(calls.mutex);
+  std::vector<void *> result;
+  for (const auto &event : calls.events)
+    result.push_back(event.handle);
+  return result;
+}
+
+std::vector<int> epochs() {
+  std::lock_guard<std::mutex> lock(calls.mutex);
+  std::vector<int> result;
+  for (const auto &event : calls.events)
+    result.push_back(event.epoch);
+  return result;
+}
+
+void test_factory_resolves_both_phases_atomically() {
+  Fixture fixture;
+  assert(fixture.executor != nullptr && !fixture.executor->faulted());
+  assert(fixture.registry->size(SubcyclingScheduleTarget::post_step) == 2);
+  assert(fixture.registry->size(SubcyclingScheduleTarget::rhs) == 2);
+}
+
+template <typename T, typename = void> struct has_public_context : std::false_type {};
+template <typename T>
+struct has_public_context<
+    T, std::void_t<decltype(std::declval<T &>().context_for_executor(0))>>
+    : std::true_type {};
+
+void test_handles_and_raw_cgh_never_escape_public_api() {
+  static_assert(!has_public_context<ScratchLocalLevelBinding>::value);
+  static_assert(!std::is_copy_constructible_v<CertifiedScratchStageExecutor>);
+  static_assert(!std::is_move_constructible_v<CertifiedScratchStageExecutor>);
+  Fixture fixture;
+  (void)fixture.post();
+  const auto observed = handles();
+  assert(std::count(observed.begin(), observed.end(), &post_handle_0) == 3);
+  assert(std::count(observed.begin(), observed.end(), &post_handle_1) == 3);
+  assert(std::count(observed.begin(), observed.end(), &rhs_handle_0) == 0);
+}
+
+void test_stage_coordinates_install_on_every_scratch_context() {
+  Fixture fixture;
+  const auto receipt = fixture.post();
+  assert(receipt.local_call_count == 6 && calls.metadata_ok.load());
+}
+
+void test_level_dt_identity_and_step_context_are_enforced() {
+  {
+    Fixture fixture;
+    fixture.coordinates.base_delta_clock = step_clock_t(3, 2);
+    ScopedStepContext scope(fixture.step, fixture.preparer);
+    assert(expect_execution_error([&] {
+             (void)fixture.executor->execute_post_step(fixture.step,
+                                                       fixture.coordinates);
+           }) == ScratchScheduleExecutionErrorCode::invalid_coordinates);
+  }
+  {
+    Fixture fixture;
+    StepContext other = fixture.step;
+    ScopedStepContext scope(other, fixture.preparer);
+    assert(expect_execution_error([&] {
+             (void)fixture.executor->execute_post_step(fixture.step,
+                                                       fixture.coordinates);
+           }) == ScratchScheduleExecutionErrorCode::invalid_step_context);
+  }
+}
+
+void test_poison_undefined_values_is_rejected_on_every_execute() {
+  Fixture fixture;
+  (void)fixture.post();
+  calls.poison.store(true);
+  ScopedStepContext scope(fixture.step, fixture.preparer);
+  assert(expect_execution_error([&] {
+           (void)fixture.executor->execute_rhs(fixture.step,
+                                               fixture.coordinates);
+         }) == ScratchScheduleExecutionErrorCode::unsupported_configuration);
+}
+
+void test_stage_metadata_restores_exactly_on_every_exit() {
+  Fixture fixture;
+  std::vector<std::array<std::uintptr_t, 5>> before;
+  for (cGH *gh : calls.contexts) {
+    gh->cctk_iteration = 777;
+    gh->cctk_time = 8.5;
+    gh->cctk_delta_time = 9.5;
+    gh->cctk_timefac = 13;
+    gh->current_scheduled_function = reinterpret_cast<void *>(0x1234);
+    before.push_back({static_cast<std::uintptr_t>(gh->cctk_iteration),
+                      static_cast<std::uintptr_t>(gh->cctk_time * 2),
+                      static_cast<std::uintptr_t>(gh->cctk_delta_time * 2),
+                      static_cast<std::uintptr_t>(gh->cctk_timefac),
+                      reinterpret_cast<std::uintptr_t>(
+                          gh->current_scheduled_function)});
+  }
+  (void)fixture.post();
+  for (std::size_t i = 0; i < calls.contexts.size(); ++i) {
+    const cGH *gh = calls.contexts[i];
+    assert(gh->cctk_iteration == static_cast<int>(before[i][0]));
+    assert(gh->cctk_time == static_cast<double>(before[i][1]) / 2.0);
+    assert(gh->cctk_delta_time == static_cast<double>(before[i][2]) / 2.0);
+    assert(gh->cctk_timefac == static_cast<int>(before[i][3]));
+    assert(reinterpret_cast<std::uintptr_t>(gh->current_scheduled_function) ==
+           before[i][4]);
+  }
+}
+
+void test_binding_lease_rejects_second_executor_and_reentry() {
+  Fixture fixture;
+  assert(expect_execution_error([&] {
+           (void)CertifiedScratchStageExecutor::create(*fixture.registry,
+                                                       *fixture.binding);
+         }) == ScratchScheduleExecutionErrorCode::binding_busy);
+  calls.reenter_executor = fixture.executor.get();
+  calls.reenter_step = &fixture.step;
+  calls.reenter_coordinates = &fixture.coordinates;
+  ScopedStepContext scope(fixture.step, fixture.preparer);
+  assert(expect_execution_error([&] {
+           (void)fixture.executor->execute_post_step(fixture.step,
+                                                     fixture.coordinates);
+         }) == ScratchScheduleExecutionErrorCode::call_failed);
+  assert(calls.reentry_code ==
+         ScratchScheduleExecutionErrorCode::reentrant_execution);
+}
+
+void test_two_thread_reentry_faults_active_call_and_binding() {
+  Fixture fixture;
+  {
+    std::lock_guard<std::mutex> lock(calls.mutex);
+    calls.hold_first_worker = true;
+  }
+
+  bool first_returned_receipt = false;
+  std::optional<ScratchScheduleExecutionErrorCode> first_error;
+  std::optional<ScratchScheduleExecutionErrorCode> second_error;
+  std::thread first([&] {
+    ScopedStepContext scope(fixture.step, fixture.preparer);
+    try {
+      (void)fixture.executor->execute_post_step(fixture.step,
+                                                fixture.coordinates);
+      first_returned_receipt = true;
+    } catch (const ScratchScheduleExecutionError &error) {
+      first_error = error.code();
+    }
+  });
+
+  {
+    std::unique_lock<std::mutex> lock(calls.mutex);
+    calls.worker_cv.wait(lock, [] { return calls.first_worker_entered; });
+  }
+  std::thread second([&] {
+    ScopedStepContext scope(fixture.step, fixture.preparer);
+    try {
+      (void)fixture.executor->execute_rhs(fixture.step, fixture.coordinates);
+    } catch (const ScratchScheduleExecutionError &error) {
+      second_error = error.code();
+    }
+  });
+  second.join();
+  {
+    std::lock_guard<std::mutex> lock(calls.mutex);
+    calls.release_first_worker = true;
+  }
+  calls.worker_cv.notify_all();
+  first.join();
+
+  assert(second_error == ScratchScheduleExecutionErrorCode::reentrant_execution);
+  assert(first_error == ScratchScheduleExecutionErrorCode::reentrant_execution);
+  assert(!first_returned_receipt && fixture.executor->faulted());
+  fixture.executor.reset();
+  assert(expect_execution_error([&] {
+           (void)CertifiedScratchStageExecutor::create(*fixture.registry,
+                                                       *fixture.binding);
+         }) == ScratchScheduleExecutionErrorCode::binding_faulted);
+}
+
+void test_idle_is_published_only_after_metadata_restore() {
+  Fixture fixture;
+  for (cGH *gh : calls.contexts) {
+    gh->cctk_iteration = 777;
+    gh->cctk_time = 8.5;
+    gh->cctk_delta_time = 9.5;
+    gh->cctk_timefac = 13;
+    gh->current_scheduled_function = reinterpret_cast<void *>(0x1234);
+  }
+  {
+    std::lock_guard<std::mutex> lock(calls.mutex);
+    calls.record_metadata_snapshots = true;
+    calls.hold_after_idle_publish = true;
+  }
+
+  bool first_receipt = false;
+  bool second_receipt = false;
+  std::thread first([&] {
+    ScopedStepContext scope(fixture.step, fixture.preparer);
+    (void)fixture.executor->execute_post_step(fixture.step,
+                                              fixture.coordinates);
+    first_receipt = true;
+  });
+  {
+    std::unique_lock<std::mutex> lock(calls.mutex);
+    calls.worker_cv.wait(lock,
+                         [] { return calls.after_idle_publish_entered; });
+  }
+  std::thread second([&] {
+    ScopedStepContext scope(fixture.step, fixture.preparer);
+    (void)fixture.executor->execute_rhs(fixture.step, fixture.coordinates);
+    second_receipt = true;
+  });
+  second.join();
+
+  std::vector<MetadataObservation> observations;
+  {
+    std::lock_guard<std::mutex> lock(calls.mutex);
+    observations = calls.metadata_snapshots;
+    calls.release_after_idle_publish = true;
+  }
+  calls.worker_cv.notify_all();
+  first.join();
+
+  assert(first_receipt && second_receipt && observations.size() == 2);
+  for (const auto &observation : observations) {
+    assert(observation.iteration == 777);
+    assert(observation.time == 8.5);
+    assert(observation.delta_time == 9.5);
+    assert(observation.timefac == 13);
+    assert(observation.scheduled_function ==
+           reinterpret_cast<void *>(0x1234));
+  }
+}
+
+void test_poststep_and_rhs_are_separate_certified_phases() {
+  Fixture fixture;
+  const auto receipt = fixture.rhs();
+  assert(receipt.phase == ScratchSchedulePhase::rhs &&
+         receipt.routine_count == 2);
+  const auto observed = handles();
+  assert(std::count(observed.begin(), observed.end(), &rhs_handle_0) == 3);
+  assert(std::count(observed.begin(), observed.end(), &rhs_handle_1) == 3);
+  assert(std::count(observed.begin(), observed.end(), &post_handle_0) == 0);
+}
+
+void test_routine_major_calls_have_one_barrier_per_routine() {
+  Fixture fixture;
+  (void)fixture.post();
+  assert(calls.barrier_count.load() == 2);
+  const auto observed_epochs = epochs();
+  assert(std::count(observed_epochs.begin(), observed_epochs.end(), 0) == 3);
+  assert(std::count(observed_epochs.begin(), observed_epochs.end(), 1) == 3);
+}
+
+void test_reads_gate_calls_and_writes_then_invalidates_update_validity() {
+  {
+    Fixture fixture;
+    auto &frame = ScratchLocalLevelBindingTestAccess::frame(*fixture.binding);
+    frame.mutable_validity(0)[0].interior = false;
+    ScopedStepContext scope(fixture.step, fixture.preparer);
+    assert(expect_execution_error([&] {
+             (void)fixture.executor->execute_post_step(fixture.step,
+                                                       fixture.coordinates);
+           }) == ScratchScheduleExecutionErrorCode::invalid_read);
+    assert(handles().empty() && calls.barrier_count.load() == 0);
+  }
+  {
+    Fixture fixture;
+    auto &frame = ScratchLocalLevelBindingTestAccess::frame(*fixture.binding);
+    (void)fixture.rhs();
+    assert(frame.validity(1)[0].interior);
+    assert(!frame.validity(1)[0].outer);
+    assert(frame.validity(1)[1].interior);
+    assert(!frame.validity(1)[1].ghosts);
+  }
+}
+
+void test_later_invalid_read_faults_binding_after_first_routine() {
+  Fixture fixture(false, true);
+  ScopedStepContext scope(fixture.step, fixture.preparer);
+  assert(expect_execution_error([&] {
+           (void)fixture.executor->execute_post_step(fixture.step,
+                                                     fixture.coordinates);
+         }) == ScratchScheduleExecutionErrorCode::invalid_read);
+  assert(calls.barrier_count.load() == 1);
+  const auto observed = handles();
+  assert(std::count(observed.begin(), observed.end(), &post_handle_0) == 3);
+  fixture.executor.reset();
+  assert(expect_execution_error([&] {
+           (void)CertifiedScratchStageExecutor::create(*fixture.registry,
+                                                       *fixture.binding);
+         }) == ScratchScheduleExecutionErrorCode::binding_faulted);
+}
+
+void test_missing_or_changed_variable_mapping_rejects_factory() {
+  auto ghext = make_ghext();
+  auto certified = make_certified(ghext);
+  auto binding = ScratchLocalLevelBinding::bind(ghext, std::move(certified));
+  auto registry = make_registry();
+  break_var_roundtrip = true;
+  assert(expect_execution_error([&] {
+           (void)CertifiedScratchStageExecutor::create(*registry, *binding);
+         }) == ScratchScheduleExecutionErrorCode::unresolved_access);
+  break_var_roundtrip = false;
+  auto executor = CertifiedScratchStageExecutor::create(*registry, *binding);
+  assert(executor != nullptr);
+}
+
+void test_inactive_wrong_level_stale_epoch_and_invalid_coordinates_fail_before_calls() {
+  {
+    Fixture fixture;
+    assert(expect_execution_error([&] {
+             (void)fixture.executor->execute_rhs(fixture.step,
+                                                 fixture.coordinates);
+           }) == ScratchScheduleExecutionErrorCode::invalid_step_context);
+    assert(handles().empty());
+  }
+  {
+    Fixture fixture;
+    StepContext wrong = fixture.step;
+    wrong.level = 1;
+    ScopedStepContext scope(wrong, fixture.preparer);
+    assert(expect_execution_error([&] {
+             (void)fixture.executor->execute_rhs(wrong, fixture.coordinates);
+           }) == ScratchScheduleExecutionErrorCode::invalid_step_context);
+    assert(handles().empty());
+  }
+  {
+    Fixture fixture;
+    ++current_epoch;
+    ScopedStepContext scope(fixture.step, fixture.preparer);
+    assert(expect_execution_error([&] {
+             (void)fixture.executor->execute_rhs(fixture.step,
+                                                 fixture.coordinates);
+           }) == ScratchScheduleExecutionErrorCode::stale_binding);
+    --current_epoch;
+    assert(handles().empty());
+  }
+  {
+    Fixture fixture;
+    fixture.coordinates.stage_time =
+        std::numeric_limits<double>::quiet_NaN();
+    ScopedStepContext scope(fixture.step, fixture.preparer);
+    assert(expect_execution_error([&] {
+             (void)fixture.executor->execute_rhs(fixture.step,
+                                                 fixture.coordinates);
+           }) == ScratchScheduleExecutionErrorCode::invalid_coordinates);
+    assert(handles().empty());
+  }
+}
+
+void test_nonzero_call_result_drains_barrier_and_faults_executor() {
+  Fixture fixture;
+  calls.nonzero_context = 1;
+  ScopedStepContext scope(fixture.step, fixture.preparer);
+  assert(expect_execution_error([&] {
+           (void)fixture.executor->execute_post_step(fixture.step,
+                                                     fixture.coordinates);
+         }) == ScratchScheduleExecutionErrorCode::call_failed);
+  assert(calls.barrier_count.load() == 1 && fixture.executor->faulted());
+}
+
+void test_worker_or_barrier_failure_restores_metadata_and_faults_binding() {
+  Fixture fixture;
+  calls.throw_context = 2;
+  ScopedStepContext scope(fixture.step, fixture.preparer);
+  assert(expect_execution_error([&] {
+           (void)fixture.executor->execute_post_step(fixture.step,
+                                                     fixture.coordinates);
+         }) == ScratchScheduleExecutionErrorCode::call_failed);
+  assert(calls.barrier_count.load() == 1);
+  fixture.executor.reset();
+  assert(expect_execution_error([&] {
+           (void)CertifiedScratchStageExecutor::create(*fixture.registry,
+                                                       *fixture.binding);
+         }) == ScratchScheduleExecutionErrorCode::binding_faulted);
+}
+
+void test_faulted_executor_cannot_be_reused() {
+  Fixture fixture;
+  calls.throw_barrier = 0;
+  {
+    ScopedStepContext scope(fixture.step, fixture.preparer);
+    assert(expect_execution_error([&] {
+             (void)fixture.executor->execute_rhs(fixture.step,
+                                                 fixture.coordinates);
+           }) == ScratchScheduleExecutionErrorCode::call_failed);
+  }
+  {
+    ScopedStepContext scope(fixture.step, fixture.preparer);
+    assert(expect_execution_error([&] {
+             (void)fixture.executor->execute_rhs(fixture.step,
+                                                 fixture.coordinates);
+           }) == ScratchScheduleExecutionErrorCode::already_faulted);
+  }
+}
+
+void test_zero_local_context_rank_is_valid() {
+  Fixture fixture(true);
+  const auto receipt = fixture.post();
+  assert(receipt.routine_count == 2 && receipt.local_call_count == 0);
+  assert(calls.barrier_count.load() == 2 && handles().empty());
+}
+
+void test_scratch_calls_do_not_mutate_live_tl0_or_live_validity() {
+  Fixture fixture;
+  auto &group = *fixture.ghext.patchdata[0].leveldata[0].groupdata[0];
+  double *live = group.mfab[0]->array(2).ptr(15, -1, -1, 0);
+  const double before = *live;
+  const auto live_validity = group.valid[0];
+  (void)fixture.post();
+  assert(*live == before && group.valid[0] == live_validity);
+}
+
+} // namespace
+
+int main() {
+  test_factory_resolves_both_phases_atomically();
+  test_handles_and_raw_cgh_never_escape_public_api();
+  test_stage_coordinates_install_on_every_scratch_context();
+  test_level_dt_identity_and_step_context_are_enforced();
+  test_poison_undefined_values_is_rejected_on_every_execute();
+  test_stage_metadata_restores_exactly_on_every_exit();
+  test_binding_lease_rejects_second_executor_and_reentry();
+  test_two_thread_reentry_faults_active_call_and_binding();
+  test_idle_is_published_only_after_metadata_restore();
+  test_poststep_and_rhs_are_separate_certified_phases();
+  test_routine_major_calls_have_one_barrier_per_routine();
+  test_reads_gate_calls_and_writes_then_invalidates_update_validity();
+  test_later_invalid_read_faults_binding_after_first_routine();
+  test_missing_or_changed_variable_mapping_rejects_factory();
+  test_inactive_wrong_level_stale_epoch_and_invalid_coordinates_fail_before_calls();
+  test_nonzero_call_result_drains_barrier_and_faults_executor();
+  test_worker_or_barrier_failure_restores_metadata_and_faults_binding();
+  test_faulted_executor_cannot_be_reused();
+  test_zero_local_context_rank_is_valid();
+  test_scratch_calls_do_not_mutate_live_tl0_or_live_validity();
+  std::cout << "Phase 8B3C certified scratch executor tests passed\n";
+}

--- a/CarpetX/test/subcycling_scratch_state_transaction_unit.cxx
+++ b/CarpetX/test/subcycling_scratch_state_transaction_unit.cxx
@@ -1,0 +1,1410 @@
+#include "subcycling_dense_output.hxx"
+#include "subcycling_dense_mfab_state.hxx"
+#include "subcycling_dense_stencil.hxx"
+#include "subcycling_scratch_state_transaction.hxx"
+#include "subcycling_scratch_state_transaction_factory.hxx"
+#include "transaction_level_step_session.hxx"
+
+#include <AMReX_MultiFab.H>
+
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace CarpetX;
+
+static_assert(!std::is_copy_constructible_v<ScratchStateToken>);
+static_assert(!std::is_copy_assignable_v<ScratchStateToken>);
+static_assert(std::is_nothrow_move_constructible_v<ScratchStateToken>);
+static_assert(std::is_nothrow_move_assignable_v<ScratchStateToken>);
+static_assert(!std::is_copy_constructible_v<ScratchStateTransaction>);
+
+template <typename Exception = std::exception, typename Function>
+void expect_throw(Function &&function) {
+  bool threw = false;
+  try {
+    function();
+  } catch (const Exception &) {
+    threw = true;
+  }
+  assert(threw);
+}
+
+struct Source {
+  int storage_token{0};
+  ScratchGFKey key{};
+  std::unique_ptr<amrex::MultiFab> multifab;
+  std::vector<ScratchValidity> validity;
+  bool grid_function_real{true};
+};
+
+Source make_source(const int group, const double base,
+                   const int box_identity = 17,
+                   const int distribution_identity = 19) {
+  static amrex::Arena arena(23);
+  static amrex::TestFabFactory factory(29);
+  Source source;
+  source.storage_token = group + 100;
+  source.key = ScratchGFKey{7, 0, 0, group};
+  source.multifab = std::make_unique<amrex::MultiFab>(
+      amrex::BoxArray(box_identity),
+      amrex::DistributionMapping(distribution_identity), 2,
+      amrex::IntVect(1, 2, 1), &arena, factory);
+  source.validity = {{true, false, true}, {false, true, false}};
+  for (std::size_t region = 0; region < 3; ++region)
+    for (int component = 0; component < 2; ++component)
+      for (std::size_t cell = 0;
+           cell < amrex::MultiFab::test_cells_per_region(); ++cell)
+        source.multifab->test_set(
+            static_cast<amrex::TestRegion>(region), component, cell,
+            base + 100.0 * static_cast<double>(region) +
+                10.0 * static_cast<double>(component) +
+                static_cast<double>(cell));
+  return source;
+}
+
+struct Fixture {
+  int requested_level{0};
+  int hierarchy_level_count{1};
+  int time_refinement_factor{1};
+  std::int64_t observed_epoch{7};
+  int level_identity{501};
+  Source evolved{make_source(10, 10.0)};
+  Source rhs{make_source(11, 2.0)};
+  Source dependent{make_source(12, 50.0)};
+  std::vector<Source *> entries{&evolved, &rhs, &dependent};
+
+  explicit Fixture(const int level = 0, const int level_count = 1)
+      : requested_level(level), hierarchy_level_count(level_count),
+        time_refinement_factor(level == 0 ? 1 : 2) {
+    for (auto *const source : entries)
+      source->key.level = requested_level;
+  }
+
+  ScratchLevelFrame copy_live_frame() {
+    UncertifiedScratchLevelManifest manifest{7, requested_level, {}};
+    std::vector<ScratchGFView> views;
+    for (const auto *source : entries) {
+      manifest.entries.push_back(
+          {source->key, &source->storage_token});
+      views.push_back({source->key, 0, &source->storage_token,
+                       source->multifab.get(), &source->validity});
+    }
+    return ScratchLevelFrame::copy_tl0(manifest, views);
+  }
+
+  ScratchStateTransactionFactoryMetadata metadata() {
+    ScratchStateTransactionFactoryMetadata result{
+        7,
+        1,
+        hierarchy_level_count,
+        41,
+        step_clock_t(1, 2),
+        0.5,
+        time_refinement_factor,
+        false,
+        {{10, 11}},
+        {11, 12},
+        [this] { return observed_epoch; },
+        {}};
+    for (auto *const source : entries) {
+      result.live_entry_readers.push_back([this, source] {
+        return ScratchLiveEntrySnapshot{
+            source->key, &level_identity, source, &source->multifab,
+            &source->storage_token, &source->validity,
+            source->multifab.get(), source->validity,
+            source->grid_function_real,
+            [source](const amrex::MultiFab &state,
+                     const std::vector<ScratchValidity> &validity) {
+              amrex::MultiFab::Copy(*source->multifab, state, 0, 0,
+                                    state.nComp(), state.nGrowVect());
+              source->validity = validity;
+            }};
+      });
+    }
+    return result;
+  }
+};
+
+ScratchScheduleExecutionReceipt successful_schedule(
+    const ScratchSchedulePhase phase, const StepContext &,
+    const ScratchStageCoordinates &) {
+  return {phase, 1, 1};
+}
+
+std::unique_ptr<ScratchStateTransaction>
+make_transaction(Fixture &fixture,
+                 ScratchStateTransactionFactory::TestScheduleExecutor executor =
+                     successful_schedule) {
+  return ScratchStateTransactionFactory::create_for_test(
+      fixture.copy_live_frame(), fixture.metadata(), std::move(executor));
+}
+
+void assert_source_equal(const amrex::MultiFab &actual,
+                         const Source &expected) {
+  for (std::size_t region = 0; region < 3; ++region)
+    for (int component = 0; component < 2; ++component)
+      for (std::size_t cell = 0;
+           cell < amrex::MultiFab::test_cells_per_region(); ++cell)
+        assert(actual.test_value(static_cast<amrex::TestRegion>(region),
+                                 component, cell) ==
+               expected.multifab->test_value(
+                   static_cast<amrex::TestRegion>(region), component, cell));
+}
+
+void fill_all(amrex::MultiFab &multifab, const double value) {
+  for (std::size_t region = 0; region < 3; ++region)
+    for (int component = 0; component < multifab.nComp(); ++component)
+      for (std::size_t cell = 0;
+           cell < amrex::MultiFab::test_cells_per_region(); ++cell)
+        multifab.test_set(static_cast<amrex::TestRegion>(region), component,
+                          cell, value);
+}
+
+struct ExactSourceSnapshot {
+  std::vector<std::uint64_t> value_bits;
+  std::vector<ScratchValidity> validity;
+};
+
+std::uint64_t bits_of(const double value) {
+  std::uint64_t bits = 0;
+  static_assert(sizeof(bits) == sizeof(value));
+  std::memcpy(&bits, &value, sizeof(bits));
+  return bits;
+}
+
+ExactSourceSnapshot exact_snapshot(const Source &source) {
+  ExactSourceSnapshot snapshot;
+  for (std::size_t region = 0; region < 3; ++region)
+    for (int component = 0; component < source.multifab->nComp(); ++component)
+      for (std::size_t cell = 0;
+           cell < amrex::MultiFab::test_cells_per_region(); ++cell)
+        snapshot.value_bits.push_back(bits_of(source.multifab->test_value(
+            static_cast<amrex::TestRegion>(region), component, cell)));
+  snapshot.validity = source.validity;
+  return snapshot;
+}
+
+void assert_exact_snapshot(const Source &source,
+                           const ExactSourceSnapshot &expected) {
+  std::size_t value = 0;
+  for (std::size_t region = 0; region < 3; ++region)
+    for (int component = 0; component < source.multifab->nComp(); ++component)
+      for (std::size_t cell = 0;
+           cell < amrex::MultiFab::test_cells_per_region(); ++cell)
+        assert(bits_of(source.multifab->test_value(
+                   static_cast<amrex::TestRegion>(region), component,
+                   cell)) == expected.value_bits.at(value++));
+  assert(value == expected.value_bits.size());
+  assert(source.validity.size() == expected.validity.size());
+  for (std::size_t component = 0; component < source.validity.size();
+       ++component) {
+    assert(source.validity[component].interior ==
+           expected.validity[component].interior);
+    assert(source.validity[component].outer ==
+           expected.validity[component].outer);
+    assert(source.validity[component].ghosts ==
+           expected.validity[component].ghosts);
+  }
+}
+
+void overwrite_live(Fixture &fixture, const double value) {
+  for (std::size_t entry = 0; entry < fixture.entries.size(); ++entry) {
+    auto &source = *fixture.entries[entry];
+    fill_all(*source.multifab, value + static_cast<double>(entry));
+    for (auto &validity : source.validity)
+      validity = {false, true, false};
+  }
+}
+
+void test_mid_primary_failure_rolls_live_tl0_back_exactly_without_schedule() {
+  Fixture fixture;
+  int schedule_calls = 0;
+  auto transaction = make_transaction(
+      fixture,
+      [&schedule_calls](const ScratchSchedulePhase phase,
+                        const StepContext &,
+                        const ScratchStageCoordinates &) {
+        ++schedule_calls;
+        return ScratchScheduleExecutionReceipt{phase, 1, 1};
+      });
+  auto rollback_state = transaction->capture_live_evolved();
+  std::vector<ExactSourceSnapshot> expected;
+  expected.reserve(fixture.entries.size());
+  for (const auto *const source : fixture.entries)
+    expected.push_back(exact_snapshot(*source));
+
+  try {
+    overwrite_live(fixture, -9000.0);
+    throw std::runtime_error("injected primary-stage failure");
+  } catch (const std::runtime_error &) {
+    transaction->rollback_live_evolved(rollback_state);
+  }
+
+  for (std::size_t entry = 0; entry < fixture.entries.size(); ++entry)
+    assert_exact_snapshot(*fixture.entries[entry], expected[entry]);
+  assert(schedule_calls == 0);
+  assert(transaction->discarded());
+  assert(!transaction->faulted());
+}
+
+void test_successful_primary_endpoint_is_not_rolled_back() {
+  Fixture fixture;
+  int schedule_calls = 0;
+  auto transaction = make_transaction(
+      fixture,
+      [&schedule_calls](const ScratchSchedulePhase phase,
+                        const StepContext &,
+                        const ScratchStageCoordinates &) {
+        ++schedule_calls;
+        return ScratchScheduleExecutionReceipt{phase, 1, 1};
+      });
+  auto rollback_state = transaction->capture_live_evolved();
+  assert(rollback_state.valid());
+  overwrite_live(fixture, 4200.0);
+  std::vector<ExactSourceSnapshot> accepted_endpoint;
+  accepted_endpoint.reserve(fixture.entries.size());
+  for (const auto *const source : fixture.entries)
+    accepted_endpoint.push_back(exact_snapshot(*source));
+
+  transaction->discard();
+
+  for (std::size_t entry = 0; entry < fixture.entries.size(); ++entry)
+    assert_exact_snapshot(*fixture.entries[entry], accepted_endpoint[entry]);
+  assert(schedule_calls == 0);
+  assert(transaction->discarded());
+  assert(!transaction->faulted());
+}
+
+void test_live_rollback_fails_closed_for_wrong_kind_or_live_drift() {
+  {
+    Fixture fixture;
+    auto transaction = make_transaction(fixture);
+    auto rhs = transaction->capture_live_rhs();
+    expect_throw<std::invalid_argument>(
+        [&] { transaction->rollback_live_evolved(rhs); });
+    assert(transaction->faulted());
+    assert(transaction->discarded());
+  }
+  {
+    Fixture fixture;
+    bool drift = false;
+    auto metadata = fixture.metadata();
+    const auto original_reader = metadata.live_entry_readers.front();
+    int replacement_identity = 999;
+    metadata.live_entry_readers.front() =
+        [original_reader, &replacement_identity, &drift] {
+          auto snapshot = original_reader();
+          if (drift)
+            snapshot.storage_identity = &replacement_identity;
+          return snapshot;
+        };
+    auto transaction = ScratchStateTransactionFactory::create_for_test(
+        fixture.copy_live_frame(), std::move(metadata), successful_schedule);
+    auto source = transaction->capture_live_evolved();
+    drift = true;
+    overwrite_live(fixture, -1300.0);
+    const auto still_mutated = exact_snapshot(fixture.evolved);
+    expect_throw<std::runtime_error>(
+        [&] { transaction->rollback_live_evolved(source); });
+    assert_exact_snapshot(fixture.evolved, still_mutated);
+    assert(transaction->faulted());
+    assert(transaction->discarded());
+  }
+}
+
+void test_full_frame_round_trip_and_fixed_working_addresses() {
+  Fixture fixture;
+  auto transaction = make_transaction(fixture);
+  const auto state = transaction->capture_live_evolved();
+  std::array<const void *, 3> addresses{};
+  for (std::size_t entry = 0; entry < addresses.size(); ++entry)
+    addresses[entry] =
+        ScratchStateTransactionFactory::working_entry_address_for_test(
+            *transaction, entry);
+
+  for (int cycle = 0; cycle < 4; ++cycle) {
+    for (std::size_t entry = 0; entry < 3; ++entry) {
+      fill_all(ScratchStateTransactionFactory::mutable_working_multifab_for_test(
+                   *transaction, entry),
+               -1000.0 - cycle);
+      auto &valid =
+          ScratchStateTransactionFactory::mutable_working_validity_for_test(
+              *transaction, entry);
+      for (auto &component : valid)
+        component = {false, false, false};
+    }
+    transaction->restore_state(state);
+    assert_source_equal(
+        ScratchStateTransactionFactory::working_multifab_for_test(*transaction,
+                                                                  0),
+        fixture.evolved);
+    assert_source_equal(
+        ScratchStateTransactionFactory::working_multifab_for_test(*transaction,
+                                                                  1),
+        fixture.rhs);
+    assert_source_equal(
+        ScratchStateTransactionFactory::working_multifab_for_test(*transaction,
+                                                                  2),
+        fixture.dependent);
+    for (std::size_t entry = 0; entry < 3; ++entry) {
+      assert(ScratchStateTransactionFactory::working_entry_address_for_test(
+                 *transaction, entry) == addresses[entry]);
+      const auto &expected = fixture.entries[entry]->validity;
+      const auto &actual =
+          ScratchStateTransactionFactory::working_validity_for_test(
+              *transaction, entry);
+      assert(actual.size() == expected.size());
+      for (std::size_t component = 0; component < actual.size(); ++component) {
+        assert(actual[component].interior == expected[component].interior);
+        assert(actual[component].outer == expected[component].outer);
+        assert(actual[component].ghosts == expected[component].ghosts);
+      }
+    }
+  }
+}
+
+void test_pair_order_rhs_canonicalization_and_mixed_linear_combination() {
+  Fixture fixture;
+  auto transaction = make_transaction(fixture);
+  assert(transaction->group_pairs().size() == 1);
+  assert(transaction->group_pairs()[0].evolved_group == 10);
+  assert(transaction->group_pairs()[0].rhs_group == 11);
+
+  auto y = transaction->capture_live_evolved();
+  auto f = transaction->capture_live_rhs();
+  auto destination = transaction->clone_state(y);
+  transaction->linear_combination(destination, 1.0, {{0.5, &f}});
+  transaction->restore_state(destination);
+
+  const auto &result =
+      ScratchStateTransactionFactory::working_multifab_for_test(*transaction,
+                                                                0);
+  for (int component = 0; component < 2; ++component)
+    for (std::size_t cell = 0;
+         cell < amrex::MultiFab::test_cells_per_region(); ++cell) {
+      const double expected =
+          fixture.evolved.multifab->test_value(amrex::TestRegion::valid,
+                                               component, cell) +
+          0.5 * fixture.rhs.multifab->test_value(amrex::TestRegion::valid,
+                                                 component, cell);
+      assert(result.test_value(amrex::TestRegion::valid, component, cell) ==
+             expected);
+      assert(result.test_value(amrex::TestRegion::outer, component, cell) ==
+             fixture.evolved.multifab->test_value(amrex::TestRegion::outer,
+                                                  component, cell));
+      assert(result.test_value(amrex::TestRegion::ghosts, component, cell) ==
+             fixture.evolved.multifab->test_value(amrex::TestRegion::ghosts,
+                                                  component, cell));
+    }
+
+  auto accumulator = transaction->clone_state(f);
+  transaction->linear_combination(accumulator, 1.0, {{2.0, &f}});
+  auto from_accumulator = transaction->clone_state(y);
+  transaction->linear_combination(from_accumulator, 0.0,
+                                  {{1.0, &accumulator}});
+  transaction->restore_state(from_accumulator);
+  const auto &accumulated =
+      ScratchStateTransactionFactory::working_multifab_for_test(*transaction,
+                                                                0);
+  assert(accumulated.test_value(amrex::TestRegion::valid, 0, 0) ==
+         3.0 * fixture.rhs.multifab->test_value(amrex::TestRegion::valid, 0,
+                                                0));
+
+  auto self_alias = transaction->clone_state(y);
+  transaction->linear_combination(self_alias, 2.0,
+                                  {{3.0, &self_alias}});
+  transaction->restore_state(self_alias);
+  assert(ScratchStateTransactionFactory::working_multifab_for_test(
+             *transaction, 0)
+             .test_value(amrex::TestRegion::valid, 0, 0) ==
+         5.0 * fixture.evolved.multifab->test_value(
+                   amrex::TestRegion::valid, 0, 0));
+
+  auto validity_source = transaction->clone_state(y);
+  transaction->set_state_valid(validity_source, ScratchStateRegion::interior,
+                               true);
+  auto validity_destination = transaction->clone_state(y);
+  transaction->set_state_valid(validity_destination,
+                               ScratchStateRegion::interior, false);
+  transaction->linear_combination(validity_destination, 0.0,
+                                  {{1.0, &validity_source}, {0.0, &f}});
+  assert(transaction->state_valid(validity_destination,
+                                  ScratchStateRegion::interior));
+}
+
+void test_restore_left_overlays_only_physical_rhs_interior_and_validity() {
+  Fixture fixture;
+  auto transaction = make_transaction(fixture);
+  auto evolved = transaction->capture_live_evolved();
+
+  const auto original_rhs_outer =
+      fixture.rhs.multifab->test_value(amrex::TestRegion::outer, 0, 0);
+  const auto original_rhs_ghost =
+      fixture.rhs.multifab->test_value(amrex::TestRegion::ghosts, 0, 0);
+  const auto original_rhs_validity = fixture.rhs.validity;
+  for (int component = 0; component < fixture.rhs.multifab->nComp();
+       ++component) {
+    for (std::size_t cell = 0;
+         cell < amrex::MultiFab::test_cells_per_region(); ++cell) {
+      fixture.rhs.multifab->test_set(amrex::TestRegion::valid, component,
+                                     cell, 700.0 + component + cell);
+      fixture.rhs.multifab->test_set(amrex::TestRegion::outer, component,
+                                     cell, 800.0 + component + cell);
+      fixture.rhs.multifab->test_set(amrex::TestRegion::ghosts, component,
+                                     cell, 900.0 + component + cell);
+    }
+    fixture.rhs.validity[static_cast<std::size_t>(component)] =
+        {true, true, true};
+  }
+  auto raw_rhs = transaction->capture_live_rhs();
+  assert(transaction->state_valid(raw_rhs, ScratchStateRegion::interior));
+  assert(!transaction->state_valid(raw_rhs, ScratchStateRegion::outer));
+  assert(!transaction->state_valid(raw_rhs, ScratchStateRegion::ghosts));
+  for (std::size_t entry = 0; entry < 3; ++entry) {
+    fill_all(ScratchStateTransactionFactory::mutable_working_multifab_for_test(
+                 *transaction, entry),
+             -600.0);
+    for (auto &validity :
+         ScratchStateTransactionFactory::mutable_working_validity_for_test(
+             *transaction, entry))
+      validity = {false, false, false};
+  }
+  transaction->restore_left(evolved, raw_rhs);
+  assert_source_equal(
+      ScratchStateTransactionFactory::working_multifab_for_test(*transaction,
+                                                                0),
+      fixture.evolved);
+  const auto &restored_rhs =
+      ScratchStateTransactionFactory::working_multifab_for_test(*transaction,
+                                                                1);
+  assert(restored_rhs.test_value(amrex::TestRegion::valid, 0, 0) == 700.0);
+  assert(restored_rhs.test_value(amrex::TestRegion::outer, 0, 0) ==
+         original_rhs_outer);
+  assert(restored_rhs.test_value(amrex::TestRegion::ghosts, 0, 0) ==
+         original_rhs_ghost);
+  assert_source_equal(
+      ScratchStateTransactionFactory::working_multifab_for_test(*transaction,
+                                                                2),
+      fixture.dependent);
+  const auto &rhs_validity =
+      ScratchStateTransactionFactory::working_validity_for_test(*transaction,
+                                                                1);
+  for (std::size_t component = 0; component < rhs_validity.size(); ++component) {
+    assert(rhs_validity[component].interior);
+    assert(rhs_validity[component].outer ==
+           original_rhs_validity[component].outer);
+    assert(rhs_validity[component].ghosts ==
+           original_rhs_validity[component].ghosts);
+  }
+}
+
+void test_hierarchy_epoch_drift_faults_before_state_mutation() {
+  Fixture fixture;
+  auto transaction = make_transaction(fixture);
+  auto state = transaction->capture_live_evolved();
+  fixture.observed_epoch = 8;
+
+  expect_throw<std::runtime_error>([&] { transaction->restore_state(state); });
+  assert(transaction->faulted());
+  assert(transaction->discarded());
+  expect_throw<std::logic_error>([&] {
+    transaction->linear_combination(state, 1.0, {});
+  });
+}
+
+void test_clean_discard_remains_nonfaulting_when_dense_take_is_empty() {
+  Fixture fixture;
+  auto transaction = make_transaction(fixture);
+  auto state = transaction->capture_live_evolved();
+  transaction->discard();
+  expect_throw<std::logic_error>(
+      [&] { transaction->rollback_live_evolved(state); });
+  assert(transaction->take_committed_dense() == nullptr);
+  assert(transaction->discarded());
+  assert(!transaction->faulted());
+}
+
+void test_zero_scale_and_zero_terms_do_not_read_nan_sources() {
+  Fixture fixture;
+  fill_all(*fixture.evolved.multifab,
+           std::numeric_limits<double>::quiet_NaN());
+  auto transaction = make_transaction(fixture);
+  auto destination = transaction->capture_live_evolved();
+  fill_all(*fixture.evolved.multifab, 4.0);
+  auto finite_source = transaction->capture_live_evolved();
+  fill_all(*fixture.rhs.multifab,
+           std::numeric_limits<double>::quiet_NaN());
+  auto zero_term = transaction->capture_live_rhs();
+  transaction->linear_combination(destination, 0.0,
+                                  {{1.0, &finite_source},
+                                   {0.0, &zero_term}});
+  transaction->restore_state(destination);
+  const auto &result =
+      ScratchStateTransactionFactory::working_multifab_for_test(*transaction,
+                                                                0);
+  for (int component = 0; component < 2; ++component)
+    for (std::size_t cell = 0;
+         cell < amrex::MultiFab::test_cells_per_region(); ++cell)
+      assert(result.test_value(amrex::TestRegion::valid, component, cell) ==
+             4.0);
+}
+
+void test_owner_epoch_kind_and_schema_rejections() {
+  Fixture first_fixture;
+  Fixture second_fixture;
+  auto first = make_transaction(first_fixture);
+  auto second = make_transaction(second_fixture);
+  auto first_state = first->capture_live_evolved();
+  auto second_state = second->capture_live_evolved();
+  expect_throw<std::invalid_argument>(
+      [&] { first->restore_state(second_state); });
+
+  auto rhs = first->capture_live_rhs();
+  expect_throw<std::invalid_argument>([&] { first->restore_state(rhs); });
+  auto stale =
+      ScratchStateTransactionFactory::stale_epoch_token_for_test(*first,
+                                                                  first_state);
+  expect_throw<std::invalid_argument>([&] { first->restore_state(stale); });
+  auto incompatible =
+      ScratchStateTransactionFactory::incompatible_schema_token_for_test(
+          *first, first_state);
+  expect_throw<std::invalid_argument>(
+      [&] { first->restore_state(incompatible); });
+}
+
+void test_post_step_sidecars_and_schedule_coordinates() {
+  Fixture fixture;
+  ScratchStateTransaction *transaction_ptr = nullptr;
+  std::vector<ScratchStageCoordinates> coordinates;
+  auto transaction = make_transaction(
+      fixture,
+      [&](const ScratchSchedulePhase phase, const StepContext &,
+          const ScratchStageCoordinates &stage) {
+        coordinates.push_back(stage);
+        if (phase == ScratchSchedulePhase::post_step) {
+          const auto &evolved_validity =
+              ScratchStateTransactionFactory::working_validity_for_test(
+                  *transaction_ptr, 0);
+          assert(evolved_validity[0].interior ==
+                 fixture.evolved.validity[0].interior);
+          assert(evolved_validity[1].interior ==
+                 fixture.evolved.validity[1].interior);
+          for (const auto entry : {1U, 2U})
+            for (const auto &validity :
+                 ScratchStateTransactionFactory::working_validity_for_test(
+                     *transaction_ptr, entry))
+              assert(!validity.interior && !validity.outer &&
+                     !validity.ghosts);
+          auto &dependent = ScratchStateTransactionFactory::
+              mutable_working_multifab_for_test(*transaction_ptr, 2);
+          dependent.test_set(amrex::TestRegion::valid, 0, 0, 777.0);
+          ScratchStateTransactionFactory::mutable_working_validity_for_test(
+              *transaction_ptr, 2)[0] = {true, true, true};
+        }
+        return ScratchScheduleExecutionReceipt{phase, 1, 1};
+      });
+  transaction_ptr = transaction.get();
+  const StepContext context{0, step_clock_t(3, 2), step_clock_t(2, 1), 1.5,
+                            2.0, SubcyclingODEMethod::rk4};
+  struct NoopPreparer final : StagePreparer {
+    void prepare_stage(const StepContext &, const StagePoint &) override {}
+  } preparer;
+  {
+    ScopedStepContext scope(context, preparer, transaction.get());
+    const StagePoint stage{StageKind::fractional, 2, 4,
+                           step_clock_t(1, 2), 1.75};
+    transaction->post_step_after_update(context, stage);
+    transaction->evaluate_rhs(context, stage);
+  }
+  assert(coordinates.size() == 2);
+  for (const auto &stage : coordinates) {
+    assert(stage.level_iteration == 41);
+    assert(stage.stage_time == 1.75);
+    assert(stage.base_delta_clock == step_clock_t(1, 2));
+    assert(stage.base_delta_time == 0.5);
+    assert(stage.time_refinement_factor == 1);
+  }
+  assert(transaction->rhs_evaluation_count() == 1);
+
+  const auto post_state = transaction->capture_scratch_evolved();
+  const auto base_state = transaction->capture_live_evolved();
+  for (int repeat = 0; repeat < 3; ++repeat) {
+    transaction->restore_state(base_state);
+    assert(ScratchStateTransactionFactory::working_multifab_for_test(
+               *transaction, 2)
+               .test_value(amrex::TestRegion::valid, 0, 0) == 50.0);
+    transaction->restore_state(post_state);
+    assert(ScratchStateTransactionFactory::working_multifab_for_test(
+               *transaction, 2)
+               .test_value(amrex::TestRegion::valid, 0, 0) == 777.0);
+    assert(ScratchStateTransactionFactory::working_validity_for_test(
+               *transaction, 2)[0]
+               .ghosts);
+  }
+}
+
+void test_level_one_timefac_two_uses_exact_stage_clock() {
+  Fixture fixture(1, 2);
+  std::vector<ScratchStageCoordinates> coordinates;
+  auto transaction = make_transaction(
+      fixture,
+      [&](const ScratchSchedulePhase phase, const StepContext &context,
+          const ScratchStageCoordinates &stage) {
+        assert(context.level == 1);
+        coordinates.push_back(stage);
+        return ScratchScheduleExecutionReceipt{phase, 1, 1};
+      });
+  const StepContext context{1, step_clock_t(1, 2), step_clock_t(3, 4), 1.0,
+                            1.25, SubcyclingODEMethod::rk4};
+  const StagePoint stage{StageKind::fractional, 1, 3, step_clock_t(1, 3),
+                         1.0 + 0.25 / 3.0};
+  struct NoopPreparer final : StagePreparer {
+    void prepare_stage(const StepContext &, const StagePoint &) override {}
+  } preparer;
+  {
+    ScopedStepContext scope(context, preparer, transaction.get());
+    transaction->post_step_after_update(context, stage);
+    transaction->evaluate_rhs(context, stage);
+  }
+  assert(coordinates.size() == 2);
+  for (const auto &observed : coordinates) {
+    assert(observed.level_iteration == 41);
+    assert(observed.stage_time == stage.stage_time);
+    assert(observed.base_delta_clock == step_clock_t(1, 2));
+    assert(observed.base_delta_time == 0.5);
+    assert(observed.time_refinement_factor == 2);
+  }
+  assert(transaction->rhs_evaluation_count() == 1);
+}
+
+void test_level_zero_remains_available_in_a_two_level_hierarchy() {
+  Fixture fixture(0, 2);
+  auto transaction = make_transaction(fixture);
+  const StepContext context{0, step_clock_t(1), step_clock_t(3, 2), 2.0,
+                            2.5, SubcyclingODEMethod::rk4};
+  const StagePoint stage{StageKind::endpoint_probe, 1, 1, step_clock_t(1),
+                         2.5};
+  struct NoopPreparer final : StagePreparer {
+    void prepare_stage(const StepContext &, const StagePoint &) override {}
+  } preparer;
+  {
+    ScopedStepContext scope(context, preparer, transaction.get());
+    transaction->evaluate_rhs(context, stage);
+  }
+  assert(transaction->rhs_evaluation_count() == 1);
+  assert(!transaction->faulted());
+  assert(!transaction->discarded());
+}
+
+void test_level_one_factory_and_context_mismatches_fail_closed() {
+  {
+    Fixture fixture(1, 1);
+    expect_throw<std::invalid_argument>([&] {
+      static_cast<void>(make_transaction(fixture));
+    });
+  }
+  {
+    Fixture fixture(1, 3);
+    expect_throw<std::invalid_argument>([&] {
+      static_cast<void>(make_transaction(fixture));
+    });
+  }
+  {
+    Fixture fixture(1, 2);
+    auto metadata = fixture.metadata();
+    metadata.time_refinement_factor = 1;
+    expect_throw<std::invalid_argument>([&] {
+      static_cast<void>(ScratchStateTransactionFactory::create_for_test(
+          fixture.copy_live_frame(), std::move(metadata),
+          successful_schedule));
+    });
+  }
+  {
+    Fixture fixture(1, 2);
+    for (auto *const source : fixture.entries)
+      source->key.patch = 1;
+    expect_throw<std::invalid_argument>([&] {
+      static_cast<void>(make_transaction(fixture));
+    });
+  }
+  {
+    Fixture fixture(1, 2);
+    auto metadata = fixture.metadata();
+    const auto reader = metadata.live_entry_readers.front();
+    metadata.live_entry_readers.front() = [reader] {
+      auto snapshot = reader();
+      snapshot.key.level = 0;
+      return snapshot;
+    };
+    expect_throw<std::invalid_argument>([&] {
+      static_cast<void>(ScratchStateTransactionFactory::create_for_test(
+          fixture.copy_live_frame(), std::move(metadata),
+          successful_schedule));
+    });
+  }
+  {
+    Fixture fixture(1, 2);
+    auto transaction = make_transaction(fixture);
+    const StepContext wrong_context{0, step_clock_t(1, 2),
+                                    step_clock_t(3, 4), 1.0, 1.25,
+                                    SubcyclingODEMethod::rk4};
+    const StagePoint stage{StageKind::primary, 1, 4, step_clock_t(0), 1.0};
+    struct NoopPreparer final : StagePreparer {
+      void prepare_stage(const StepContext &, const StagePoint &) override {}
+    } preparer;
+    ScopedStepContext scope(wrong_context, preparer, transaction.get());
+    expect_throw<std::invalid_argument>(
+        [&] { transaction->evaluate_rhs(wrong_context, stage); });
+    assert(transaction->faulted());
+    assert(transaction->discarded());
+  }
+  {
+    Fixture fixture(1, 2);
+    auto transaction = make_transaction(fixture);
+    const StepContext wrong_clock{1, step_clock_t(0), step_clock_t(1, 2),
+                                  0.0, 0.5,
+                                  SubcyclingODEMethod::rk4};
+    const StagePoint stage{StageKind::fractional, 1, 2,
+                           step_clock_t(1, 2), 0.25};
+    struct NoopPreparer final : StagePreparer {
+      void prepare_stage(const StepContext &, const StagePoint &) override {}
+    } preparer;
+    ScopedStepContext scope(wrong_clock, preparer, transaction.get());
+    expect_throw<std::invalid_argument>(
+        [&] { transaction->evaluate_rhs(wrong_clock, stage); });
+    assert(transaction->faulted());
+    assert(transaction->discarded());
+  }
+}
+
+DenseCapability capability(const SubcyclingODEMethod method) {
+  TableauFingerprint fingerprint{};
+  fingerprint[0] = static_cast<std::uint8_t>(method) + 1;
+  const int controls = method == SubcyclingODEMethod::rk4
+                           ? 5
+                           : method == SubcyclingODEMethod::rkf78_order7 ? 8
+                                                                        : 9;
+  const int stages = method == SubcyclingODEMethod::rk4
+                         ? 4
+                         : method == SubcyclingODEMethod::rkf78_order7 ? 11
+                                                                      : 13;
+  const int order = controls - 1;
+  return {method, fingerprint, order, order, stages, 0, controls, true, true};
+}
+
+void publish_dense_for_session(ScratchStateTransaction &transaction,
+                               const StepContext &context) {
+  const auto cap = capability(context.method);
+  DenseOutputProvider provider(cap);
+  const DenseIntervalId interval{
+      context.level, context.begin_clock, context.end_clock,
+      context.begin_time, context.end_time, context.method,
+      cap.tableau_fingerprint};
+  const auto &constraints =
+      reference_dense_stencil(context.method).specification().constraints;
+  std::vector<ScratchStateToken> states;
+  std::vector<ScratchDenseSampleRef> samples;
+  states.reserve(constraints.size());
+  samples.reserve(constraints.size());
+  for (const auto &constraint : constraints) {
+    const bool value = constraint.kind == DenseSampleKind::value;
+    states.push_back(value ? transaction.capture_live_evolved()
+                           : transaction.capture_live_rhs());
+    samples.push_back({constraint.theta,
+                       value ? ScratchDenseSampleKind::value
+                             : ScratchDenseSampleKind::raw_derivative,
+                       &states.back()});
+  }
+  transaction.commit_dense(context, provider, interval, samples);
+}
+
+struct NoopSessionPreparer final : StagePreparer {
+  void prepare_stage(const StepContext &, const StagePoint &) override {}
+};
+
+void test_transaction_level_session_accepts_dense_and_nondense_endpoints() {
+  {
+    Fixture fixture;
+    for (auto *const source : {&fixture.evolved, &fixture.rhs})
+      for (auto &validity : source->validity)
+        validity = {true, true, true};
+    const StepContext context{0, step_clock_t(0), step_clock_t(1, 2), 0.0,
+                              0.5, SubcyclingODEMethod::rk4};
+    int evolution_calls = 0;
+    int commit_calls = 0;
+    auto transaction = make_transaction(fixture);
+    auto *const transaction_address = transaction.get();
+    TransactionLevelStepSession session(
+        std::move(transaction), true,
+        [&](ScratchStateTransaction &active) {
+          ++evolution_calls;
+          publish_dense_for_session(active, context);
+          overwrite_live(fixture, 6100.0);
+        },
+        [&] { ++commit_calls; });
+    assert(session.transaction() == transaction_address);
+
+    LevelAdvanceResult result;
+    NoopSessionPreparer preparer;
+    {
+      ScopedStepContext scope(context, preparer, session.transaction());
+      result = session.advance();
+    }
+    assert(result.dense_interval != nullptr);
+    assert(result.dense_interval->id().begin_clock == context.begin_clock);
+    assert(result.dense_interval->id().end_clock == context.end_clock);
+    assert(evolution_calls == 1);
+    assert(commit_calls == 0);
+    expect_throw<std::logic_error>([&] { session.advance(); });
+
+    std::vector<ExactSourceSnapshot> accepted;
+    for (const auto *const source : fixture.entries)
+      accepted.push_back(exact_snapshot(*source));
+    session.commit();
+    assert(commit_calls == 1);
+    assert(session.transaction() == nullptr);
+    for (std::size_t entry = 0; entry < fixture.entries.size(); ++entry)
+      assert_exact_snapshot(*fixture.entries[entry], accepted[entry]);
+    expect_throw<std::logic_error>([&] { session.commit(); });
+    expect_throw<std::logic_error>([&] { session.advance(); });
+  }
+
+  {
+    Fixture fixture;
+    const StepContext context{0, step_clock_t(0), step_clock_t(1, 2), 0.0,
+                              0.5, SubcyclingODEMethod::rk4};
+    int evolution_calls = 0;
+    int commit_calls = 0;
+    TransactionLevelStepSession session(
+        make_transaction(fixture), false,
+        [&](ScratchStateTransaction &) {
+          ++evolution_calls;
+          overwrite_live(fixture, 7100.0);
+        },
+        [&] { ++commit_calls; });
+    expect_throw<std::logic_error>([&] { session.commit(); });
+    NoopSessionPreparer preparer;
+    LevelAdvanceResult result;
+    {
+      ScopedStepContext scope(context, preparer, session.transaction());
+      result = session.advance();
+    }
+    assert(result.dense_interval == nullptr);
+    session.commit();
+    assert(evolution_calls == 1);
+    assert(commit_calls == 1);
+  }
+}
+
+void test_transaction_level_session_rolls_back_evolution_or_commit_failure() {
+  {
+    Fixture fixture;
+    std::vector<ExactSourceSnapshot> expected;
+    for (const auto *const source : fixture.entries)
+      expected.push_back(exact_snapshot(*source));
+    int evolution_calls = 0;
+    int commit_calls = 0;
+    TransactionLevelStepSession session(
+        make_transaction(fixture), false,
+        [&](ScratchStateTransaction &) {
+          ++evolution_calls;
+          overwrite_live(fixture, -8100.0);
+          throw std::runtime_error("injected level evolution failure");
+        },
+        [&] { ++commit_calls; });
+    expect_throw<std::runtime_error>([&] { session.advance(); });
+    assert(evolution_calls == 1);
+    assert(commit_calls == 0);
+    assert(session.transaction() == nullptr);
+    for (std::size_t entry = 0; entry < fixture.entries.size(); ++entry)
+      assert_exact_snapshot(*fixture.entries[entry], expected[entry]);
+    expect_throw<std::logic_error>([&] { session.advance(); });
+    expect_throw<std::logic_error>([&] { session.commit(); });
+  }
+
+  {
+    Fixture fixture;
+    std::vector<ExactSourceSnapshot> expected;
+    for (const auto *const source : fixture.entries)
+      expected.push_back(exact_snapshot(*source));
+    TransactionLevelStepSession session(
+        make_transaction(fixture), false,
+        [&](ScratchStateTransaction &) { overwrite_live(fixture, -9100.0); },
+        [] { throw std::runtime_error("injected accepted-metadata failure"); });
+    const auto result = session.advance();
+    assert(result.dense_interval == nullptr);
+    expect_throw<std::runtime_error>([&] { session.commit(); });
+    assert(session.transaction() == nullptr);
+    for (std::size_t entry = 0; entry < fixture.entries.size(); ++entry)
+      assert_exact_snapshot(*fixture.entries[entry], expected[entry]);
+  }
+}
+
+void test_uncommitted_transaction_level_session_destructor_rolls_back() {
+  Fixture fixture;
+  std::vector<ExactSourceSnapshot> expected;
+  for (const auto *const source : fixture.entries)
+    expected.push_back(exact_snapshot(*source));
+  int commit_calls = 0;
+  {
+    TransactionLevelStepSession session(
+        make_transaction(fixture), false,
+        [&](ScratchStateTransaction &) { overwrite_live(fixture, -10100.0); },
+        [&] { ++commit_calls; });
+    const auto result = session.advance();
+    assert(result.dense_interval == nullptr);
+    assert(commit_calls == 0);
+  }
+  assert(commit_calls == 0);
+  for (std::size_t entry = 0; entry < fixture.entries.size(); ++entry)
+    assert_exact_snapshot(*fixture.entries[entry], expected[entry]);
+}
+
+void test_dense_commit_is_atomic_and_uses_phase7_builder() {
+  Fixture fixture(1, 2);
+  for (auto *source : {&fixture.evolved, &fixture.rhs})
+    for (auto &validity : source->validity)
+      validity.interior = true;
+  auto transaction = ScratchStateTransactionFactory::create_for_test(
+      fixture.copy_live_frame(), fixture.metadata(), successful_schedule);
+  const auto method = SubcyclingODEMethod::rk4;
+  const auto cap = capability(method);
+  DenseOutputProvider provider(cap);
+  const StepContext context{1, step_clock_t(0), step_clock_t(1, 4), 0.0,
+                            0.25, method};
+  DenseIntervalId id{1, step_clock_t(0), step_clock_t(1, 4), 0.0, 0.25,
+                     method, cap.tableau_fingerprint};
+
+  const auto &constraints =
+      reference_dense_stencil(method).specification().constraints;
+  auto y0 = transaction->capture_live_evolved();
+  auto raw_f = transaction->capture_live_rhs();
+  std::vector<ScratchStateToken> owned_samples;
+  owned_samples.reserve(constraints.size());
+  std::vector<ScratchDenseSampleRef> refs;
+  refs.reserve(constraints.size());
+  for (const auto &constraint : constraints) {
+    const bool value = constraint.kind == DenseSampleKind::value;
+    if (value) {
+      auto sample = transaction->clone_state(y0);
+      transaction->linear_combination(
+          sample, 1.0, {{constraint.theta * 0.25, &raw_f}});
+      owned_samples.push_back(std::move(sample));
+    } else {
+      owned_samples.push_back(transaction->clone_state(raw_f));
+    }
+    refs.push_back({constraint.theta,
+                    value ? ScratchDenseSampleKind::value
+                          : ScratchDenseSampleKind::raw_derivative,
+                    &owned_samples.back()});
+  }
+  struct NoopPreparer final : StagePreparer {
+    void prepare_stage(const StepContext &, const StagePoint &) override {}
+  } preparer;
+  {
+    ScopedStepContext scope(context, preparer, transaction.get());
+    transaction->commit_dense(context, provider, id, refs);
+  }
+  const auto interval = transaction->take_committed_dense();
+  assert(interval != nullptr);
+  assert(interval->id().level == 1);
+  assert(interval->control_count() == 5);
+  assert(transaction->take_committed_dense() == nullptr);
+
+  auto destination = OwnedMultiFabDenseState::copy_of(
+      {{{7, 0, 1, 10}, fixture.evolved.multifab.get()}});
+  constexpr double theta = 0.37;
+  interval->evaluate(theta, *destination);
+  const double expected =
+      fixture.evolved.multifab->test_value(amrex::TestRegion::valid, 0, 0) +
+      theta * 0.25 *
+          fixture.rhs.multifab->test_value(amrex::TestRegion::valid, 0, 0);
+  assert(std::abs(destination->multifab(0).test_value(
+                      amrex::TestRegion::valid, 0, 0) -
+                  expected) < 1.0e-11);
+  {
+    ScopedStepContext scope(context, preparer, transaction.get());
+    expect_throw<std::logic_error>(
+        [&] { transaction->commit_dense(context, provider, id, refs); });
+  }
+
+  Fixture stale_fixture(1, 2);
+  for (auto *source : {&stale_fixture.evolved, &stale_fixture.rhs})
+    for (auto &validity : source->validity)
+      validity.interior = true;
+  auto stale_transaction = ScratchStateTransactionFactory::create_for_test(
+      stale_fixture.copy_live_frame(), stale_fixture.metadata(),
+      successful_schedule);
+  auto stale_y = stale_transaction->capture_live_evolved();
+  auto stale_f = stale_transaction->capture_live_rhs();
+  std::vector<ScratchStateToken> stale_owned;
+  stale_owned.reserve(constraints.size());
+  std::vector<ScratchDenseSampleRef> stale_refs;
+  stale_refs.reserve(constraints.size());
+  for (const auto &constraint : constraints) {
+    const bool value = constraint.kind == DenseSampleKind::value;
+    stale_owned.push_back(stale_transaction->clone_state(value ? stale_y
+                                                               : stale_f));
+    stale_refs.push_back(
+        {constraint.theta,
+         value ? ScratchDenseSampleKind::value
+               : ScratchDenseSampleKind::raw_derivative,
+         &stale_owned.back()});
+  }
+  {
+    ScopedStepContext scope(context, preparer, stale_transaction.get());
+    stale_transaction->commit_dense(context, provider, id, stale_refs);
+  }
+  stale_fixture.observed_epoch = 8;
+  assert(stale_transaction->take_committed_dense() == nullptr);
+  assert(stale_transaction->faulted());
+  assert(stale_transaction->discarded());
+
+  Fixture invalid_fixture(1, 2);
+  for (auto *source : {&invalid_fixture.evolved, &invalid_fixture.rhs})
+    for (auto &validity : source->validity)
+      validity.interior = true;
+  auto invalid_transaction =
+      ScratchStateTransactionFactory::create_for_test(
+          invalid_fixture.copy_live_frame(), invalid_fixture.metadata(),
+          successful_schedule);
+  std::vector<ScratchStateToken> invalid_owned;
+  invalid_owned.reserve(constraints.size());
+  std::vector<ScratchDenseSampleRef> invalid_refs;
+  invalid_refs.reserve(constraints.size());
+  for (const auto &constraint : constraints) {
+    const bool value = constraint.kind == DenseSampleKind::value;
+    invalid_owned.push_back(value
+                                ? invalid_transaction->capture_live_evolved()
+                                : invalid_transaction->capture_live_rhs());
+    invalid_refs.push_back(
+        {constraint.theta,
+         value ? ScratchDenseSampleKind::value
+               : ScratchDenseSampleKind::raw_derivative,
+         &invalid_owned.back()});
+  }
+  invalid_refs.front().kind = ScratchDenseSampleKind::raw_derivative;
+  {
+    ScopedStepContext scope(context, preparer, invalid_transaction.get());
+    expect_throw<std::invalid_argument>([&] {
+      invalid_transaction->commit_dense(context, provider, id, invalid_refs);
+    });
+  }
+  assert(invalid_transaction->take_committed_dense() == nullptr);
+  assert(invalid_transaction->faulted());
+}
+
+void test_dense_commit_rejects_unrelated_interval_identity() {
+  const auto method = SubcyclingODEMethod::rk4;
+  const auto cap = capability(method);
+  DenseOutputProvider provider(cap);
+  const auto &constraints =
+      reference_dense_stencil(method).specification().constraints;
+  struct NoopPreparer final : StagePreparer {
+    void prepare_stage(const StepContext &, const StagePoint &) override {}
+  } preparer;
+
+  for (int variant = 0; variant < 6; ++variant) {
+    Fixture fixture;
+    for (auto *source : {&fixture.evolved, &fixture.rhs})
+      for (auto &validity : source->validity)
+        validity.interior = true;
+    auto transaction = make_transaction(fixture);
+    StepContext context{0, step_clock_t(0), step_clock_t(1, 2), 0.0, 0.5,
+                        method};
+    DenseIntervalId id{0, step_clock_t(0), step_clock_t(1, 2), 0.0, 0.5,
+                       method, cap.tableau_fingerprint};
+    if (variant == 0) {
+      id.begin_clock = step_clock_t(1);
+      id.end_clock = step_clock_t(3, 2);
+    } else if (variant == 1) {
+      id.begin_time = 1.0;
+      id.end_time = 1.5;
+    } else if (variant == 2) {
+      context.level = 1;
+      id.level = 1;
+    } else if (variant == 3) {
+      id.method = SubcyclingODEMethod::dp87_order8;
+    } else if (variant == 4) {
+      id.tableau_fingerprint[0] ^= 0xff;
+    }
+
+    std::vector<ScratchStateToken> owned;
+    owned.reserve(constraints.size());
+    std::vector<ScratchDenseSampleRef> refs;
+    refs.reserve(constraints.size());
+    for (const auto &constraint : constraints) {
+      const bool value = constraint.kind == DenseSampleKind::value;
+      owned.push_back(value ? transaction->capture_live_evolved()
+                            : transaction->capture_live_rhs());
+      refs.push_back({constraint.theta,
+                      value ? ScratchDenseSampleKind::value
+                            : ScratchDenseSampleKind::raw_derivative,
+                      &owned.back()});
+    }
+    if (variant == 5) {
+      expect_throw<std::logic_error>(
+          [&] { transaction->commit_dense(context, provider, id, refs); });
+    } else {
+      ScopedStepContext scope(context, preparer, transaction.get());
+      expect_throw<std::exception>(
+          [&] { transaction->commit_dense(context, provider, id, refs); });
+    }
+    assert(transaction->take_committed_dense() == nullptr);
+    assert(transaction->faulted());
+  }
+}
+
+void test_dense_commit_rejects_invalid_mapped_interiors() {
+  Fixture fixture;
+  auto transaction = make_transaction(fixture);
+  const auto method = SubcyclingODEMethod::rk4;
+  const auto cap = capability(method);
+  DenseOutputProvider provider(cap);
+  const StepContext context{0, step_clock_t(0), step_clock_t(1, 2), 0.0, 0.5,
+                            method};
+  DenseIntervalId id{0, step_clock_t(0), step_clock_t(1, 2), 0.0, 0.5,
+                     method, cap.tableau_fingerprint};
+  const auto &constraints =
+      reference_dense_stencil(method).specification().constraints;
+  std::vector<ScratchStateToken> owned;
+  owned.reserve(constraints.size());
+  std::vector<ScratchDenseSampleRef> refs;
+  refs.reserve(constraints.size());
+  for (const auto &constraint : constraints) {
+    const bool value = constraint.kind == DenseSampleKind::value;
+    owned.push_back(value ? transaction->capture_live_evolved()
+                          : transaction->capture_live_rhs());
+    refs.push_back({constraint.theta,
+                    value ? ScratchDenseSampleKind::value
+                          : ScratchDenseSampleKind::raw_derivative,
+                    &owned.back()});
+  }
+  struct NoopPreparer final : StagePreparer {
+    void prepare_stage(const StepContext &, const StagePoint &) override {}
+  } preparer;
+  {
+    ScopedStepContext scope(context, preparer, transaction.get());
+    expect_throw<std::invalid_argument>(
+        [&] { transaction->commit_dense(context, provider, id, refs); });
+  }
+  assert(transaction->take_committed_dense() == nullptr);
+  assert(transaction->faulted());
+}
+
+void test_fault_discards_transaction_without_partial_publication() {
+  Fixture fixture;
+  auto transaction = make_transaction(
+      fixture,
+      [](const ScratchSchedulePhase phase, const StepContext &,
+         const ScratchStageCoordinates &) -> ScratchScheduleExecutionReceipt {
+        if (phase == ScratchSchedulePhase::rhs)
+          throw std::runtime_error("injected RHS failure");
+        return {phase, 1, 1};
+      });
+  auto state = transaction->capture_live_evolved();
+  const StepContext context{0, step_clock_t(0), step_clock_t(1, 2), 0.0, 0.5,
+                            SubcyclingODEMethod::rk4};
+  struct NoopPreparer final : StagePreparer {
+    void prepare_stage(const StepContext &, const StagePoint &) override {}
+  } preparer;
+  {
+    ScopedStepContext scope(context, preparer, transaction.get());
+    expect_throw<std::runtime_error>(
+        [&] {
+          transaction->evaluate_rhs(
+              context, {StageKind::fractional, 2, 4,
+                        step_clock_t(1, 2), 0.25});
+        });
+  }
+  assert(transaction->faulted());
+  assert(transaction->discarded());
+  assert(transaction->rhs_evaluation_count() == 0);
+  expect_throw<std::logic_error>(
+      [&] { transaction->rollback_live_evolved(state); });
+  expect_throw<std::logic_error>([&] { transaction->restore_state(state); });
+}
+
+void test_live_capture_drift_and_factory_envelope_rejection() {
+  {
+    Fixture fixture;
+    auto transaction = make_transaction(fixture);
+    fixture.observed_epoch = 8;
+    expect_throw<std::runtime_error>(
+        [&] { static_cast<void>(transaction->capture_live_evolved()); });
+  }
+  {
+    Fixture fixture;
+    auto metadata = fixture.metadata();
+    const auto original_reader = metadata.live_entry_readers[0];
+    int replacement_identity = 999;
+    bool drift = false;
+    metadata.live_entry_readers[0] = [original_reader,
+                                      &replacement_identity, &drift] {
+      auto snapshot = original_reader();
+      if (drift)
+        snapshot.storage_identity = &replacement_identity;
+      return snapshot;
+    };
+    auto transaction = ScratchStateTransactionFactory::create_for_test(
+        fixture.copy_live_frame(), std::move(metadata), successful_schedule);
+    drift = true;
+    expect_throw<std::runtime_error>(
+        [&] { static_cast<void>(transaction->capture_live_rhs()); });
+  }
+  {
+    Fixture fixture;
+    auto metadata = fixture.metadata();
+    metadata.patch_count = 2;
+    expect_throw<std::invalid_argument>([&] {
+      static_cast<void>(ScratchStateTransactionFactory::create_for_test(
+          fixture.copy_live_frame(), std::move(metadata),
+          successful_schedule));
+    });
+  }
+  {
+    Fixture fixture;
+    auto metadata = fixture.metadata();
+    metadata.time_refinement_factor = 3;
+    expect_throw<std::invalid_argument>([&] {
+      static_cast<void>(ScratchStateTransactionFactory::create_for_test(
+          fixture.copy_live_frame(), std::move(metadata),
+          successful_schedule));
+    });
+  }
+  {
+    Fixture fixture;
+    fixture.rhs.multifab = make_source(11, 2.0, 31).multifab;
+    expect_throw<std::invalid_argument>([&] {
+      static_cast<void>(make_transaction(fixture));
+    });
+  }
+  {
+    Fixture fixture;
+    auto second_evolved = make_source(13, 70.0);
+    auto second_rhs = make_source(14, 7.0);
+    fixture.entries.push_back(&second_evolved);
+    fixture.entries.push_back(&second_rhs);
+    auto metadata = fixture.metadata();
+    metadata.group_pairs = {{13, 14}, {10, 11}};
+    metadata.dependent_groups.push_back(14);
+    expect_throw<std::invalid_argument>([&] {
+      static_cast<void>(ScratchStateTransactionFactory::create_for_test(
+          fixture.copy_live_frame(), std::move(metadata),
+          successful_schedule));
+    });
+  }
+  {
+    Fixture fixture;
+    auto metadata = fixture.metadata();
+    metadata.dependent_groups.push_back(10);
+    expect_throw<std::invalid_argument>([&] {
+      static_cast<void>(ScratchStateTransactionFactory::create_for_test(
+          fixture.copy_live_frame(), std::move(metadata),
+          successful_schedule));
+    });
+  }
+}
+
+void test_scoped_context_borrows_and_restores_transaction_pointer() {
+  Fixture fixture;
+  Fixture other_fixture;
+  auto transaction = make_transaction(fixture);
+  auto other_transaction = make_transaction(other_fixture);
+  const StepContext context{0, step_clock_t(0), step_clock_t(1, 2), 0.0, 0.5,
+                            SubcyclingODEMethod::rk4};
+  struct NoopPreparer final : StagePreparer {
+    void prepare_stage(const StepContext &, const StagePoint &) override {}
+  } preparer;
+  assert(current_scratch_state_transaction() == nullptr);
+  {
+    ScopedStepContext scope(context, preparer, transaction.get());
+    assert(current_scratch_state_transaction() == transaction.get());
+    expect_throw<std::logic_error>(
+        [&] {
+          other_transaction->evaluate_rhs(
+              context, {StageKind::fractional, 2, 4,
+                        step_clock_t(1, 2), 0.25});
+        });
+  }
+  assert(current_scratch_state_transaction() == nullptr);
+  {
+    ScopedStepContext legacy_scope(context, preparer);
+    assert(current_scratch_state_transaction() == nullptr);
+  }
+}
+
+void test_exact_stage_fraction_rejects_a_matching_range_but_wrong_time() {
+  Fixture fixture;
+  auto transaction = make_transaction(fixture);
+  const StepContext context{0, step_clock_t(0), step_clock_t(1, 2), 0.0, 0.5,
+                            SubcyclingODEMethod::rk4};
+  struct NoopPreparer final : StagePreparer {
+    void prepare_stage(const StepContext &, const StagePoint &) override {}
+  } preparer;
+  {
+    ScopedStepContext scope(context, preparer, transaction.get());
+    expect_throw<std::invalid_argument>([&] {
+      transaction->evaluate_rhs(
+          context, {StageKind::fractional, 2, 4,
+                    step_clock_t(1, 4), 0.25});
+    });
+  }
+  assert(transaction->faulted());
+  assert(transaction->discarded());
+  assert(transaction->rhs_evaluation_count() == 0);
+}
+
+void test_dependent_groups_are_exposed_in_canonical_order() {
+  Fixture fixture;
+  auto metadata = fixture.metadata();
+  metadata.dependent_groups = {12, 11};
+  auto transaction = ScratchStateTransactionFactory::create_for_test(
+      fixture.copy_live_frame(), std::move(metadata), successful_schedule);
+  assert((transaction->dependent_groups() == std::vector<int>{11, 12}));
+}
+
+} // namespace
+
+int main() {
+  test_mid_primary_failure_rolls_live_tl0_back_exactly_without_schedule();
+  test_successful_primary_endpoint_is_not_rolled_back();
+  test_live_rollback_fails_closed_for_wrong_kind_or_live_drift();
+  test_full_frame_round_trip_and_fixed_working_addresses();
+  test_pair_order_rhs_canonicalization_and_mixed_linear_combination();
+  test_restore_left_overlays_only_physical_rhs_interior_and_validity();
+  test_hierarchy_epoch_drift_faults_before_state_mutation();
+  test_clean_discard_remains_nonfaulting_when_dense_take_is_empty();
+  test_zero_scale_and_zero_terms_do_not_read_nan_sources();
+  test_owner_epoch_kind_and_schema_rejections();
+  test_post_step_sidecars_and_schedule_coordinates();
+  test_level_one_timefac_two_uses_exact_stage_clock();
+  test_level_zero_remains_available_in_a_two_level_hierarchy();
+  test_level_one_factory_and_context_mismatches_fail_closed();
+  test_transaction_level_session_accepts_dense_and_nondense_endpoints();
+  test_transaction_level_session_rolls_back_evolution_or_commit_failure();
+  test_uncommitted_transaction_level_session_destructor_rolls_back();
+  test_dense_commit_is_atomic_and_uses_phase7_builder();
+  test_dense_commit_rejects_unrelated_interval_identity();
+  test_dense_commit_rejects_invalid_mapped_interiors();
+  test_fault_discards_transaction_without_partial_publication();
+  test_live_capture_drift_and_factory_envelope_rejection();
+  test_scoped_context_borrows_and_restores_transaction_pointer();
+  test_exact_stage_fraction_rejects_a_matching_range_but_wrong_time();
+  test_dependent_groups_are_exposed_in_canonical_order();
+  std::cout << "Scratch-state transaction tests passed\n";
+  return 0;
+}

--- a/CarpetX/test/subcycling_scratch_state_transaction_unit.cxx
+++ b/CarpetX/test/subcycling_scratch_state_transaction_unit.cxx
@@ -953,6 +953,113 @@ void test_transaction_level_session_rolls_back_evolution_or_commit_failure() {
   }
 }
 
+void test_transaction_level_session_rolls_back_terminal_transaction_failures() {
+  const auto exercise_schedule_failure =
+      [](const ScratchSchedulePhase failing_phase, const double poison) {
+        Fixture fixture;
+        std::vector<ExactSourceSnapshot> expected;
+        for (const auto *const source : fixture.entries)
+          expected.push_back(exact_snapshot(*source));
+        int schedule_calls = 0;
+        const StepContext context{0, step_clock_t(3, 2), step_clock_t(2, 1),
+                                  1.5, 2.0, SubcyclingODEMethod::rk4};
+        const StagePoint stage{StageKind::fractional, 2, 4,
+                               step_clock_t(1, 2), 1.75};
+        TransactionLevelStepSession session(
+            make_transaction(
+                fixture,
+                [&](const ScratchSchedulePhase phase, const StepContext &,
+                    const ScratchStageCoordinates &)
+                    -> ScratchScheduleExecutionReceipt {
+                  ++schedule_calls;
+                  if (phase == failing_phase)
+                    throw std::runtime_error("injected scratch schedule failure");
+                  return {phase, 1, 1};
+                }),
+            false,
+            [&](ScratchStateTransaction &active) {
+              overwrite_live(fixture, poison);
+              if (failing_phase == ScratchSchedulePhase::post_step)
+                active.post_step_after_update(context, stage);
+              else
+                active.evaluate_rhs(context, stage);
+            });
+        NoopSessionPreparer preparer;
+        {
+          ScopedStepContext scope(context, preparer, session.transaction());
+          expect_throw<std::runtime_error>([&] { session.advance(); });
+        }
+        assert(schedule_calls == 1);
+        assert(session.transaction() == nullptr);
+        for (std::size_t entry = 0; entry < fixture.entries.size(); ++entry)
+          assert_exact_snapshot(*fixture.entries[entry], expected[entry]);
+      };
+
+  exercise_schedule_failure(ScratchSchedulePhase::post_step, -11100.0);
+  exercise_schedule_failure(ScratchSchedulePhase::rhs, -11200.0);
+
+  Fixture fixture;
+  std::vector<ExactSourceSnapshot> expected;
+  for (const auto *const source : fixture.entries)
+    expected.push_back(exact_snapshot(*source));
+  TransactionLevelStepSession session(
+      make_transaction(fixture), false,
+      [&](ScratchStateTransaction &active) {
+        overwrite_live(fixture, -11300.0);
+        active.discard();
+        throw std::runtime_error("injected solver discard");
+      });
+  expect_throw<std::runtime_error>([&] { session.advance(); });
+  assert(session.transaction() == nullptr);
+  for (std::size_t entry = 0; entry < fixture.entries.size(); ++entry)
+    assert_exact_snapshot(*fixture.entries[entry], expected[entry]);
+}
+
+void test_armed_live_rollback_disarms_and_fails_closed_on_stale_epoch() {
+  {
+    Fixture fixture;
+    auto transaction = make_transaction(fixture);
+    transaction->arm_live_evolved_rollback();
+    overwrite_live(fixture, 11400.0);
+    std::vector<ExactSourceSnapshot> accepted;
+    for (const auto *const source : fixture.entries)
+      accepted.push_back(exact_snapshot(*source));
+
+    transaction->disarm_live_evolved_rollback();
+    transaction->discard();
+    expect_throw<std::logic_error>(
+        [&] { transaction->rollback_live_evolved(); });
+    for (std::size_t entry = 0; entry < fixture.entries.size(); ++entry)
+      assert_exact_snapshot(*fixture.entries[entry], accepted[entry]);
+    assert(transaction->discarded());
+    assert(!transaction->faulted());
+  }
+
+  {
+    Fixture fixture;
+    auto transaction = make_transaction(fixture);
+    transaction->arm_live_evolved_rollback();
+    overwrite_live(fixture, -11500.0);
+    std::vector<ExactSourceSnapshot> still_mutated;
+    for (const auto *const source : fixture.entries)
+      still_mutated.push_back(exact_snapshot(*source));
+    fixture.observed_epoch = 8;
+
+    expect_throw<std::runtime_error>(
+        [&] { transaction->rollback_live_evolved(); });
+    for (std::size_t entry = 0; entry < fixture.entries.size(); ++entry)
+      assert_exact_snapshot(*fixture.entries[entry], still_mutated[entry]);
+    assert(transaction->faulted());
+    assert(transaction->discarded());
+
+    fixture.observed_epoch = 7;
+    expect_throw<std::logic_error>(
+        [&] { transaction->rollback_live_evolved(); });
+    for (std::size_t entry = 0; entry < fixture.entries.size(); ++entry)
+      assert_exact_snapshot(*fixture.entries[entry], still_mutated[entry]);
+  }
+}
+
 void test_uncommitted_transaction_level_session_destructor_rolls_back() {
   Fixture fixture;
   std::vector<ExactSourceSnapshot> expected;
@@ -1396,6 +1503,8 @@ int main() {
   test_level_one_factory_and_context_mismatches_fail_closed();
   test_transaction_level_session_accepts_dense_and_nondense_endpoints();
   test_transaction_level_session_rolls_back_evolution_or_commit_failure();
+  test_transaction_level_session_rolls_back_terminal_transaction_failures();
+  test_armed_live_rollback_disarms_and_fails_closed_on_stale_epoch();
   test_uncommitted_transaction_level_session_destructor_rolls_back();
   test_dense_commit_is_atomic_and_uses_phase7_builder();
   test_dense_commit_rejects_unrelated_interval_identity();

--- a/CarpetX/test/subcycling_scratch_state_unit.cxx
+++ b/CarpetX/test/subcycling_scratch_state_unit.cxx
@@ -1,0 +1,492 @@
+#include "subcycling_scratch_state.hxx"
+
+#include <AMReX_MultiFab.H>
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using CarpetX::ScratchGFKey;
+using CarpetX::ScratchGFManifestEntry;
+using CarpetX::ScratchGFView;
+using CarpetX::ScratchLevelFrame;
+using CarpetX::ScratchValidity;
+using CarpetX::UncertifiedScratchLevelManifest;
+
+static_assert(!std::is_copy_constructible_v<ScratchLevelFrame>);
+static_assert(!std::is_copy_assignable_v<ScratchLevelFrame>);
+static_assert(std::is_nothrow_move_constructible_v<ScratchLevelFrame>);
+static_assert(std::is_nothrow_move_assignable_v<ScratchLevelFrame>);
+
+template <typename Function>
+void expect_invalid_argument(Function &&function) {
+  bool threw = false;
+  try {
+    function();
+  } catch (const std::invalid_argument &) {
+    threw = true;
+  }
+  assert(threw);
+}
+
+template <typename Function> void expect_out_of_range(Function &&function) {
+  bool threw = false;
+  try {
+    function();
+  } catch (const std::out_of_range &) {
+    threw = true;
+  }
+  assert(threw);
+}
+
+template <typename Function> void expect_runtime_error(Function &&function) {
+  bool threw = false;
+  try {
+    function();
+  } catch (const std::runtime_error &) {
+    threw = true;
+  }
+  assert(threw);
+}
+
+ScratchGFKey key(const std::int64_t epoch = 41, const int level = 2,
+                 const int patch = 0, const int group = 3) {
+  return ScratchGFKey{epoch, level, patch, group};
+}
+
+bool same_key(const ScratchGFKey &left, const ScratchGFKey &right) {
+  return left.hierarchy_epoch == right.hierarchy_epoch &&
+         left.level == right.level && left.patch == right.patch &&
+         left.group_index == right.group_index;
+}
+
+struct Source {
+  std::unique_ptr<amrex::MultiFab> multifab;
+  std::vector<ScratchValidity> validity;
+};
+
+Source make_source(amrex::Arena *arena, const int factory_setting,
+                   const int box_array, const int distribution,
+                   const int components, const amrex::IntVect &grow,
+                   const bool defined = true) {
+  amrex::TestFabFactory factory(factory_setting);
+  Source result;
+  result.multifab = std::make_unique<amrex::MultiFab>(
+      amrex::BoxArray(box_array), amrex::DistributionMapping(distribution),
+      components, grow, arena, factory, defined);
+  if (components > 0) {
+    result.validity.reserve(static_cast<std::size_t>(components));
+    for (int component = 0; component < components; ++component) {
+      result.validity.push_back(ScratchValidity{
+          component % 2 == 0, component % 3 == 0, component % 2 != 0});
+    }
+  }
+  return result;
+}
+
+void populate(amrex::MultiFab &multifab, const double base) {
+  const std::array<amrex::TestRegion, 3> regions{
+      amrex::TestRegion::valid, amrex::TestRegion::outer,
+      amrex::TestRegion::ghosts};
+  for (std::size_t region = 0; region < regions.size(); ++region) {
+    for (int component = 0; component < multifab.nComp(); ++component) {
+      for (std::size_t cell = 0;
+           cell < amrex::MultiFab::test_cells_per_region(); ++cell) {
+        multifab.test_set(regions[region], component, cell,
+                          base + 100.0 * static_cast<double>(region) +
+                              10.0 * static_cast<double>(component) +
+                              static_cast<double>(cell));
+      }
+    }
+  }
+}
+
+ScratchGFView view(const ScratchGFKey &entry_key, const void *token,
+                   const Source &source, const int time_level = 0) {
+  return ScratchGFView{entry_key, time_level, token, source.multifab.get(),
+                       &source.validity};
+}
+
+UncertifiedScratchLevelManifest manifest(
+    const std::int64_t epoch, const int level,
+    const std::vector<ScratchGFKey> &keys,
+    const std::vector<const void *> &tokens) {
+  assert(keys.size() == tokens.size());
+  UncertifiedScratchLevelManifest result{epoch, level, {}};
+  result.entries.reserve(keys.size());
+  for (std::size_t index = 0; index < keys.size(); ++index)
+    result.entries.push_back(ScratchGFManifestEntry{keys[index], tokens[index]});
+  return result;
+}
+
+void expect_prevalidation_rejection(
+    const UncertifiedScratchLevelManifest &invalid_manifest,
+    const std::vector<ScratchGFView> &invalid_views) {
+  amrex::MultiFab::reset_deep_copy_log();
+  const int live_before = amrex::MultiFab::owned_live_count();
+  expect_invalid_argument([&] {
+    static_cast<void>(
+        ScratchLevelFrame::copy_tl0(invalid_manifest, invalid_views));
+  });
+  assert(amrex::MultiFab::deep_copy_attempt_count() == 0);
+  assert(amrex::MultiFab::owned_live_count() == live_before);
+}
+
+void test_ordered_multi_patch_multi_group_copy_and_exact_metadata() {
+  amrex::Arena first_arena(11);
+  amrex::Arena second_arena(13);
+  auto first = make_source(&first_arena, 101, 17, 19, 2,
+                           amrex::IntVect(1, 2, 3));
+  auto second = make_source(&first_arena, 103, 23, 29, 1,
+                            amrex::IntVect(0, 4, 2));
+  auto third = make_source(&second_arena, 107, 31, 37, 3,
+                           amrex::IntVect(3, 1, 5));
+  populate(*first.multifab, 1000.0);
+  populate(*second.multifab, 2000.0);
+  populate(*third.multifab, 3000.0);
+
+  int first_token = 1;
+  int second_token = 2;
+  int third_token = 3;
+  const std::vector<ScratchGFKey> keys{key(41, 2, 0, 3), key(41, 2, 0, 8),
+                                       key(41, 2, 1, 2)};
+  const std::vector<const void *> tokens{&first_token, &second_token,
+                                         &third_token};
+  const auto supplied_manifest = manifest(41, 2, keys, tokens);
+  const std::vector<ScratchGFView> views{
+      view(keys[0], tokens[0], first), view(keys[1], tokens[1], second),
+      view(keys[2], tokens[2], third)};
+
+  amrex::MultiFab::reset_deep_copy_log();
+  const int live_before = amrex::MultiFab::owned_live_count();
+  {
+    auto frame = ScratchLevelFrame::copy_tl0(supplied_manifest, views);
+    assert(frame.hierarchy_epoch() == 41);
+    assert(frame.level() == 2);
+    assert(frame.entry_count() == 3);
+    assert(amrex::MultiFab::deep_copy_attempt_count() == 3);
+    assert(amrex::MultiFab::owned_live_count() == live_before + 3);
+
+    const std::array<const Source *, 3> sources{&first, &second, &third};
+    const std::array<amrex::TestRegion, 3> regions{
+        amrex::TestRegion::valid, amrex::TestRegion::outer,
+        amrex::TestRegion::ghosts};
+    for (std::size_t index = 0; index < sources.size(); ++index) {
+      const auto &source = *sources[index]->multifab;
+      const auto &owned = frame.multifab(index);
+      assert(same_key(frame.key(index), keys[index]));
+      assert(&owned != &source);
+      assert(owned.test_storage_address() != source.test_storage_address());
+      assert(owned.boxArray() == source.boxArray());
+      assert(owned.DistributionMap() == source.DistributionMap());
+      assert(owned.nComp() == source.nComp());
+      assert(owned.nGrowVect() == source.nGrowVect());
+      assert(owned.arena() == source.arena());
+      const auto *source_factory =
+          dynamic_cast<const amrex::TestFabFactory *>(&source.Factory());
+      const auto *owned_factory =
+          dynamic_cast<const amrex::TestFabFactory *>(&owned.Factory());
+      assert(source_factory != nullptr);
+      assert(owned_factory != nullptr);
+      assert(owned_factory != source_factory);
+      assert(owned_factory->setting() == source_factory->setting());
+      assert(frame.validity(index).size() == sources[index]->validity.size());
+      for (std::size_t component = 0;
+           component < sources[index]->validity.size(); ++component) {
+        assert(frame.validity(index)[component].interior ==
+               sources[index]->validity[component].interior);
+        assert(frame.validity(index)[component].outer ==
+               sources[index]->validity[component].outer);
+        assert(frame.validity(index)[component].ghosts ==
+               sources[index]->validity[component].ghosts);
+      }
+      for (const auto region : regions) {
+        for (int component = 0; component < source.nComp(); ++component) {
+          for (std::size_t cell = 0;
+               cell < amrex::MultiFab::test_cells_per_region(); ++cell) {
+            assert(owned.test_value(region, component, cell) ==
+                   source.test_value(region, component, cell));
+          }
+        }
+      }
+    }
+
+    frame.mutable_multifab(0).test_set(amrex::TestRegion::valid, 0, 0, -10.0);
+    frame.mutable_multifab(0).test_set(amrex::TestRegion::outer, 0, 0, -20.0);
+    frame.mutable_multifab(0).test_set(amrex::TestRegion::ghosts, 0, 0, -30.0);
+    assert(first.multifab->test_value(amrex::TestRegion::valid, 0, 0) ==
+           1000.0);
+    assert(first.multifab->test_value(amrex::TestRegion::outer, 0, 0) ==
+           1100.0);
+    assert(first.multifab->test_value(amrex::TestRegion::ghosts, 0, 0) ==
+           1200.0);
+
+    frame.mutable_validity(0)[0] = ScratchValidity{false, false, true};
+    assert(first.validity[0].interior);
+    assert(first.validity[0].outer);
+    assert(!first.validity[0].ghosts);
+  }
+  assert(amrex::MultiFab::owned_live_count() == live_before);
+}
+
+void test_manifest_errors_fail_before_first_deep_copy() {
+  amrex::Arena arena(17);
+  auto first = make_source(&arena, 1, 2, 3, 1, amrex::IntVect(1, 2, 3));
+  auto second = make_source(&arena, 2, 5, 7, 1, amrex::IntVect(2, 1, 4));
+  int token_a = 1;
+  int token_b = 2;
+  const auto first_key = key(41, 2, 0, 3);
+  const auto second_key = key(41, 2, 1, 4);
+  const std::vector<ScratchGFView> valid_views{
+      view(first_key, &token_a, first), view(second_key, &token_b, second)};
+
+  expect_prevalidation_rejection(manifest(-1, 2, {first_key}, {&token_a}),
+                                 {valid_views[0]});
+  expect_prevalidation_rejection(manifest(41, -1, {first_key}, {&token_a}),
+                                 {valid_views[0]});
+  expect_prevalidation_rejection(manifest(41, 2, {}, {}), {});
+
+  for (const auto &invalid_key :
+       std::vector<ScratchGFKey>{key(-1, 2, 0, 3), key(41, -1, 0, 3),
+                                 key(41, 2, -1, 3), key(41, 2, 0, -1),
+                                 key(42, 2, 0, 3), key(41, 3, 0, 3)}) {
+    expect_prevalidation_rejection(
+        manifest(41, 2, {invalid_key}, {&token_a}),
+        {ScratchGFView{invalid_key, 0, &token_a, first.multifab.get(),
+                       &first.validity}});
+  }
+
+  const auto later_group = key(41, 2, 0, 8);
+  const auto earlier_group = key(41, 2, 0, 3);
+  expect_prevalidation_rejection(
+      manifest(41, 2, {later_group, earlier_group}, {&token_a, &token_b}),
+      {view(later_group, &token_a, first),
+       view(earlier_group, &token_b, second)});
+  expect_prevalidation_rejection(
+      manifest(41, 2, {first_key, first_key}, {&token_a, &token_b}),
+      {view(first_key, &token_a, first), view(first_key, &token_b, second)});
+  expect_prevalidation_rejection(manifest(41, 2, {first_key}, {nullptr}),
+                                 {view(first_key, nullptr, first)});
+  expect_prevalidation_rejection(
+      manifest(41, 2, {first_key, second_key}, {&token_a, &token_a}),
+      {view(first_key, &token_a, first),
+       view(second_key, &token_a, second)});
+}
+
+void test_view_errors_fail_before_first_deep_copy() {
+  amrex::Arena arena(19);
+  auto first = make_source(&arena, 1, 2, 3, 1, amrex::IntVect(1, 2, 3));
+  auto second = make_source(&arena, 2, 5, 7, 2, amrex::IntVect(2, 1, 4));
+  auto third = make_source(&arena, 3, 11, 13, 1, amrex::IntVect(3, 2, 1));
+  int token_a = 1;
+  int token_b = 2;
+  int token_c = 3;
+  int wrong_token = 4;
+  const auto first_key = key(41, 2, 0, 3);
+  const auto second_key = key(41, 2, 0, 8);
+  const auto third_key = key(41, 2, 1, 2);
+  const auto two_manifest =
+      manifest(41, 2, {first_key, second_key}, {&token_a, &token_b});
+  const std::vector<ScratchGFView> valid_views{
+      view(first_key, &token_a, first), view(second_key, &token_b, second)};
+
+  expect_prevalidation_rejection(two_manifest, {valid_views[0]});
+  expect_prevalidation_rejection(
+      two_manifest,
+      {valid_views[0], valid_views[1], view(third_key, &token_c, third)});
+
+  auto invalid_views = valid_views;
+  invalid_views[1].key = key(41, 2, 1, 8);
+  expect_prevalidation_rejection(two_manifest, invalid_views);
+  invalid_views = valid_views;
+  invalid_views[1].source_storage_identity = &wrong_token;
+  expect_prevalidation_rejection(two_manifest, invalid_views);
+  invalid_views = valid_views;
+  invalid_views[1].time_level = 1;
+  expect_prevalidation_rejection(two_manifest, invalid_views);
+  invalid_views = valid_views;
+  invalid_views[1].multifab = nullptr;
+  expect_prevalidation_rejection(two_manifest, invalid_views);
+  invalid_views = valid_views;
+  invalid_views[1].multifab = first.multifab.get();
+  expect_prevalidation_rejection(two_manifest, invalid_views);
+  invalid_views = valid_views;
+  invalid_views[1].validity = nullptr;
+  expect_prevalidation_rejection(two_manifest, invalid_views);
+  invalid_views = valid_views;
+  invalid_views[1].validity = &first.validity;
+  expect_prevalidation_rejection(two_manifest, invalid_views);
+
+  auto undefined =
+      make_source(&arena, 5, 17, 19, 1, amrex::IntVect(1), false);
+  expect_prevalidation_rejection(manifest(41, 2, {first_key}, {&token_a}),
+                                 {view(first_key, &token_a, undefined)});
+  auto zero_components =
+      make_source(&arena, 7, 23, 29, 0, amrex::IntVect(1));
+  expect_prevalidation_rejection(manifest(41, 2, {first_key}, {&token_a}),
+                                 {view(first_key, &token_a, zero_components)});
+  auto bad_validity =
+      make_source(&arena, 11, 31, 37, 2, amrex::IntVect(1));
+  bad_validity.validity.pop_back();
+  expect_prevalidation_rejection(manifest(41, 2, {first_key}, {&token_a}),
+                                 {view(first_key, &token_a, bad_validity)});
+}
+
+void test_distinct_alias_wrappers_with_one_storage_token_are_rejected() {
+  amrex::Arena arena(23);
+  auto first_wrapper =
+      make_source(&arena, 1, 2, 3, 1, amrex::IntVect(1, 2, 3));
+  auto second_wrapper =
+      make_source(&arena, 1, 2, 3, 1, amrex::IntVect(1, 2, 3));
+  assert(first_wrapper.multifab.get() != second_wrapper.multifab.get());
+  int canonical_storage_token = 1;
+  const auto first_key = key(41, 2, 0, 3);
+  const auto second_key = key(41, 2, 0, 8);
+  expect_prevalidation_rejection(
+      manifest(41, 2, {first_key, second_key},
+               {&canonical_storage_token, &canonical_storage_token}),
+      {view(first_key, &canonical_storage_token, first_wrapper),
+       view(second_key, &canonical_storage_token, second_wrapper)});
+}
+
+void test_late_invalid_last_view_prevalidates_the_complete_batch() {
+  amrex::Arena arena(29);
+  auto first = make_source(&arena, 1, 2, 3, 1, amrex::IntVect(1));
+  auto second = make_source(&arena, 2, 5, 7, 1, amrex::IntVect(2));
+  auto third = make_source(&arena, 3, 11, 13, 2, amrex::IntVect(3));
+  third.validity.pop_back();
+  int token_a = 1;
+  int token_b = 2;
+  int token_c = 3;
+  const auto first_key = key(41, 2, 0, 3);
+  const auto second_key = key(41, 2, 0, 8);
+  const auto third_key = key(41, 2, 1, 2);
+  expect_prevalidation_rejection(
+      manifest(41, 2, {first_key, second_key, third_key},
+               {&token_a, &token_b, &token_c}),
+      {view(first_key, &token_a, first), view(second_key, &token_b, second),
+       view(third_key, &token_c, third)});
+}
+
+void test_first_and_later_deep_copy_exceptions_roll_back_owned_entries() {
+  amrex::Arena arena(31);
+  auto first = make_source(&arena, 1, 2, 3, 1, amrex::IntVect(1));
+  auto second = make_source(&arena, 2, 5, 7, 1, amrex::IntVect(2));
+  auto third = make_source(&arena, 3, 11, 13, 1, amrex::IntVect(3));
+  int token_a = 1;
+  int token_b = 2;
+  int token_c = 3;
+  const auto first_key = key(41, 2, 0, 3);
+  const auto second_key = key(41, 2, 0, 8);
+  const auto third_key = key(41, 2, 1, 2);
+  const auto supplied_manifest =
+      manifest(41, 2, {first_key, second_key, third_key},
+               {&token_a, &token_b, &token_c});
+  const std::vector<ScratchGFView> views{
+      view(first_key, &token_a, first), view(second_key, &token_b, second),
+      view(third_key, &token_c, third)};
+  const int live_before = amrex::MultiFab::owned_live_count();
+
+  amrex::MultiFab::reset_deep_copy_log();
+  amrex::MultiFab::fail_deep_copy_after(0);
+  expect_runtime_error([&] {
+    static_cast<void>(ScratchLevelFrame::copy_tl0(supplied_manifest, views));
+  });
+  assert(amrex::MultiFab::deep_copy_attempt_count() == 1);
+  assert(amrex::MultiFab::owned_live_count() == live_before);
+
+  amrex::MultiFab::reset_deep_copy_log();
+  amrex::MultiFab::fail_deep_copy_after(1);
+  expect_runtime_error([&] {
+    static_cast<void>(ScratchLevelFrame::copy_tl0(supplied_manifest, views));
+  });
+  assert(amrex::MultiFab::deep_copy_attempt_count() == 2);
+  assert(amrex::MultiFab::owned_live_count() == live_before);
+  amrex::MultiFab::reset_deep_copy_log();
+}
+
+ScratchLevelFrame make_single_entry_frame(const std::int64_t epoch,
+                                          const int level,
+                                          const double value) {
+  amrex::Arena arena(37);
+  auto source = make_source(&arena, 41, 43, 47, 1, amrex::IntVect(1, 2, 3));
+  populate(*source.multifab, value);
+  int token = 1;
+  const auto entry_key = key(epoch, level, 0, 3);
+  return ScratchLevelFrame::copy_tl0(
+      manifest(epoch, level, {entry_key}, {&token}),
+      {view(entry_key, &token, source)});
+}
+
+void assert_moved_from(const ScratchLevelFrame &frame) {
+  assert(frame.hierarchy_epoch() == -1);
+  assert(frame.level() == -1);
+  assert(frame.entry_count() == 0);
+  expect_out_of_range([&] { static_cast<void>(frame.key(0)); });
+  expect_out_of_range([&] { static_cast<void>(frame.multifab(0)); });
+  expect_out_of_range([&] { static_cast<void>(frame.validity(0)); });
+}
+
+void test_move_construction_assignment_self_move_and_bounds() {
+  const int live_before = amrex::MultiFab::owned_live_count();
+  {
+    auto source = make_single_entry_frame(51, 4, 7000.0);
+    auto moved = ScratchLevelFrame(std::move(source));
+    assert_moved_from(source);
+    assert(moved.hierarchy_epoch() == 51);
+    assert(moved.level() == 4);
+    assert(moved.entry_count() == 1);
+    assert(moved.multifab(0).test_value(amrex::TestRegion::valid, 0, 0) ==
+           7000.0);
+
+    const void *storage_before_self_move =
+        moved.multifab(0).test_storage_address();
+    auto *self_alias = &moved;
+    moved = std::move(*self_alias);
+    assert(moved.hierarchy_epoch() == 51);
+    assert(moved.level() == 4);
+    assert(moved.entry_count() == 1);
+    assert(moved.multifab(0).test_storage_address() == storage_before_self_move);
+
+    auto assignment_source = make_single_entry_frame(61, 5, 8000.0);
+    moved = std::move(assignment_source);
+    assert_moved_from(assignment_source);
+    assert(moved.hierarchy_epoch() == 61);
+    assert(moved.level() == 5);
+    assert(moved.entry_count() == 1);
+    assert(moved.multifab(0).test_value(amrex::TestRegion::ghosts, 0, 1) ==
+           8201.0);
+
+    expect_out_of_range([&] { static_cast<void>(moved.key(1)); });
+    expect_out_of_range([&] { static_cast<void>(moved.multifab(1)); });
+    expect_out_of_range(
+        [&] { static_cast<void>(moved.mutable_multifab(1)); });
+    expect_out_of_range([&] { static_cast<void>(moved.validity(1)); });
+    expect_out_of_range(
+        [&] { static_cast<void>(moved.mutable_validity(1)); });
+  }
+  assert(amrex::MultiFab::owned_live_count() == live_before);
+}
+
+} // namespace
+
+int main() {
+  test_ordered_multi_patch_multi_group_copy_and_exact_metadata();
+  test_manifest_errors_fail_before_first_deep_copy();
+  test_view_errors_fail_before_first_deep_copy();
+  test_distinct_alias_wrappers_with_one_storage_token_are_rejected();
+  test_late_invalid_last_view_prevalidates_the_complete_batch();
+  test_first_and_later_deep_copy_exceptions_roll_back_owned_entries();
+  test_move_construction_assignment_self_move_and_bounds();
+  std::cout << "Scratch level-state ownership tests passed\n";
+  return 0;
+}

--- a/CarpetX/test/subcycling_stage_spatial_preparer_unit.cxx
+++ b/CarpetX/test/subcycling_stage_spatial_preparer_unit.cxx
@@ -1,0 +1,236 @@
+#include "subcycling_stage_spatial_preparer.hxx"
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+using namespace CarpetX;
+
+template <typename Exception = std::exception, typename Function>
+void expect_throw(Function &&function) {
+  bool threw = false;
+  try {
+    function();
+  } catch (const Exception &) {
+    threw = true;
+  }
+  assert(threw);
+}
+
+TableauFingerprint fingerprint() {
+  TableauFingerprint value{};
+  value.fill(9);
+  return value;
+}
+
+class ScalarState final : public DenseStateVector {
+public:
+  explicit ScalarState(const double value) : value_(value) {}
+
+  bool compatible(const DenseStateVector &other) const noexcept override {
+    return dynamic_cast<const ScalarState *>(&other) != nullptr;
+  }
+
+  void copy_from(const DenseStateVector &other) override {
+    value_ = dynamic_cast<const ScalarState &>(other).value_;
+  }
+
+  void linear_combination(
+      const std::vector<double> &weights,
+      const std::vector<const DenseStateVector *> &sources) override {
+    value_ = 0.0;
+    for (std::size_t i = 0; i < weights.size(); ++i)
+      value_ += weights[i] *
+                dynamic_cast<const ScalarState &>(*sources[i]).value_;
+  }
+
+private:
+  double value_;
+};
+
+std::shared_ptr<const DenseInterval> parent_interval() {
+  const auto table = fingerprint();
+  const DenseCapability capability{SubcyclingODEMethod::rk4, table, 4, 4,
+                                   4, 4, 5, true, true};
+  DenseIntervalBuilder builder(
+      capability,
+      DenseIntervalId{0, step_clock_t(0), step_clock_t(1), 10.0, 14.0,
+                      SubcyclingODEMethod::rk4, table});
+  for (int control = 0; control < 5; ++control)
+    builder.add_control(std::make_unique<ScalarState>(control));
+  return builder.seal();
+}
+
+StepContext level_context(const int level) {
+  return StepContext{level, step_clock_t(0), step_clock_t(1), 10.0, 14.0,
+                     SubcyclingODEMethod::rk4};
+}
+
+StagePoint stage(const StageKind kind, const step_clock_t fraction,
+                 const double time, const int index = 1,
+                 const int count = 1) {
+  return StagePoint{kind, index, count, fraction, time};
+}
+
+void test_primary_level_zero_prepares_live_then_promotes() {
+  TwoLevelStageSpatialPreparer::TestBackend backend;
+  backend.metadata.level = 0;
+  backend.metadata.level_count = 2;
+  backend.metadata.evolved_group_count = 3;
+  auto preparer = TwoLevelStageSpatialPreparer::create_for_test(backend);
+
+  const auto receipt = preparer.prepare_for_test(
+      level_context(0), stage(StageKind::primary, step_clock_t(1, 2), 12.0),
+      nullptr);
+
+  assert(receipt.target == StageSpatialTarget::primary_live_tl0);
+  assert(receipt.patch == 0);
+  assert(receipt.level == 0);
+  assert(receipt.stage_clock == step_clock_t(1, 2));
+  assert(!receipt.parent_theta.has_value());
+  assert(receipt.evolved_group_count == 3);
+  assert((backend.events == std::vector<std::string>{"prepare L0 live",
+                                                      "promote live"}));
+  assert(backend.fault_calls == 0);
+}
+
+void test_fractional_level_one_uses_exact_parent_theta_and_scratch() {
+  TwoLevelStageSpatialPreparer::TestBackend backend;
+  backend.metadata.level = 1;
+  backend.metadata.level_count = 2;
+  backend.metadata.evolved_group_count = 2;
+  auto preparer = TwoLevelStageSpatialPreparer::create_for_test(backend);
+  const auto parent = parent_interval();
+
+  const auto receipt = preparer.prepare_for_test(
+      level_context(1),
+      stage(StageKind::fractional, step_clock_t(1, 4), 11.0, 2, 4),
+      parent.get());
+
+  assert(receipt.target == StageSpatialTarget::transaction_scratch);
+  assert(receipt.level == 1);
+  assert(receipt.stage_clock == step_clock_t(1, 4));
+  assert(receipt.parent_theta == step_clock_t(1, 4));
+  assert(backend.observed_parent_theta == step_clock_t(1, 4));
+  assert((backend.events ==
+          std::vector<std::string>{"prepare L1 scratch theta=1/4",
+                                   "promote scratch"}));
+  assert(backend.fault_calls == 0);
+}
+
+void test_endpoint_probe_is_transaction_private_scratch() {
+  TwoLevelStageSpatialPreparer::TestBackend backend;
+  backend.metadata.level = 0;
+  auto preparer = TwoLevelStageSpatialPreparer::create_for_test(backend);
+
+  const auto receipt = preparer.prepare_for_test(
+      level_context(0),
+      stage(StageKind::endpoint_probe, step_clock_t(1), 14.0), nullptr);
+
+  assert(receipt.target == StageSpatialTarget::transaction_scratch);
+  assert((backend.events == std::vector<std::string>{"prepare L0 scratch",
+                                                      "promote scratch"}));
+}
+
+void test_preflight_failures_do_not_prepare_or_promote_and_fault_once() {
+  struct Case {
+    int patch_count{1};
+    int level_count{2};
+    int ratio{2};
+    std::int64_t observed_epoch{7};
+    bool ownership_conflict{false};
+    bool provide_parent{true};
+  };
+  const std::vector<Case> cases{
+      Case{2, 2, 2, 7, false, true},
+      Case{1, 3, 2, 7, false, true},
+      Case{1, 2, 4, 7, false, true},
+      Case{1, 2, 2, 8, false, true},
+      Case{1, 2, 2, 7, true, true},
+      Case{1, 2, 2, 7, false, false},
+  };
+
+  for (const auto &test : cases) {
+    TwoLevelStageSpatialPreparer::TestBackend backend;
+    backend.metadata.patch_count = test.patch_count;
+    backend.metadata.level_count = test.level_count;
+    backend.metadata.spatial_refinement_ratio = test.ratio;
+    backend.metadata.level = 1;
+    backend.metadata.transaction_epoch = 7;
+    backend.metadata.observed_epoch = test.observed_epoch;
+    backend.metadata.global_sync_ownership_conflict =
+        test.ownership_conflict;
+    auto preparer = TwoLevelStageSpatialPreparer::create_for_test(backend);
+    const auto parent = parent_interval();
+
+    expect_throw([&] {
+      preparer.prepare_for_test(
+          level_context(1),
+          stage(StageKind::fractional, step_clock_t(1, 4), 11.0, 2, 4),
+          test.provide_parent ? parent.get() : nullptr);
+    });
+    assert(backend.prepare_calls == 0);
+    assert(backend.promote_calls == 0);
+    assert(backend.fault_calls == 1);
+  }
+}
+
+void test_fill_failure_never_promotes_validity_and_faults_once() {
+  TwoLevelStageSpatialPreparer::TestBackend backend;
+  backend.metadata.level = 0;
+  backend.throw_during_prepare = true;
+  auto preparer = TwoLevelStageSpatialPreparer::create_for_test(backend);
+
+  expect_throw<std::runtime_error>([&] {
+    preparer.prepare_for_test(
+        level_context(0),
+        stage(StageKind::fractional, step_clock_t(1, 2), 12.0), nullptr);
+  });
+
+  assert(backend.prepare_calls == 1);
+  assert(backend.promote_calls == 0);
+  assert(backend.fault_calls == 1);
+  assert((backend.events == std::vector<std::string>{"prepare L0 scratch",
+                                                      "fault"}));
+}
+
+void test_metadata_and_stage_drift_fail_closed() {
+  TwoLevelStageSpatialPreparer::TestBackend backend;
+  backend.metadata.level = 0;
+  auto preparer = TwoLevelStageSpatialPreparer::create_for_test(backend);
+
+  expect_throw([&] {
+    preparer.prepare_for_test(
+        level_context(1), stage(StageKind::primary, step_clock_t(0), 10.0),
+        nullptr);
+  });
+  assert(backend.fault_calls == 1);
+
+  TwoLevelStageSpatialPreparer::TestBackend bad_time;
+  bad_time.metadata.level = 0;
+  auto bad_time_preparer =
+      TwoLevelStageSpatialPreparer::create_for_test(bad_time);
+  expect_throw([&] {
+    bad_time_preparer.prepare_for_test(
+        level_context(0),
+        stage(StageKind::primary, step_clock_t(1, 2), 12.25), nullptr);
+  });
+  assert(bad_time.fault_calls == 1);
+}
+
+} // namespace
+
+int main() {
+  test_primary_level_zero_prepares_live_then_promotes();
+  test_fractional_level_one_uses_exact_parent_theta_and_scratch();
+  test_endpoint_probe_is_transaction_private_scratch();
+  test_preflight_failures_do_not_prepare_or_promote_and_fault_once();
+  test_fill_failure_never_promotes_validity_and_faults_once();
+  test_metadata_and_stage_drift_fail_closed();
+  std::cout << "subcycling stage spatial preparer unit tests passed\n";
+}

--- a/CarpetX/test/subcycling_static_v1_top_adapter_unit.cxx
+++ b/CarpetX/test/subcycling_static_v1_top_adapter_unit.cxx
@@ -66,6 +66,14 @@ void test_static_policy_fails_closed_before_runtime_mutation() {
 
   policy = valid_policy();
   policy.recovering = true;
+  policy.root_iteration_zero = false;
+  validate_static_v1_policy_envelope(policy);
+
+  policy.level_clocks_zero = false;
+  rejects([&] { validate_static_v1_policy_envelope(policy); });
+
+  policy = valid_policy();
+  policy.root_iteration_zero = false;
   rejects([&] { validate_static_v1_policy_envelope(policy); });
 
   policy = valid_policy();
@@ -170,17 +178,37 @@ void test_static_v1_stops_initial_regrid_after_one_l1_creation() {
 }
 
 void test_active_thorn_gate_is_an_exact_whitelist() {
-  std::vector<std::string> active{
+  const std::vector<std::string> p1_active{
       "zlib",          "AMReX",       "TestODESolvers2", "CarpetX",
       "CarpetXRegrid", "Cactus",      "Arith",            "BoxInBox",
       "IOUtil",        "Loop",        "MPI",              "NSIMD",
       "ODESolvers",    "yaml_cpp"};
-  assert(has_exact_static_v1_test_odesolvers2_active_thorns(active));
-  active.push_back("ADMBase");
-  assert(!has_exact_static_v1_test_odesolvers2_active_thorns(active));
-  active.pop_back();
-  active.pop_back();
-  assert(!has_exact_static_v1_test_odesolvers2_active_thorns(active));
+  assert(has_exact_static_v1_test_odesolvers2_active_thorns(p1_active));
+
+  auto p2_checkpoint_active = p1_active;
+  p2_checkpoint_active.push_back("HDF5");
+  p2_checkpoint_active.push_back("Silo");
+  assert(has_exact_static_v1_test_odesolvers2_active_thorns(
+      p2_checkpoint_active));
+
+  auto one_backend_only = p1_active;
+  one_backend_only.push_back("HDF5");
+  assert(!has_exact_static_v1_test_odesolvers2_active_thorns(
+      one_backend_only));
+  one_backend_only.back() = "Silo";
+  assert(!has_exact_static_v1_test_odesolvers2_active_thorns(
+      one_backend_only));
+
+  auto unrelated_extra = p2_checkpoint_active;
+  unrelated_extra.push_back("ADMBase");
+  assert(!has_exact_static_v1_test_odesolvers2_active_thorns(
+      unrelated_extra));
+
+  auto missing_required = p2_checkpoint_active;
+  missing_required.erase(
+      std::find(missing_required.begin(), missing_required.end(), "MPI"));
+  assert(!has_exact_static_v1_test_odesolvers2_active_thorns(
+      missing_required));
 }
 
 void test_active_level_history_rotates_once_before_tl0_capture() {

--- a/CarpetX/test/subcycling_static_v1_top_adapter_unit.cxx
+++ b/CarpetX/test/subcycling_static_v1_top_adapter_unit.cxx
@@ -14,6 +14,7 @@ using CarpetX::RuntimeClockMetadata;
 using CarpetX::StaticV1EvolvePath;
 using CarpetX::StaticV1LevelOneCreationEnvelope;
 using CarpetX::StaticV1PolicyEnvelope;
+using CarpetX::StaticV1Rational;
 using CarpetX::StaticV1SyncObserverAction;
 using CarpetX::StepContext;
 using CarpetX::SubcyclingODEMethod;
@@ -22,6 +23,7 @@ using CarpetX::cycle_then_capture_static_v1_level_state;
 using CarpetX::has_exact_static_v1_test_odesolvers2_active_thorns;
 using CarpetX::permits_static_v1_level_one_creation;
 using CarpetX::select_static_v1_evolve_path;
+using CarpetX::static_v1_parent_refinement_ratio_index;
 using CarpetX::should_stop_static_v1_initial_regrid_loop;
 using CarpetX::static_v1_sync_observer_order;
 using CarpetX::step_clock_t;
@@ -43,7 +45,9 @@ StaticV1PolicyEnvelope valid_policy() {
 }
 
 StaticV1LevelOneCreationEnvelope valid_level_one_creation() {
-  return {true, 1, 0, 1, 2, 1, 0, 0, 0, 0, 1, false, {2, 2, 2}, 0.0};
+  return {true, 1, 0, 1, 2, 1, 0, 0, 0,
+          StaticV1Rational{0, 1}, StaticV1Rational{1, 1}, false,
+          {2, 2, 2}, 0.0};
 }
 
 void test_legacy_selection_is_a_strict_false_branch() {
@@ -117,11 +121,19 @@ void test_static_v1_level_one_creation_envelope_is_exact() {
   assert(!permits_static_v1_level_one_creation(envelope));
 
   envelope = valid_level_one_creation();
-  envelope.coarse_iteration = 1;
+  envelope.coarse_iteration = {1, 1};
   assert(!permits_static_v1_level_one_creation(envelope));
 
   envelope = valid_level_one_creation();
-  envelope.coarse_delta_iteration = 2;
+  envelope.coarse_delta_iteration = {2, 1};
+  assert(!permits_static_v1_level_one_creation(envelope));
+
+  envelope = valid_level_one_creation();
+  envelope.coarse_iteration = {1, 2};
+  assert(!permits_static_v1_level_one_creation(envelope));
+
+  envelope = valid_level_one_creation();
+  envelope.coarse_delta_iteration = {3, 2};
   assert(!permits_static_v1_level_one_creation(envelope));
 
   envelope = valid_level_one_creation();
@@ -129,7 +141,15 @@ void test_static_v1_level_one_creation_envelope_is_exact() {
   assert(!permits_static_v1_level_one_creation(envelope));
 
   envelope = valid_level_one_creation();
+  envelope.spatial_refinement_ratio = {1, 2, 2};
+  assert(!permits_static_v1_level_one_creation(envelope));
+
+  envelope = valid_level_one_creation();
   envelope.spatial_refinement_ratio = {2, 1, 2};
+  assert(!permits_static_v1_level_one_creation(envelope));
+
+  envelope = valid_level_one_creation();
+  envelope.spatial_refinement_ratio = {2, 2, 1};
   assert(!permits_static_v1_level_one_creation(envelope));
 
   envelope = valid_level_one_creation();
@@ -137,9 +157,15 @@ void test_static_v1_level_one_creation_envelope_is_exact() {
   assert(!permits_static_v1_level_one_creation(envelope));
 }
 
+void test_static_v1_level_one_uses_the_parent_refinement_ratio() {
+  assert(static_v1_parent_refinement_ratio_index(1) == 0);
+}
+
 void test_static_v1_stops_initial_regrid_after_one_l1_creation() {
   assert(should_stop_static_v1_initial_regrid_loop(true, 1, 2, 2));
   assert(!should_stop_static_v1_initial_regrid_loop(false, 1, 2, 2));
+  assert(!should_stop_static_v1_initial_regrid_loop(true, 2, 2, 2));
+  assert(!should_stop_static_v1_initial_regrid_loop(true, 1, 3, 2));
   assert(!should_stop_static_v1_initial_regrid_loop(true, 1, 2, 1));
 }
 
@@ -206,6 +232,7 @@ int main() {
   test_legacy_selection_is_a_strict_false_branch();
   test_static_policy_fails_closed_before_runtime_mutation();
   test_static_v1_level_one_creation_envelope_is_exact();
+  test_static_v1_level_one_uses_the_parent_refinement_ratio();
   test_static_v1_stops_initial_regrid_after_one_l1_creation();
   test_active_thorn_gate_is_an_exact_whitelist();
   test_active_level_history_rotates_once_before_tl0_capture();

--- a/CarpetX/test/subcycling_static_v1_top_adapter_unit.cxx
+++ b/CarpetX/test/subcycling_static_v1_top_adapter_unit.cxx
@@ -12,6 +12,7 @@ namespace {
 
 using CarpetX::RuntimeClockMetadata;
 using CarpetX::StaticV1EvolvePath;
+using CarpetX::StaticV1LevelOneCreationEnvelope;
 using CarpetX::StaticV1PolicyEnvelope;
 using CarpetX::StaticV1SyncObserverAction;
 using CarpetX::StepContext;
@@ -19,7 +20,9 @@ using CarpetX::SubcyclingODEMethod;
 using CarpetX::candidate_runtime_clock;
 using CarpetX::cycle_then_capture_static_v1_level_state;
 using CarpetX::has_exact_static_v1_test_odesolvers2_active_thorns;
+using CarpetX::permits_static_v1_level_one_creation;
 using CarpetX::select_static_v1_evolve_path;
+using CarpetX::should_stop_static_v1_initial_regrid_loop;
 using CarpetX::static_v1_sync_observer_order;
 using CarpetX::step_clock_t;
 using CarpetX::validate_static_v1_policy_envelope;
@@ -37,6 +40,10 @@ template <class Function> void rejects(Function &&function) {
 StaticV1PolicyEnvelope valid_policy() {
   return {1, 2, 2, 0, false, false, true, false, false,
           true, true, true, true, true, true};
+}
+
+StaticV1LevelOneCreationEnvelope valid_level_one_creation() {
+  return {true, 1, 0, 1, 2, 1, 0, 0, 0, 0, 1, false, {2, 2, 2}, 0.0};
 }
 
 void test_legacy_selection_is_a_strict_false_branch() {
@@ -68,6 +75,72 @@ void test_static_policy_fails_closed_before_runtime_mutation() {
   policy = valid_policy();
   policy.bounded_test_odesolvers2_configuration = false;
   rejects([&] { validate_static_v1_policy_envelope(policy); });
+}
+
+void test_static_v1_level_one_creation_envelope_is_exact() {
+  assert(permits_static_v1_level_one_creation(valid_level_one_creation()));
+
+  auto envelope = valid_level_one_creation();
+  envelope.subcycling_enabled = false;
+  assert(!permits_static_v1_level_one_creation(envelope));
+
+  envelope = valid_level_one_creation();
+  envelope.configured_patch_count = 2;
+  assert(!permits_static_v1_level_one_creation(envelope));
+
+  envelope = valid_level_one_creation();
+  envelope.callback_patch = 1;
+  assert(!permits_static_v1_level_one_creation(envelope));
+
+  envelope = valid_level_one_creation();
+  envelope.callback_level = 0;
+  assert(!permits_static_v1_level_one_creation(envelope));
+
+  envelope = valid_level_one_creation();
+  envelope.configured_level_count = 3;
+  assert(!permits_static_v1_level_one_creation(envelope));
+
+  envelope = valid_level_one_creation();
+  envelope.existing_level_count = 0;
+  assert(!permits_static_v1_level_one_creation(envelope));
+
+  envelope = valid_level_one_creation();
+  envelope.regrid_every = 1;
+  assert(!permits_static_v1_level_one_creation(envelope));
+
+  envelope = valid_level_one_creation();
+  envelope.coarse_patch = 1;
+  assert(!permits_static_v1_level_one_creation(envelope));
+
+  envelope = valid_level_one_creation();
+  envelope.coarse_level = 1;
+  assert(!permits_static_v1_level_one_creation(envelope));
+
+  envelope = valid_level_one_creation();
+  envelope.coarse_iteration = 1;
+  assert(!permits_static_v1_level_one_creation(envelope));
+
+  envelope = valid_level_one_creation();
+  envelope.coarse_delta_iteration = 2;
+  assert(!permits_static_v1_level_one_creation(envelope));
+
+  envelope = valid_level_one_creation();
+  envelope.coarse_is_subcycling_level = true;
+  assert(!permits_static_v1_level_one_creation(envelope));
+
+  envelope = valid_level_one_creation();
+  envelope.spatial_refinement_ratio = {2, 1, 2};
+  assert(!permits_static_v1_level_one_creation(envelope));
+
+  envelope = valid_level_one_creation();
+  envelope.callback_time = 0.5;
+  assert(!permits_static_v1_level_one_creation(envelope));
+}
+
+void test_static_v1_stops_initial_regrid_after_one_l1_creation() {
+  assert(should_stop_static_v1_initial_regrid_loop(true, 1, 2, 2));
+  assert(!should_stop_static_v1_initial_regrid_loop(false, 1, 2, 2));
+  assert(!should_stop_static_v1_initial_regrid_loop(true, 1, 2, 1));
 }
 
 void test_active_thorn_gate_is_an_exact_whitelist() {
@@ -132,6 +205,8 @@ void test_sync_observer_order_is_exact() {
 int main() {
   test_legacy_selection_is_a_strict_false_branch();
   test_static_policy_fails_closed_before_runtime_mutation();
+  test_static_v1_level_one_creation_envelope_is_exact();
+  test_static_v1_stops_initial_regrid_after_one_l1_creation();
   test_active_thorn_gate_is_an_exact_whitelist();
   test_active_level_history_rotates_once_before_tl0_capture();
   test_candidate_mapping_uses_endpoint_iterations_without_preincrement();

--- a/CarpetX/test/subcycling_static_v1_top_adapter_unit.cxx
+++ b/CarpetX/test/subcycling_static_v1_top_adapter_unit.cxx
@@ -1,0 +1,140 @@
+#include "../src/subcycling_runtime_clock.hxx"
+#include "../src/subcycling_static_v1_contract.hxx"
+
+#include <array>
+#include <cassert>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using CarpetX::RuntimeClockMetadata;
+using CarpetX::StaticV1EvolvePath;
+using CarpetX::StaticV1PolicyEnvelope;
+using CarpetX::StaticV1SyncObserverAction;
+using CarpetX::StepContext;
+using CarpetX::SubcyclingODEMethod;
+using CarpetX::candidate_runtime_clock;
+using CarpetX::cycle_then_capture_static_v1_level_state;
+using CarpetX::has_exact_static_v1_test_odesolvers2_active_thorns;
+using CarpetX::select_static_v1_evolve_path;
+using CarpetX::static_v1_sync_observer_order;
+using CarpetX::step_clock_t;
+using CarpetX::validate_static_v1_policy_envelope;
+
+template <class Function> void rejects(Function &&function) {
+  bool rejected = false;
+  try {
+    function();
+  } catch (const std::invalid_argument &) {
+    rejected = true;
+  }
+  assert(rejected);
+}
+
+StaticV1PolicyEnvelope valid_policy() {
+  return {1, 2, 2, 0, false, false, true, false, false,
+          true, true, true, true, true, true};
+}
+
+void test_legacy_selection_is_a_strict_false_branch() {
+  assert(select_static_v1_evolve_path(false) ==
+         StaticV1EvolvePath::legacy);
+  assert(select_static_v1_evolve_path(true) ==
+         StaticV1EvolvePath::static_v1);
+}
+
+void test_static_policy_fails_closed_before_runtime_mutation() {
+  validate_static_v1_policy_envelope(valid_policy());
+
+  auto policy = valid_policy();
+  policy.patch_count = 2;
+  rejects([&] { validate_static_v1_policy_envelope(policy); });
+
+  policy = valid_policy();
+  policy.recovering = true;
+  rejects([&] { validate_static_v1_policy_envelope(policy); });
+
+  policy = valid_policy();
+  policy.restrict_during_sync = true;
+  rejects([&] { validate_static_v1_policy_envelope(policy); });
+
+  policy = valid_policy();
+  policy.complete_method_schema = false;
+  rejects([&] { validate_static_v1_policy_envelope(policy); });
+
+  policy = valid_policy();
+  policy.bounded_test_odesolvers2_configuration = false;
+  rejects([&] { validate_static_v1_policy_envelope(policy); });
+}
+
+void test_active_thorn_gate_is_an_exact_whitelist() {
+  std::vector<std::string> active{
+      "zlib",          "AMReX",       "TestODESolvers2", "CarpetX",
+      "CarpetXRegrid", "Cactus",      "Arith",            "BoxInBox",
+      "IOUtil",        "Loop",        "MPI",              "NSIMD",
+      "ODESolvers",    "yaml_cpp"};
+  assert(has_exact_static_v1_test_odesolvers2_active_thorns(active));
+  active.push_back("ADMBase");
+  assert(!has_exact_static_v1_test_odesolvers2_active_thorns(active));
+  active.pop_back();
+  active.pop_back();
+  assert(!has_exact_static_v1_test_odesolvers2_active_thorns(active));
+}
+
+void test_active_level_history_rotates_once_before_tl0_capture() {
+  std::vector<int> events;
+  const int captured = cycle_then_capture_static_v1_level_state(
+      [&] { events.push_back(1); },
+      [&] {
+        events.push_back(2);
+        return 17;
+      });
+  assert(captured == 17);
+  assert((events == std::vector<int>{1, 2}));
+}
+
+void test_candidate_mapping_uses_endpoint_iterations_without_preincrement() {
+  const StepContext coarse{0, step_clock_t(0), step_clock_t(1), 4.0, 4.5,
+                           SubcyclingODEMethod::rk4, true, 1};
+  const StepContext fine_first{1, step_clock_t(0), step_clock_t(1, 2), 4.0,
+                               4.25, SubcyclingODEMethod::rk4, false, 1};
+  const StepContext fine_second{1, step_clock_t(1, 2), step_clock_t(1), 4.25,
+                                4.5, SubcyclingODEMethod::rk4, false, 2};
+
+  const RuntimeClockMetadata coarse_clock =
+      candidate_runtime_clock(coarse, 0.5);
+  const RuntimeClockMetadata fine_first_clock =
+      candidate_runtime_clock(fine_first, 0.5);
+  const RuntimeClockMetadata fine_second_clock =
+      candidate_runtime_clock(fine_second, 0.5);
+
+  assert(coarse_clock.iteration == 1 && coarse_clock.timefac == 1);
+  assert(fine_first_clock.iteration == 1 && fine_first_clock.timefac == 2);
+  assert(fine_second_clock.iteration == 2 && fine_second_clock.timefac == 2);
+}
+
+void test_sync_observer_order_is_exact() {
+  constexpr auto order = static_v1_sync_observer_order();
+  static_assert(order[0] ==
+                StaticV1SyncObserverAction::cycle_synchronized_globals);
+  static_assert(order[1] == StaticV1SyncObserverAction::postrestrict);
+  static_assert(order[2] == StaticV1SyncObserverAction::poststep);
+  static_assert(order[3] == StaticV1SyncObserverAction::analysis);
+  static_assert(order[4] == StaticV1SyncObserverAction::output);
+  static_assert(order[5] == StaticV1SyncObserverAction::checkpoint);
+}
+
+} // namespace
+
+int main() {
+  test_legacy_selection_is_a_strict_false_branch();
+  test_static_policy_fails_closed_before_runtime_mutation();
+  test_active_thorn_gate_is_an_exact_whitelist();
+  test_active_level_history_rotates_once_before_tl0_capture();
+  test_candidate_mapping_uses_endpoint_iterations_without_preincrement();
+  test_sync_observer_order_is_exact();
+  std::cout << "subcycling_static_v1_top_adapter_unit: PASS\n";
+}

--- a/CarpetX/test/subcycling_step_context_unit.cxx
+++ b/CarpetX/test/subcycling_step_context_unit.cxx
@@ -1,0 +1,254 @@
+#include "subcycling_step_context.hxx"
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+
+namespace {
+
+using CarpetX::ScopedStepContext;
+using CarpetX::StagePreparer;
+using CarpetX::StageKind;
+using CarpetX::StagePoint;
+using CarpetX::StepContext;
+using CarpetX::SubcyclingODEMethod;
+using CarpetX::current_step_context;
+using CarpetX::prepare_stage;
+using CarpetX::step_clock_t;
+using CarpetX::step_context_active;
+
+static_assert(
+    std::is_same_v<decltype(current_step_context()), const StepContext *>);
+
+class RecordingPreparer final : public StagePreparer {
+public:
+  std::vector<const StepContext *> contexts;
+  std::vector<StagePoint> stage_points;
+  bool throw_on_prepare{false};
+
+  void prepare_stage(const StepContext &context,
+                     const StagePoint &stage_point) override {
+    contexts.push_back(&context);
+    stage_points.push_back(stage_point);
+    if (throw_on_prepare)
+      throw std::runtime_error("requested prepare failure");
+  }
+};
+
+StepContext valid_context() {
+  return StepContext{2, step_clock_t(5, 8), step_clock_t(7, 8), 1.25, 2.5,
+                     SubcyclingODEMethod::rk4};
+}
+
+StagePoint point(const StageKind kind, const int stage_index,
+                 const int stage_count, const step_clock_t fraction,
+                 const double time) {
+  return StagePoint{kind, stage_index, stage_count, fraction, time};
+}
+
+template <typename Exception, typename Function>
+void expect_throw(Function &&function) {
+  bool threw = false;
+  try {
+    function();
+  } catch (const Exception &) {
+    threw = true;
+  }
+  assert(threw);
+}
+
+void test_absent_context_is_a_noop() {
+  assert(!step_context_active());
+  assert(current_step_context() == nullptr);
+  prepare_stage(point(StageKind::endpoint_probe, 1, 1, step_clock_t(1),
+                      std::numeric_limits<double>::quiet_NaN()),
+                SubcyclingODEMethod::dp87_order8);
+  assert(!step_context_active());
+}
+
+void test_scope_exposes_const_exact_context_and_records_any_in_range_order() {
+  RecordingPreparer preparer;
+  const auto context = valid_context();
+
+  {
+    ScopedStepContext scope(context, preparer);
+    assert(step_context_active());
+    assert(current_step_context() == &context);
+    assert(current_step_context()->level == 2);
+    assert(current_step_context()->begin_clock == step_clock_t(5, 8));
+    assert(current_step_context()->end_clock == step_clock_t(7, 8));
+
+    prepare_stage(point(StageKind::primary, 1, 4, step_clock_t(0), 1.25),
+                  SubcyclingODEMethod::rk4);
+    prepare_stage(point(StageKind::primary, 4, 4, step_clock_t(1), 2.5),
+                  SubcyclingODEMethod::rk4);
+    prepare_stage(point(StageKind::primary, 2, 4, step_clock_t(2, 5), 1.75),
+                  SubcyclingODEMethod::rk4);
+    prepare_stage(point(StageKind::primary, 2, 4, step_clock_t(2, 5), 1.75),
+                  SubcyclingODEMethod::rk4);
+  }
+
+  assert(!step_context_active());
+  assert(current_step_context() == nullptr);
+  assert(preparer.contexts ==
+         std::vector<const StepContext *>({&context, &context, &context,
+                                           &context}));
+  assert(preparer.stage_points.size() == 4);
+  assert(preparer.stage_points[0].stage_fraction == step_clock_t(0));
+  assert(preparer.stage_points[1].stage_fraction == step_clock_t(1));
+  assert(preparer.stage_points[2].stage_fraction == step_clock_t(2, 5));
+  assert(preparer.stage_points[3].stage_fraction == step_clock_t(2, 5));
+}
+
+void test_active_prepare_rejects_method_and_range_violations() {
+  RecordingPreparer preparer;
+  const auto context = valid_context();
+  ScopedStepContext scope(context, preparer);
+
+  expect_throw<std::invalid_argument>([&] {
+    prepare_stage(point(StageKind::primary, 2, 4, step_clock_t(1, 5), 1.5),
+                  SubcyclingODEMethod::rkf78_order7);
+  });
+  expect_throw<std::invalid_argument>([&] {
+    prepare_stage(point(StageKind::primary, 2, 4, step_clock_t(1, 5),
+                        std::numeric_limits<double>::quiet_NaN()),
+                  SubcyclingODEMethod::rk4);
+  });
+  expect_throw<std::out_of_range>(
+      [&] {
+        prepare_stage(point(StageKind::primary, 1, 4, step_clock_t(0), 1.0),
+                      SubcyclingODEMethod::rk4);
+      });
+  expect_throw<std::out_of_range>(
+      [&] {
+        prepare_stage(point(StageKind::primary, 4, 4, step_clock_t(1), 3.0),
+                      SubcyclingODEMethod::rk4);
+      });
+  expect_throw<std::invalid_argument>([&] {
+    prepare_stage(point(StageKind::primary, 0, 4, step_clock_t(0), 1.25),
+                  SubcyclingODEMethod::rk4);
+  });
+  expect_throw<std::invalid_argument>([&] {
+    prepare_stage(point(StageKind::primary, 2, 1, step_clock_t(1, 2), 1.875),
+                  SubcyclingODEMethod::rk4);
+  });
+  expect_throw<std::out_of_range>([&] {
+    prepare_stage(point(StageKind::primary, 2, 4, step_clock_t(-1, 8), 1.25),
+                  SubcyclingODEMethod::rk4);
+  });
+  expect_throw<std::invalid_argument>([&] {
+    prepare_stage(point(StageKind::primary, 2, 4, step_clock_t(1, 2), 1.5),
+                  SubcyclingODEMethod::rk4);
+  });
+  assert(preparer.stage_points.empty());
+}
+
+void test_installation_rejects_invalid_contexts_and_nesting() {
+  RecordingPreparer preparer;
+
+  auto check_invalid = [&](const StepContext &context) {
+    expect_throw<std::invalid_argument>(
+        [&] { ScopedStepContext scope(context, preparer); });
+    assert(!step_context_active());
+  };
+
+  auto context = valid_context();
+  context.level = -1;
+  check_invalid(context);
+
+  context = valid_context();
+  context.end_clock = context.begin_clock;
+  check_invalid(context);
+
+  context = valid_context();
+  context.end_clock = step_clock_t(1, 2);
+  check_invalid(context);
+
+  context = valid_context();
+  context.begin_time = std::numeric_limits<double>::quiet_NaN();
+  check_invalid(context);
+
+  context = valid_context();
+  context.end_time = std::numeric_limits<double>::infinity();
+  check_invalid(context);
+
+  context = valid_context();
+  context.end_time = context.begin_time;
+  check_invalid(context);
+
+  context = valid_context();
+  context.end_time = 1.0;
+  check_invalid(context);
+
+  const auto outer_context = valid_context();
+  const auto inner_context = valid_context();
+  {
+    ScopedStepContext outer(outer_context, preparer);
+    expect_throw<std::logic_error>(
+        [&] { ScopedStepContext inner(inner_context, preparer); });
+    assert(current_step_context() == &outer_context);
+  }
+  assert(!step_context_active());
+}
+
+void test_unwinding_restores_absence_and_propagates_callback_exceptions() {
+  RecordingPreparer preparer;
+  const auto context = valid_context();
+
+  expect_throw<std::runtime_error>([&] {
+    ScopedStepContext scope(context, preparer);
+    throw std::runtime_error("requested scope unwind");
+  });
+  assert(!step_context_active());
+
+  preparer.throw_on_prepare = true;
+  expect_throw<std::runtime_error>([&] {
+    ScopedStepContext scope(context, preparer);
+    prepare_stage(point(StageKind::primary, 2, 4, step_clock_t(1, 5), 1.5),
+                  SubcyclingODEMethod::rk4);
+  });
+  assert(!step_context_active());
+  assert(current_step_context() == nullptr);
+}
+
+void test_auxiliary_stage_requires_and_preserves_transaction_binding() {
+  RecordingPreparer preparer;
+  const auto context = valid_context();
+  auto *const transaction = reinterpret_cast<CarpetX::ScratchStateTransaction *>(
+      static_cast<std::uintptr_t>(0x10));
+  {
+    ScopedStepContext scope(context, preparer, transaction);
+    prepare_stage(
+        point(StageKind::fractional, 2, 4, step_clock_t(1, 4), 1.5625),
+        SubcyclingODEMethod::rk4);
+    prepare_stage(
+        point(StageKind::endpoint_probe, 1, 1, step_clock_t(3, 4), 2.1875),
+        SubcyclingODEMethod::rk4);
+  }
+  assert(preparer.stage_points.size() == 2);
+
+  ScopedStepContext scope(context, preparer);
+  expect_throw<std::logic_error>([&] {
+    prepare_stage(
+        point(StageKind::fractional, 2, 4, step_clock_t(1, 4), 1.5625),
+        SubcyclingODEMethod::rk4);
+  });
+}
+
+} // namespace
+
+int main() {
+  test_absent_context_is_a_noop();
+  test_scope_exposes_const_exact_context_and_records_any_in_range_order();
+  test_active_prepare_rejects_method_and_range_violations();
+  test_installation_rejects_invalid_contexts_and_nesting();
+  test_unwinding_restores_absence_and_propagates_callback_exceptions();
+  test_auxiliary_stage_requires_and_preserves_transaction_binding();
+  std::cout << "Subcycling StepContext tests passed\n";
+  return 0;
+}

--- a/ODESolvers/interface.ccl
+++ b/ODESolvers/interface.ccl
@@ -3,6 +3,11 @@
 IMPLEMENTS: ODESolvers
 
 USES INCLUDE HEADER: div.hxx
+USES INCLUDE HEADER: subcycling_dense_output.hxx
+USES INCLUDE HEADER: subcycling_dense_stencil.hxx
+USES INCLUDE HEADER: subcycling_method_contract.hxx
+USES INCLUDE HEADER: subcycling_scratch_state_transaction.hxx
+USES INCLUDE HEADER: subcycling_step_context.hxx
 
 
 

--- a/ODESolvers/schedule.ccl
+++ b/ODESolvers/schedule.ccl
@@ -10,6 +10,12 @@ SCHEDULE ODESolvers_InitConstants AT WRAGH
   WRITES: do_substeps
 } "Set up dummy loop counters for schedule printout"
 
+SCHEDULE ODESolvers_RegisterSubcyclingMethodContract AT PARAMCHECK
+{
+  LANG: C
+  OPTIONS: global
+} "Register the frozen ODE method contract for CarpetX subcycling"
+
 SCHEDULE ODESolvers_Solve AT evol
 {
   LANG: C
@@ -217,3 +223,9 @@ SCHEDULE ODESolvers_Solve AT evol
   SCHEDULE GROUP ODESolvers_Analysis AT analysis
   {
   } "Calculate analysis quantities everywhere"
+
+SCHEDULE ODESolvers_UnregisterSubcyclingMethodSteeringGuard AT CCTK_SHUTDOWN
+{
+  LANG: C
+  OPTIONS: global
+} "Release the ODE method steering guard"

--- a/ODESolvers/src/cactus_explicit_rk_operations.hxx
+++ b/ODESolvers/src/cactus_explicit_rk_operations.hxx
@@ -1,0 +1,270 @@
+#ifndef ODESOLVERS_CACTUS_EXPLICIT_RK_OPERATIONS_HXX
+#define ODESOLVERS_CACTUS_EXPLICIT_RK_OPERATIONS_HXX
+
+#include "explicit_rk.hxx"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+
+namespace ODESolvers {
+
+template <typename Scalar, typename State>
+struct CactusExplicitRKScratchHooks {
+  std::function<void(State &, State &, const State &, const State &, Scalar)>
+      restore_left;
+  std::function<void(State &, const State &, Scalar)> restore_state;
+  std::function<void(State &, const ExplicitRKStagePoint &, Scalar)>
+      post_step_after_update;
+  std::function<void(State &, State &, int, const ExplicitRKStagePoint &,
+                     Scalar)>
+      evaluate_rhs;
+  std::function<State(State &, State &, const ExplicitRKStagePoint &, Scalar)>
+      probe_endpoint_rhs;
+  std::function<std::size_t()> rhs_evaluation_count;
+};
+
+template <typename State, typename PrepareInitial, typename EvaluateRHS,
+          typename ValidateRHS, typename UpdateState, typename AccumulateRK4>
+struct CactusExplicitRKOperations {
+  using scalar_type = typename State::scalar_type;
+  using state_type = State;
+  using scratch_hooks_type = CactusExplicitRKScratchHooks<scalar_type, State>;
+
+  State &var;
+  State &rhs_component;
+  PrepareInitial prepare_initial_callback;
+  EvaluateRHS evaluate_rhs_callback;
+  ValidateRHS validate_rhs_callback;
+  UpdateState update_state_callback;
+  AccumulateRK4 accumulate_rk4_callback;
+  std::function<void(State &, const ExplicitRKStagePoint &, scalar_type)>
+      stage_materialization_callback;
+  std::function<void(const ExplicitRKStagePoint &, scalar_type)>
+      stage_preparation_callback;
+  std::function<void(scalar_type)> live_post_step_callback;
+  scratch_hooks_type *scratch_hooks = nullptr;
+  std::uint64_t state_generation_value = 0;
+  bool loaded_rhs_available = false;
+  scalar_type loaded_rhs_time =
+      std::numeric_limits<scalar_type>::quiet_NaN();
+  scalar_type current_stage_time =
+      std::numeric_limits<scalar_type>::quiet_NaN();
+  std::optional<ExplicitRKStagePoint> current_stage_point;
+  bool current_stage_prepared = false;
+
+  CactusExplicitRKOperations(State &var_, State &rhs_component_,
+                             PrepareInitial prepare_initial_callback_,
+                             EvaluateRHS evaluate_rhs_callback_,
+                             ValidateRHS validate_rhs_callback_,
+                             UpdateState update_state_callback_,
+                             AccumulateRK4 accumulate_rk4_callback_)
+      : var(var_), rhs_component(rhs_component_),
+        prepare_initial_callback(std::move(prepare_initial_callback_)),
+        evaluate_rhs_callback(std::move(evaluate_rhs_callback_)),
+        validate_rhs_callback(std::move(validate_rhs_callback_)),
+        update_state_callback(std::move(update_state_callback_)),
+        accumulate_rk4_callback(std::move(accumulate_rk4_callback_)) {}
+
+  const State &state() const noexcept { return var; }
+  const State &rhs() const noexcept { return rhs_component; }
+
+  State snapshot_state() const { return var.snapshot_state(); }
+  State snapshot_rhs() const { return rhs_component.snapshot_rhs(); }
+
+  void set_stage_point(const ExplicitRKStagePoint &point) {
+    if (point.stage_index <= 0 || point.stage_count <= 0 ||
+        point.stage_index > point.stage_count ||
+        point.parent_fraction.denominator <= 0 ||
+        point.parent_fraction.numerator < 0 ||
+        point.parent_fraction.numerator > point.parent_fraction.denominator)
+      throw std::invalid_argument("explicit RK stage point is invalid");
+    switch (point.kind) {
+    case ExplicitRKStageKind::primary:
+    case ExplicitRKStageKind::fractional:
+      break;
+    case ExplicitRKStageKind::endpoint_probe:
+      if (point.stage_index != 1 || point.stage_count != 1)
+        throw std::invalid_argument(
+            "endpoint probe must use the singleton stage index");
+      break;
+    default:
+      throw std::invalid_argument("explicit RK stage kind is invalid");
+    }
+    current_stage_point = point;
+    current_stage_prepared = false;
+  }
+
+  void prepare_initial(const scalar_type stage_time) {
+    current_stage_time = stage_time;
+    prepare_initial_callback(stage_time);
+    prepare_active_stage();
+  }
+
+  void evaluate_rhs(const int stage) {
+    if ((stage_materialization_callback || stage_preparation_callback) &&
+        !current_stage_prepared)
+      throw std::logic_error(
+          "RHS evaluation reached an unprepared explicit RK stage");
+    if (scratch_hooks != nullptr) {
+      const auto &stage_point = require_current_stage_point();
+      require_hook(static_cast<bool>(scratch_hooks->evaluate_rhs),
+                   "scratch evaluate_rhs hook is missing");
+      scratch_hooks->evaluate_rhs(var, rhs_component, stage, stage_point,
+                                  current_stage_time);
+    } else {
+      evaluate_rhs_callback(stage);
+    }
+  }
+
+  void validate_rhs(const int stage) { validate_rhs_callback(stage); }
+
+  void update_state(
+      const int update_index, const scalar_type stage_time,
+      const scalar_type destination_scale,
+      const LinearCombinationView<scalar_type, State> combination) {
+    update_state_callback(update_index, stage_time, destination_scale,
+                          combination);
+    current_stage_time = stage_time;
+    prepare_active_stage();
+    if (scratch_hooks != nullptr) {
+      const auto &stage_point = require_current_stage_point();
+      require_hook(static_cast<bool>(scratch_hooks->post_step_after_update),
+                   "scratch PostStep hook is missing");
+      scratch_hooks->post_step_after_update(var, stage_point, stage_time);
+    } else if (live_post_step_callback) {
+      live_post_step_callback(stage_time);
+    }
+    ++state_generation_value;
+    loaded_rhs_available = false;
+  }
+
+  void accumulate_rk4(State &accumulator, const scalar_type factor,
+                      const State &increment) {
+    accumulate_rk4_callback(accumulator, factor, increment);
+  }
+
+  void restore_left(const State &left_state, const State &left_rhs,
+                    const scalar_type left_time) {
+    require_scratch_hook_set();
+    require_hook(static_cast<bool>(scratch_hooks->restore_left),
+                 "scratch restore_left hook is missing");
+    scratch_hooks->restore_left(var, rhs_component, left_state, left_rhs,
+                                left_time);
+    current_stage_time = left_time;
+    ++state_generation_value;
+    loaded_rhs_available = true;
+    loaded_rhs_time = left_time;
+    current_stage_point.reset();
+    current_stage_prepared = false;
+  }
+
+  void restore_state(const State &state, const scalar_type state_time) {
+    require_scratch_hook_set();
+    require_hook(static_cast<bool>(scratch_hooks->restore_state),
+                 "scratch restore_state hook is missing");
+    scratch_hooks->restore_state(var, state, state_time);
+    current_stage_time = state_time;
+    ++state_generation_value;
+    loaded_rhs_available = false;
+    current_stage_point.reset();
+    current_stage_prepared = false;
+  }
+
+  State probe_endpoint_rhs(const scalar_type state_time,
+                           const ExplicitRKStagePoint &stage_point) {
+    require_scratch_hook_set();
+    set_stage_point(stage_point);
+    current_stage_time = state_time;
+    prepare_active_stage();
+    require_hook(static_cast<bool>(scratch_hooks->post_step_after_update),
+                 "scratch PostStep hook is missing");
+    scratch_hooks->post_step_after_update(var, stage_point, state_time);
+    require_hook(static_cast<bool>(scratch_hooks->probe_endpoint_rhs),
+                 "scratch endpoint RHS hook is missing");
+    return scratch_hooks->probe_endpoint_rhs(var, rhs_component, stage_point,
+                                             state_time);
+  }
+
+  std::size_t rhs_evaluation_count() const {
+    require_scratch_hook_set();
+    require_hook(static_cast<bool>(scratch_hooks->rhs_evaluation_count),
+                 "scratch RHS count hook is missing");
+    return scratch_hooks->rhs_evaluation_count();
+  }
+
+  std::uint64_t state_generation() const noexcept {
+    return state_generation_value;
+  }
+
+  LoadedRHSProvenance<scalar_type>
+  loaded_rhs_provenance(const scalar_type left_time) const {
+    if (!loaded_rhs_available || left_time != loaded_rhs_time)
+      throw std::logic_error("no exact loaded left RHS is available");
+    return {state_generation_value, left_time};
+  }
+
+  void validate_loaded_rhs_provenance(
+      const LoadedRHSProvenance<scalar_type> &provenance) const {
+    if (!loaded_rhs_available ||
+        provenance.state_generation != state_generation_value ||
+        provenance.left_time != loaded_rhs_time)
+      throw std::logic_error("loaded RHS provenance is stale");
+  }
+
+  void consume_loaded_rhs(
+      const LoadedRHSProvenance<scalar_type> &provenance) {
+    validate_loaded_rhs_provenance(provenance);
+    loaded_rhs_available = false;
+  }
+
+private:
+  const ExplicitRKStagePoint &require_current_stage_point() const {
+    if (!current_stage_point.has_value())
+      throw std::logic_error("scratch operation has no exact stage point");
+    return *current_stage_point;
+  }
+
+  void prepare_active_stage() {
+    if (!stage_materialization_callback && !stage_preparation_callback)
+      return;
+    if (!current_stage_point.has_value())
+      throw std::logic_error(
+          "driver stage preparation has no exact stage point");
+    if (scratch_hooks != nullptr && stage_preparation_callback &&
+        !stage_materialization_callback)
+      throw std::logic_error(
+          "scratch driver stage preparation has no materialization callback");
+    if (stage_materialization_callback)
+      stage_materialization_callback(var, *current_stage_point,
+                                     current_stage_time);
+    if (stage_preparation_callback)
+      stage_preparation_callback(*current_stage_point, current_stage_time);
+    current_stage_prepared = true;
+  }
+
+  static void require_hook(const bool present, const char *const message) {
+    if (!present)
+      throw std::logic_error(message);
+  }
+
+  void require_scratch_hook_set() const {
+    if (scratch_hooks == nullptr)
+      throw std::logic_error("scratch operation requested without hooks");
+  }
+};
+
+template <typename State, typename PrepareInitial, typename EvaluateRHS,
+          typename ValidateRHS, typename UpdateState, typename AccumulateRK4>
+CactusExplicitRKOperations(State &, State &, PrepareInitial, EvaluateRHS,
+                           ValidateRHS, UpdateState, AccumulateRK4)
+    -> CactusExplicitRKOperations<State, PrepareInitial, EvaluateRHS,
+                                  ValidateRHS, UpdateState, AccumulateRK4>;
+
+} // namespace ODESolvers
+
+#endif // ODESOLVERS_CACTUS_EXPLICIT_RK_OPERATIONS_HXX

--- a/ODESolvers/src/explicit_rk.cxx
+++ b/ODESolvers/src/explicit_rk.cxx
@@ -1,0 +1,506 @@
+#include "explicit_rk.hxx"
+
+#include <array>
+#include <cstddef>
+#include <numeric>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+namespace ODESolvers {
+namespace {
+
+using I = std::int64_t;
+constexpr RationalCoefficient Q(const I numerator,
+                                const I denominator = 1) {
+  return {numerator, denominator};
+}
+
+const ExplicitRKTableau rk4_tableau{
+    ExplicitRKMethod::rk4,
+    4,
+    {{}, {Q(1, 2)}, {Q(0), Q(1, 2)}, {Q(0), Q(0), Q(1)}},
+    {Q(1, 6), Q(1, 3), Q(1, 3), Q(1, 6)},
+    {Q(0), Q(1, 2), Q(1, 2), Q(1)}};
+
+const ExplicitRKTableau rkf78_tableau{
+    ExplicitRKMethod::rkf78,
+    7,
+    {{},
+     {Q(2, 27)},
+     {Q(1, 36), Q(3, 36)},
+     {Q(1, 24), Q(0), Q(3, 24)},
+     {Q(20, 48), Q(0), Q(-75, 48), Q(75, 48)},
+     {Q(1, 20), Q(0), Q(0), Q(5, 20), Q(4, 20)},
+     {Q(-25, 108), Q(0), Q(0), Q(125, 108), Q(-260, 108), Q(250, 108)},
+     {Q(31, 300), Q(0), Q(0), Q(0), Q(61, 225), Q(-2, 9), Q(13, 900)},
+     {Q(2), Q(0), Q(0), Q(-53, 6), Q(704, 45), Q(-107, 9), Q(67, 90),
+      Q(3)},
+     {Q(-91, 108), Q(0), Q(0), Q(23, 108), Q(-976, 135), Q(311, 54),
+      Q(-19, 60), Q(17, 6), Q(-1, 12)},
+     {Q(2383, 4100), Q(0), Q(0), Q(-341, 164), Q(4496, 1025), Q(-301, 82),
+      Q(2133, 4100), Q(45, 82), Q(45, 164), Q(18, 41)}},
+    {Q(41, 840), Q(0), Q(0), Q(0), Q(0), Q(34, 105), Q(9, 35), Q(9, 35),
+     Q(9, 280), Q(9, 280), Q(41, 840)},
+    {Q(0), Q(2, 27), Q(1, 9), Q(1, 6), Q(5, 12), Q(1, 2), Q(5, 6), Q(1, 6),
+     Q(2, 3), Q(1, 3), Q(1)}};
+
+const ExplicitRKTableau dp87_tableau{
+    ExplicitRKMethod::dp87,
+    8,
+    {{},
+     {Q(1, 18)},
+     {Q(1, 48), Q(1, 16)},
+     {Q(1, 32), Q(0), Q(3, 32)},
+     {Q(5, 16), Q(0), Q(-75, 64), Q(75, 64)},
+     {Q(3, 80), Q(0), Q(0), Q(3, 16), Q(3, 20)},
+     {Q(29443841, 614563906), Q(0), Q(0), Q(77736538, 692538347),
+      Q(-28693883, 1125000000), Q(23124283, 1800000000)},
+     {Q(16016141, 946692911), Q(0), Q(0), Q(61564180, 158732637),
+      Q(22789713, 633445777), Q(545815736, 2771057229),
+      Q(-180193667, 1043307555)},
+     {Q(39632708, 573591083), Q(0), Q(0), Q(-433636366, 683701615),
+      Q(-421739975, 2616292301), Q(100302831, 723423059),
+      Q(790204164, 839813087), Q(800635310, 3783071287)},
+     {Q(246121993, 1340847787), Q(0), Q(0), Q(-37695042795, 15268766246),
+      Q(-309121744, 1061227803), Q(-12992083, 490766935),
+      Q(6005943493, 2108947869), Q(393006217, 1396673457),
+      Q(123872331, 1001029789)},
+     {Q(-1028468189, 846180014), Q(0), Q(0), Q(8478235783, 508512852),
+      Q(1311729495, 1432422823), Q(-10304129995, 1701304382),
+      Q(-48777925059, 3047939560), Q(15336726248, 1032824649),
+      Q(-45442868181, 3398467696), Q(3065993473, 597172653)},
+     {Q(185892177, 718116043), Q(0), Q(0), Q(-3185094517, 667107341),
+      Q(-477755414, 1098053517), Q(-703635378, 230739211),
+      Q(5731566787, 1027545527), Q(5232866602, 850066563),
+      Q(-4093664535, 808688257), Q(3962137247, 1805957418),
+      Q(65686358, 487910083)},
+     {Q(403863854, 491063109), Q(0), Q(0), Q(-5068492393, 434740067),
+      Q(-411421997, 543043805), Q(652783627, 914296604),
+      Q(11173962825, 925320556), Q(-13158990841, 6184727034),
+      Q(3936647629, 1978049680), Q(-160528059, 685178525),
+      Q(248638103, 1413531060), Q(0)}},
+    {Q(14005451, 335480064), Q(0), Q(0), Q(0), Q(0),
+     Q(-59238493, 1068277825), Q(181606767, 758867731),
+     Q(561292985, 797845732), Q(-1041891430, 1371343529),
+     Q(760417239, 1151165299), Q(118820643, 751138087),
+     Q(-528747749, 2220607170), Q(1, 4)},
+    {}};
+
+void validate_coefficient(const RationalCoefficient coefficient) {
+  if (coefficient.denominator <= 0)
+    throw std::invalid_argument(
+        "explicit RK coefficient denominator is not positive");
+  if (coefficient.numerator == std::numeric_limits<I>::min())
+    throw std::invalid_argument(
+        "explicit RK coefficient numerator has unsupported minimum value");
+}
+
+bool same_rational(const RationalCoefficient left,
+                   const RationalCoefficient right) {
+  validate_coefficient(left);
+  validate_coefficient(right);
+  const auto left_divisor = std::gcd(left.numerator, left.denominator);
+  const auto right_divisor = std::gcd(right.numerator, right.denominator);
+  return left.numerator / left_divisor == right.numerator / right_divisor &&
+         left.denominator / left_divisor ==
+             right.denominator / right_divisor;
+}
+
+RationalCoefficient add_exact(const RationalCoefficient left,
+                              const RationalCoefficient right) {
+  validate_coefficient(left);
+  validate_coefficient(right);
+  const auto denominator_gcd =
+      std::gcd(left.denominator, right.denominator);
+  const auto left_multiplier = right.denominator / denominator_gcd;
+  const auto right_multiplier = left.denominator / denominator_gcd;
+  const auto checked_product = [](const I value, const I multiplier) {
+    if (value != 0 &&
+        (value > std::numeric_limits<I>::max() / multiplier ||
+         value < std::numeric_limits<I>::min() / multiplier))
+      throw std::overflow_error("exact RK rational validation overflow");
+    return value * multiplier;
+  };
+  const I left_numerator = checked_product(left.numerator, left_multiplier);
+  const I right_numerator = checked_product(right.numerator, right_multiplier);
+  if ((right_numerator > 0 &&
+       left_numerator > std::numeric_limits<I>::max() - right_numerator) ||
+      (right_numerator < 0 &&
+       left_numerator < std::numeric_limits<I>::min() - right_numerator))
+    throw std::overflow_error("exact RK rational validation overflow");
+  const I numerator = left_numerator + right_numerator;
+  if (numerator == std::numeric_limits<I>::min())
+    throw std::overflow_error("exact RK rational validation overflow");
+  const I denominator = checked_product(left.denominator, left_multiplier);
+  const auto divisor = std::gcd(numerator, denominator);
+  return {numerator / divisor, denominator / divisor};
+}
+
+I checked_signed_product(const I left, const I right) {
+  constexpr I minimum = std::numeric_limits<I>::min();
+  constexpr I maximum = std::numeric_limits<I>::max();
+  if (left > 0) {
+    if ((right > 0 && left > maximum / right) ||
+        (right < 0 && right < minimum / left))
+      throw std::overflow_error("exact RK rational multiplication overflow");
+  } else if (left < 0) {
+    if ((right > 0 && left < minimum / right) ||
+        (right < 0 && left < maximum / right))
+      throw std::overflow_error("exact RK rational multiplication overflow");
+  }
+  return left * right;
+}
+
+RationalCoefficient multiply_exact(RationalCoefficient left,
+                                   RationalCoefficient right) {
+  validate_coefficient(left);
+  validate_coefficient(right);
+  const auto left_cancel = std::gcd(
+      left.numerator < 0 ? -left.numerator : left.numerator,
+      right.denominator);
+  const auto right_cancel = std::gcd(
+      right.numerator < 0 ? -right.numerator : right.numerator,
+      left.denominator);
+  left.numerator /= left_cancel;
+  right.denominator /= left_cancel;
+  right.numerator /= right_cancel;
+  left.denominator /= right_cancel;
+  return {checked_signed_product(left.numerator, right.numerator),
+          checked_signed_product(left.denominator, right.denominator)};
+}
+
+RationalCoefficient sum_exact(
+    const std::vector<RationalCoefficient> &coefficients) {
+  RationalCoefficient result{0, 1};
+  for (const auto coefficient : coefficients)
+    result = add_exact(result, coefficient);
+  return result;
+}
+
+void validate_against_canonical(const ExplicitRKTableau &tableau,
+                                const ExplicitRKTableau &canonical) {
+  for (std::size_t stage = 0; stage < tableau.a.size(); ++stage)
+    for (std::size_t i = 0; i < tableau.a[stage].size(); ++i)
+      if (tableau.a[stage][i].numerator !=
+              canonical.a[stage][i].numerator ||
+          tableau.a[stage][i].denominator !=
+              canonical.a[stage][i].denominator)
+        throw std::invalid_argument("explicit RK A coefficient mismatch");
+  for (std::size_t i = 0; i < tableau.b.size(); ++i)
+    if (tableau.b[i].numerator != canonical.b[i].numerator ||
+        tableau.b[i].denominator != canonical.b[i].denominator)
+      throw std::invalid_argument("explicit RK b coefficient mismatch");
+  for (std::size_t i = 0; i < tableau.c.size(); ++i)
+    if (tableau.c[i].numerator != canonical.c[i].numerator ||
+        tableau.c[i].denominator != canonical.c[i].denominator)
+      throw std::invalid_argument("explicit RK c coefficient mismatch");
+}
+
+void append_u8(std::vector<std::uint8_t> &bytes, const std::uint8_t value) {
+  bytes.push_back(value);
+}
+
+void append_u32(std::vector<std::uint8_t> &bytes, const std::uint32_t value) {
+  for (int shift = 24; shift >= 0; shift -= 8)
+    bytes.push_back(static_cast<std::uint8_t>(value >> shift));
+}
+
+void append_u64(std::vector<std::uint8_t> &bytes, const std::uint64_t value) {
+  for (int shift = 56; shift >= 0; shift -= 8)
+    bytes.push_back(static_cast<std::uint8_t>(value >> shift));
+}
+
+void append_i64(std::vector<std::uint8_t> &bytes, const std::int64_t value) {
+  append_u64(bytes, static_cast<std::uint64_t>(value));
+}
+
+void append_rational(std::vector<std::uint8_t> &bytes,
+                     const RationalCoefficient coefficient) {
+  validate_coefficient(coefficient);
+  append_i64(bytes, coefficient.numerator);
+  append_u64(bytes, static_cast<std::uint64_t>(coefficient.denominator));
+}
+
+std::vector<std::uint8_t>
+serialize_tableau(const ExplicitRKTableau &tableau) {
+  validate_explicit_rk_tableau(tableau);
+  static constexpr std::array<std::uint8_t, 23> tag{{
+      'C', 'X', '-', 'E', 'X', 'P', 'L', 'I', 'C', 'I', 'T', '-',
+      'R', 'K', '-', 'T', 'A', 'B', 'L', 'E', 'A', 'U', '\0'}};
+  std::vector<std::uint8_t> bytes;
+  bytes.reserve(64U + tableau.a.size() * tableau.a.size() * 8U);
+  bytes.insert(bytes.end(), tag.begin(), tag.end());
+  append_u32(bytes, 1U);
+  switch (tableau.method) {
+  case ExplicitRKMethod::rk4:
+    append_u8(bytes, 1U);
+    break;
+  case ExplicitRKMethod::rkf78:
+    append_u8(bytes, 2U);
+    break;
+  case ExplicitRKMethod::dp87:
+    append_u8(bytes, 3U);
+    break;
+  default:
+    throw std::invalid_argument("unsupported explicit RK method");
+  }
+  append_u32(bytes, static_cast<std::uint32_t>(tableau.endpoint_order));
+  append_u32(bytes, static_cast<std::uint32_t>(tableau.a.size()));
+  append_u8(bytes, tableau.method == ExplicitRKMethod::dp87 ? 1U : 0U);
+  append_u32(bytes, static_cast<std::uint32_t>(tableau.a.size()));
+  for (const auto &row : tableau.a) {
+    append_u32(bytes, static_cast<std::uint32_t>(row.size()));
+    for (const auto coefficient : row)
+      append_rational(bytes, coefficient);
+  }
+  append_u32(bytes, static_cast<std::uint32_t>(tableau.b.size()));
+  for (const auto coefficient : tableau.b)
+    append_rational(bytes, coefficient);
+  append_u32(bytes, static_cast<std::uint32_t>(tableau.c.size()));
+  for (const auto coefficient : tableau.c)
+    append_rational(bytes, coefficient);
+  return bytes;
+}
+
+constexpr std::uint32_t rotate_right(const std::uint32_t value,
+                                     const int count) noexcept {
+  return (value >> count) | (value << (32 - count));
+}
+
+ExplicitRKTableauFingerprint
+sha256(const std::vector<std::uint8_t> &message) {
+  static constexpr std::array<std::uint32_t, 64> round_constants{{
+      0x428a2f98U, 0x71374491U, 0xb5c0fbcfU, 0xe9b5dba5U,
+      0x3956c25bU, 0x59f111f1U, 0x923f82a4U, 0xab1c5ed5U,
+      0xd807aa98U, 0x12835b01U, 0x243185beU, 0x550c7dc3U,
+      0x72be5d74U, 0x80deb1feU, 0x9bdc06a7U, 0xc19bf174U,
+      0xe49b69c1U, 0xefbe4786U, 0x0fc19dc6U, 0x240ca1ccU,
+      0x2de92c6fU, 0x4a7484aaU, 0x5cb0a9dcU, 0x76f988daU,
+      0x983e5152U, 0xa831c66dU, 0xb00327c8U, 0xbf597fc7U,
+      0xc6e00bf3U, 0xd5a79147U, 0x06ca6351U, 0x14292967U,
+      0x27b70a85U, 0x2e1b2138U, 0x4d2c6dfcU, 0x53380d13U,
+      0x650a7354U, 0x766a0abbU, 0x81c2c92eU, 0x92722c85U,
+      0xa2bfe8a1U, 0xa81a664bU, 0xc24b8b70U, 0xc76c51a3U,
+      0xd192e819U, 0xd6990624U, 0xf40e3585U, 0x106aa070U,
+      0x19a4c116U, 0x1e376c08U, 0x2748774cU, 0x34b0bcb5U,
+      0x391c0cb3U, 0x4ed8aa4aU, 0x5b9cca4fU, 0x682e6ff3U,
+      0x748f82eeU, 0x78a5636fU, 0x84c87814U, 0x8cc70208U,
+      0x90befffaU, 0xa4506cebU, 0xbef9a3f7U, 0xc67178f2U}};
+  std::array<std::uint32_t, 8> hash{{
+      0x6a09e667U, 0xbb67ae85U, 0x3c6ef372U, 0xa54ff53aU,
+      0x510e527fU, 0x9b05688cU, 0x1f83d9abU, 0x5be0cd19U}};
+
+  std::vector<std::uint8_t> padded(message);
+  const std::uint64_t bit_count =
+      static_cast<std::uint64_t>(message.size()) * 8U;
+  padded.push_back(0x80U);
+  while (padded.size() % 64U != 56U)
+    padded.push_back(0U);
+  append_u64(padded, bit_count);
+
+  for (std::size_t block = 0; block < padded.size(); block += 64U) {
+    std::array<std::uint32_t, 64> words{};
+    for (std::size_t i = 0; i < 16U; ++i) {
+      const std::size_t offset = block + 4U * i;
+      words[i] = (static_cast<std::uint32_t>(padded[offset]) << 24) |
+                 (static_cast<std::uint32_t>(padded[offset + 1U]) << 16) |
+                 (static_cast<std::uint32_t>(padded[offset + 2U]) << 8) |
+                 static_cast<std::uint32_t>(padded[offset + 3U]);
+    }
+    for (std::size_t i = 16U; i < words.size(); ++i) {
+      const std::uint32_t s0 = rotate_right(words[i - 15U], 7) ^
+                               rotate_right(words[i - 15U], 18) ^
+                               (words[i - 15U] >> 3);
+      const std::uint32_t s1 = rotate_right(words[i - 2U], 17) ^
+                               rotate_right(words[i - 2U], 19) ^
+                               (words[i - 2U] >> 10);
+      words[i] = words[i - 16U] + s0 + words[i - 7U] + s1;
+    }
+
+    std::uint32_t a = hash[0];
+    std::uint32_t b = hash[1];
+    std::uint32_t c = hash[2];
+    std::uint32_t d = hash[3];
+    std::uint32_t e = hash[4];
+    std::uint32_t f = hash[5];
+    std::uint32_t g = hash[6];
+    std::uint32_t h = hash[7];
+    for (std::size_t i = 0; i < words.size(); ++i) {
+      const std::uint32_t upper_sigma1 =
+          rotate_right(e, 6) ^ rotate_right(e, 11) ^ rotate_right(e, 25);
+      const std::uint32_t choice = (e & f) ^ ((~e) & g);
+      const std::uint32_t temp1 =
+          h + upper_sigma1 + choice + round_constants[i] + words[i];
+      const std::uint32_t upper_sigma0 =
+          rotate_right(a, 2) ^ rotate_right(a, 13) ^ rotate_right(a, 22);
+      const std::uint32_t majority = (a & b) ^ (a & c) ^ (b & c);
+      const std::uint32_t temp2 = upper_sigma0 + majority;
+      h = g;
+      g = f;
+      f = e;
+      e = d + temp1;
+      d = c;
+      c = b;
+      b = a;
+      a = temp1 + temp2;
+    }
+    hash[0] += a;
+    hash[1] += b;
+    hash[2] += c;
+    hash[3] += d;
+    hash[4] += e;
+    hash[5] += f;
+    hash[6] += g;
+    hash[7] += h;
+  }
+
+  ExplicitRKTableauFingerprint result{};
+  for (std::size_t i = 0; i < hash.size(); ++i)
+    for (std::size_t byte = 0; byte < 4U; ++byte)
+      result[4U * i + byte] = static_cast<std::uint8_t>(
+          hash[i] >> static_cast<int>(24U - 8U * byte));
+  return result;
+}
+
+} // namespace
+
+const ExplicitRKTableau &explicit_rk_tableau(const ExplicitRKMethod method) {
+  switch (method) {
+  case ExplicitRKMethod::rk4:
+    return rk4_tableau;
+  case ExplicitRKMethod::rkf78:
+    return rkf78_tableau;
+  case ExplicitRKMethod::dp87:
+    return dp87_tableau;
+  }
+  throw std::invalid_argument("unsupported explicit RK method");
+}
+
+RationalCoefficient
+explicit_rk_stage_fraction(const ExplicitRKMethod method,
+                           const int stage_index) {
+  static constexpr std::array<RationalCoefficient, 4> rk4_fractions{{
+      Q(0), Q(1, 2), Q(1, 2), Q(1)}};
+  static constexpr std::array<RationalCoefficient, 11> rkf78_fractions{{
+      Q(0), Q(2, 27), Q(1, 9), Q(1, 6), Q(5, 12), Q(1, 2),
+      Q(5, 6), Q(1, 6), Q(2, 3), Q(1, 3), Q(1)}};
+  static constexpr std::array<RationalCoefficient, 13> dp87_fractions{{
+      Q(0), Q(1, 18), Q(1, 12), Q(1, 8), Q(5, 16), Q(3, 8),
+      Q(59, 400), Q(93, 200), Q(5490023248LL, 9719169821LL),
+      Q(13, 20), Q(1201146811LL, 1299019798LL), Q(1), Q(1)}};
+  if (stage_index <= 0)
+    throw std::out_of_range("explicit RK stage index is out of range");
+  const auto index = static_cast<std::size_t>(stage_index - 1);
+  switch (method) {
+  case ExplicitRKMethod::rk4:
+    if (index < rk4_fractions.size())
+      return rk4_fractions[index];
+    break;
+  case ExplicitRKMethod::rkf78:
+    if (index < rkf78_fractions.size())
+      return rkf78_fractions[index];
+    break;
+  case ExplicitRKMethod::dp87:
+    if (index < dp87_fractions.size())
+      return dp87_fractions[index];
+    break;
+  }
+  throw std::out_of_range("explicit RK stage index is out of range");
+}
+
+ExplicitRKStagePoint
+explicit_rk_stage_point(const ExplicitRKMethod method,
+                        const ExplicitRKAdvanceFrame &frame,
+                        const int stage_index) {
+  if (frame.kind != ExplicitRKStageKind::primary &&
+      frame.kind != ExplicitRKStageKind::fractional)
+    throw std::invalid_argument(
+        "explicit RK advance kind cannot be an endpoint probe");
+  validate_coefficient(frame.begin_fraction);
+  validate_coefficient(frame.extent_fraction);
+  if (frame.begin_fraction.numerator < 0 ||
+      frame.extent_fraction.numerator <= 0)
+    throw std::invalid_argument("explicit RK advance fraction is invalid");
+  const auto endpoint =
+      add_exact(frame.begin_fraction, frame.extent_fraction);
+  if (endpoint.numerator > endpoint.denominator)
+    throw std::out_of_range(
+        "explicit RK advance fraction exceeds the parent step");
+  const auto &tableau = explicit_rk_tableau(method);
+  const int stage_count = static_cast<int>(tableau.a.size());
+  const auto local_fraction = explicit_rk_stage_fraction(method, stage_index);
+  const auto parent_fraction =
+      add_exact(frame.begin_fraction,
+                multiply_exact(frame.extent_fraction, local_fraction));
+  if (parent_fraction.numerator < 0 ||
+      parent_fraction.numerator > parent_fraction.denominator)
+    throw std::out_of_range(
+        "explicit RK stage fraction exceeds the parent step");
+  return {frame.kind, stage_index, stage_count, parent_fraction};
+}
+
+void validate_explicit_rk_tableau(const ExplicitRKTableau &tableau) {
+  int expected_stages = 0;
+  int expected_order = 0;
+  const ExplicitRKTableau *canonical = nullptr;
+  switch (tableau.method) {
+  case ExplicitRKMethod::rk4:
+    expected_stages = 4;
+    expected_order = 4;
+    canonical = &rk4_tableau;
+    break;
+  case ExplicitRKMethod::rkf78:
+    expected_stages = 11;
+    expected_order = 7;
+    canonical = &rkf78_tableau;
+    break;
+  case ExplicitRKMethod::dp87:
+    expected_stages = 13;
+    expected_order = 8;
+    canonical = &dp87_tableau;
+    break;
+  default:
+    throw std::invalid_argument("unsupported explicit RK method");
+  }
+  if (tableau.endpoint_order != expected_order ||
+      static_cast<int>(tableau.a.size()) != expected_stages ||
+      static_cast<int>(tableau.b.size()) != expected_stages)
+    throw std::invalid_argument("explicit RK descriptor shape/order mismatch");
+  for (std::size_t stage = 0; stage < tableau.a.size(); ++stage) {
+    if (tableau.a[stage].size() != stage)
+      throw std::invalid_argument("explicit RK A row length mismatch");
+    for (const auto coefficient : tableau.a[stage])
+      validate_coefficient(coefficient);
+  }
+  for (const auto coefficient : tableau.b)
+    validate_coefficient(coefficient);
+
+  if (tableau.method == ExplicitRKMethod::dp87) {
+    if (!tableau.c.empty())
+      throw std::invalid_argument("DP87 must derive c from A rows");
+  } else {
+    if (tableau.c.size() != tableau.a.size())
+      throw std::invalid_argument("explicit RK c descriptor length mismatch");
+    for (const auto coefficient : tableau.c)
+      validate_coefficient(coefficient);
+  }
+  if (tableau.method != ExplicitRKMethod::dp87 &&
+      !same_rational(sum_exact(tableau.b), Q(1)))
+    throw std::invalid_argument("exact explicit RK b sum is not one");
+  if (tableau.method == ExplicitRKMethod::rkf78)
+    for (std::size_t stage = 0; stage < tableau.a.size(); ++stage)
+      if (!same_rational(sum_exact(tableau.a[stage]), tableau.c[stage]))
+        throw std::invalid_argument("exact RKF78 A row sum does not equal c");
+  // Execution reads the caller's exact integer pairs for the RK4 legacy
+  // arithmetic. Require the audited canonical spelling, not merely a
+  // mathematically equivalent fraction, before entering the kernel.
+  validate_against_canonical(tableau, *canonical);
+}
+
+ExplicitRKTableauFingerprint
+explicit_rk_tableau_fingerprint(const ExplicitRKMethod method) {
+  return sha256(serialize_tableau(explicit_rk_tableau(method)));
+}
+
+} // namespace ODESolvers

--- a/ODESolvers/src/explicit_rk.hxx
+++ b/ODESolvers/src/explicit_rk.hxx
@@ -1,0 +1,583 @@
+#ifndef ODESOLVERS_EXPLICIT_RK_HXX
+#define ODESOLVERS_EXPLICIT_RK_HXX
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace ODESolvers {
+
+enum class ExplicitRKMethod { rk4, rkf78, dp87 };
+enum class InitialRHSMode { calculate, reuse_loaded };
+
+template <typename Scalar> struct LoadedRHSProvenance {
+  std::uint64_t state_generation;
+  Scalar left_time;
+};
+
+template <typename Scalar> class LoadedRHSToken {
+public:
+  LoadedRHSToken(const LoadedRHSToken &) = delete;
+  LoadedRHSToken &operator=(const LoadedRHSToken &) = delete;
+
+  LoadedRHSToken(LoadedRHSToken &&other) noexcept
+      : provenance_(other.provenance_), consumed_(other.consumed_) {
+    other.consumed_ = true;
+  }
+
+  LoadedRHSToken &operator=(LoadedRHSToken &&) = delete;
+
+  const LoadedRHSProvenance<Scalar> &provenance() const noexcept {
+    return provenance_;
+  }
+  bool consumed() const noexcept { return consumed_; }
+  void consume_once() {
+    if (consumed_)
+      throw std::invalid_argument("loaded RHS token has already been consumed");
+    consumed_ = true;
+  }
+
+private:
+  explicit LoadedRHSToken(const LoadedRHSProvenance<Scalar> provenance)
+      : provenance_(provenance) {}
+
+  LoadedRHSProvenance<Scalar> provenance_;
+  bool consumed_ = false;
+
+  template <typename Ops>
+  friend LoadedRHSToken<typename Ops::scalar_type>
+  make_loaded_rhs_token(const Ops &, typename Ops::scalar_type);
+};
+
+template <typename Ops>
+LoadedRHSToken<typename Ops::scalar_type>
+make_loaded_rhs_token(const Ops &ops,
+                      const typename Ops::scalar_type left_time) {
+  return LoadedRHSToken<typename Ops::scalar_type>(
+      ops.loaded_rhs_provenance(left_time));
+}
+
+template <typename Scalar, typename State> struct LinearCombinationView {
+  const Scalar *factors;
+  const State *const *sources;
+  std::size_t size;
+};
+
+struct RationalCoefficient {
+  std::int64_t numerator;
+  std::int64_t denominator;
+};
+
+enum class ExplicitRKStageKind : std::uint8_t {
+  primary,
+  fractional,
+  endpoint_probe,
+};
+
+struct ExplicitRKAdvanceFrame {
+  ExplicitRKStageKind kind;
+  RationalCoefficient begin_fraction;
+  RationalCoefficient extent_fraction;
+};
+
+struct ExplicitRKStagePoint {
+  ExplicitRKStageKind kind;
+  int stage_index;
+  int stage_count;
+  RationalCoefficient parent_fraction;
+};
+
+struct ExplicitRKTableau {
+  ExplicitRKMethod method;
+  int endpoint_order;
+  std::vector<std::vector<RationalCoefficient>> a;
+  std::vector<RationalCoefficient> b;
+  // RK4 and RKF78 retain explicit exact stage abscissae. DP87 intentionally
+  // leaves this empty and accumulates each converted A row left-to-right.
+  std::vector<RationalCoefficient> c;
+};
+
+const ExplicitRKTableau &explicit_rk_tableau(ExplicitRKMethod method);
+void validate_explicit_rk_tableau(const ExplicitRKTableau &tableau);
+RationalCoefficient explicit_rk_stage_fraction(ExplicitRKMethod method,
+                                                int stage_index);
+ExplicitRKStagePoint
+explicit_rk_stage_point(ExplicitRKMethod method,
+                        const ExplicitRKAdvanceFrame &frame,
+                        int stage_index);
+
+using ExplicitRKTableauFingerprint = std::array<std::uint8_t, 32>;
+ExplicitRKTableauFingerprint
+explicit_rk_tableau_fingerprint(ExplicitRKMethod method);
+
+struct NullExplicitRKObserver {
+  template <typename Scalar, typename State>
+  void initial_state(Scalar, const State &) const noexcept {}
+  template <typename Scalar, typename State>
+  void initial_rhs(Scalar, const State &) const noexcept {}
+  template <typename Scalar, typename State>
+  void stage_rhs(int, Scalar, const State &) const noexcept {}
+  template <typename Scalar, typename State>
+  void accepted_endpoint(Scalar, const State &) const noexcept {}
+};
+
+namespace detail {
+
+template <typename Ops, typename = void>
+struct accepts_stage_point : std::false_type {};
+
+template <typename Ops>
+struct accepts_stage_point<
+    Ops, std::void_t<decltype(std::declval<Ops &>().set_stage_point(
+             std::declval<const ExplicitRKStagePoint &>()))>>
+    : std::true_type {};
+
+template <typename Ops>
+void publish_stage_point(Ops &ops, const ExplicitRKStagePoint &point) {
+  if constexpr (accepts_stage_point<Ops>::value)
+    ops.set_stage_point(point);
+}
+
+template <typename Scalar>
+Scalar convert_coefficient(const RationalCoefficient coefficient) {
+  if (coefficient.denominator <= 0)
+    throw std::invalid_argument("explicit RK coefficient denominator is not positive");
+  const Scalar value = static_cast<Scalar>(coefficient.numerator) /
+                       static_cast<Scalar>(coefficient.denominator);
+  using std::isfinite;
+  if (!isfinite(value))
+    throw std::invalid_argument("explicit RK coefficient conversion is not finite");
+  return value;
+}
+
+template <typename Scalar>
+Scalar scale_rational_like_legacy(const Scalar value,
+                                  const RationalCoefficient coefficient) {
+  if (coefficient.denominator <= 0)
+    throw std::invalid_argument("explicit RK coefficient denominator is not positive");
+  return value * static_cast<Scalar>(coefficient.numerator) /
+         static_cast<Scalar>(coefficient.denominator);
+}
+
+template <typename Scalar>
+Scalar ratio_of_rationals(const RationalCoefficient numerator,
+                          const RationalCoefficient denominator) {
+  if (numerator.denominator <= 0 || denominator.denominator <= 0 ||
+      denominator.numerator == 0)
+    throw std::invalid_argument("invalid explicit RK rational ratio");
+  return (static_cast<Scalar>(numerator.numerator) *
+          static_cast<Scalar>(denominator.denominator)) /
+         (static_cast<Scalar>(numerator.denominator) *
+          static_cast<Scalar>(denominator.numerator));
+}
+
+template <typename Scalar> struct ConvertedTableau {
+  std::vector<std::vector<Scalar>> a;
+  std::vector<Scalar> b;
+  std::vector<Scalar> c;
+};
+
+template <typename Scalar>
+ConvertedTableau<Scalar> convert_tableau(const ExplicitRKTableau &tableau) {
+  ConvertedTableau<Scalar> result;
+  result.a.reserve(tableau.a.size());
+  for (const auto &row : tableau.a) {
+    std::vector<Scalar> converted;
+    converted.reserve(row.size());
+    for (const auto coefficient : row)
+      converted.push_back(convert_coefficient<Scalar>(coefficient));
+    result.a.push_back(std::move(converted));
+  }
+  result.b.reserve(tableau.b.size());
+  for (const auto coefficient : tableau.b)
+    result.b.push_back(convert_coefficient<Scalar>(coefficient));
+  result.c.reserve(tableau.c.size());
+  for (const auto coefficient : tableau.c)
+    result.c.push_back(convert_coefficient<Scalar>(coefficient));
+  Scalar b_sum = Scalar(0);
+  for (const Scalar coefficient : result.b)
+    b_sum += coefficient;
+  using std::abs;
+  if (!std::isfinite(b_sum) ||
+      abs(b_sum - Scalar(1)) >
+          Scalar(64) * std::numeric_limits<Scalar>::epsilon() *
+              Scalar(std::max<std::size_t>(1U, result.b.size())))
+    throw std::invalid_argument("explicit RK b coefficients do not sum to one");
+  if (tableau.method == ExplicitRKMethod::rkf78) {
+    for (std::size_t stage = 0; stage < result.a.size(); ++stage) {
+      Scalar row_sum = Scalar(0);
+      for (const Scalar coefficient : result.a[stage])
+        row_sum += coefficient;
+      if (abs(row_sum - result.c.at(stage)) >
+          Scalar(64) * std::numeric_limits<Scalar>::epsilon() *
+              Scalar(std::max<std::size_t>(1U,
+                                           result.a[stage].size())))
+        throw std::invalid_argument("RKF78 converted c does not match A row");
+    }
+  }
+  return result;
+}
+
+template <typename Scalar>
+const ConvertedTableau<Scalar> &
+canonical_converted_tableau(const ExplicitRKMethod method) {
+  switch (method) {
+  case ExplicitRKMethod::rkf78: {
+    static const ConvertedTableau<Scalar> converted =
+        convert_tableau<Scalar>(explicit_rk_tableau(ExplicitRKMethod::rkf78));
+    return converted;
+  }
+  case ExplicitRKMethod::dp87: {
+    static const ConvertedTableau<Scalar> converted =
+        convert_tableau<Scalar>(explicit_rk_tableau(ExplicitRKMethod::dp87));
+    return converted;
+  }
+  case ExplicitRKMethod::rk4:
+    break;
+  }
+  throw std::logic_error("RK4 does not require a converted tableau");
+}
+
+template <typename Scalar, typename State, std::size_t N>
+LinearCombinationView<Scalar, State>
+make_linear_combination_view(const std::array<Scalar, N> &factors,
+                             const std::array<const State *, N> &sources) {
+  return {factors.data(), sources.data(), N};
+}
+
+template <typename Scalar>
+void validate_interval_and_mode(const Scalar begin_time, const Scalar dt,
+                                const InitialRHSMode initial_rhs_mode) {
+  using std::isfinite;
+  if (!isfinite(begin_time) || !isfinite(dt) || !(dt > Scalar(0)) ||
+      !isfinite(begin_time + dt))
+    throw std::invalid_argument("explicit RK interval must be finite with positive dt");
+  if (initial_rhs_mode != InitialRHSMode::calculate &&
+      initial_rhs_mode != InitialRHSMode::reuse_loaded)
+    throw std::invalid_argument("invalid explicit RK initial RHS mode");
+}
+
+template <typename Ops>
+void validate_and_consume_loaded_rhs(
+    const typename Ops::scalar_type begin_time,
+    Ops &ops,
+    LoadedRHSToken<typename Ops::scalar_type> &loaded_rhs_token) {
+  if (loaded_rhs_token.consumed())
+    throw std::invalid_argument("loaded RHS token has already been consumed");
+  const auto &provenance = loaded_rhs_token.provenance();
+  using std::isfinite;
+  if (!isfinite(provenance.left_time) ||
+      provenance.left_time != begin_time ||
+      provenance.state_generation != ops.state_generation())
+    throw std::invalid_argument(
+        "loaded RHS token does not match the left state/time");
+  ops.validate_loaded_rhs_provenance(provenance);
+  ops.consume_loaded_rhs(provenance);
+  loaded_rhs_token.consume_once();
+}
+
+template <typename Ops, typename Observer>
+void advance_validated_explicit_rk(const ExplicitRKTableau &tableau,
+                                   const typename Ops::scalar_type begin_time,
+                                   const typename Ops::scalar_type dt,
+                                   const bool reuse_loaded_rhs,
+                                   const ExplicitRKAdvanceFrame &advance_frame,
+                                   Ops &ops,
+                                   Observer &observer) {
+  using Scalar = typename Ops::scalar_type;
+  using State = typename Ops::state_type;
+
+  const auto stage_point = [&](const int stage_index) {
+    return explicit_rk_stage_point(tableau.method, advance_frame,
+                                   stage_index);
+  };
+  const int stage_count = static_cast<int>(tableau.a.size());
+  publish_stage_point(ops, stage_point(1));
+  ops.prepare_initial(begin_time);
+  const auto old = ops.snapshot_state();
+  observer.initial_state(begin_time, ops.state());
+
+  const auto evaluate_stage = [&](const int stage, const Scalar stage_time) {
+    if (stage != 1 || !reuse_loaded_rhs)
+      ops.evaluate_rhs(stage);
+    ops.validate_rhs(stage);
+    if (stage == 1)
+      observer.initial_rhs(stage_time, ops.rhs());
+    observer.stage_rhs(stage, stage_time, ops.rhs());
+  };
+
+  if (tableau.method == ExplicitRKMethod::rk4) {
+    evaluate_stage(1, begin_time);
+    auto accumulator = ops.snapshot_rhs();
+
+    const Scalar half_dt =
+        scale_rational_like_legacy(dt, tableau.a.at(1).at(0));
+    const std::array<Scalar, 1> stage2_factors{{half_dt}};
+    const std::array<const State *, 1> stage2_sources{{&accumulator}};
+    publish_stage_point(ops, stage_point(2));
+    ops.update_state(1, begin_time + half_dt, Scalar(1),
+                     make_linear_combination_view(stage2_factors,
+                                                  stage2_sources));
+    evaluate_stage(2, begin_time + half_dt);
+    ops.accumulate_rk4(
+        accumulator,
+        ratio_of_rationals<Scalar>(tableau.b.at(1), tableau.b.at(0)),
+        ops.rhs());
+
+    const std::array<Scalar, 2> stage3_factors{{
+        Scalar(1),
+        scale_rational_like_legacy(dt, tableau.a.at(2).at(1))}};
+    const std::array<const State *, 2> stage3_sources{{&old, &ops.rhs()}};
+    publish_stage_point(ops, stage_point(3));
+    ops.update_state(2, begin_time + half_dt, Scalar(0),
+                     make_linear_combination_view(stage3_factors,
+                                                  stage3_sources));
+    evaluate_stage(3, begin_time + half_dt);
+    ops.accumulate_rk4(
+        accumulator,
+        ratio_of_rationals<Scalar>(tableau.b.at(2), tableau.b.at(0)),
+        ops.rhs());
+
+    const std::array<Scalar, 2> stage4_factors{{
+        Scalar(1),
+        scale_rational_like_legacy(dt, tableau.a.at(3).at(2))}};
+    const std::array<const State *, 2> stage4_sources{{&old, &ops.rhs()}};
+    publish_stage_point(ops, stage_point(4));
+    ops.update_state(3, begin_time + dt, Scalar(0),
+                     make_linear_combination_view(stage4_factors,
+                                                  stage4_sources));
+    evaluate_stage(4, begin_time + dt);
+    const std::array<Scalar, 3> endpoint_factors{{
+        Scalar(1), scale_rational_like_legacy(dt, tableau.b.at(0)),
+        scale_rational_like_legacy(dt, tableau.b.at(3))}};
+    const std::array<const State *, 3> endpoint_sources{{
+        &old, &accumulator, &ops.rhs()}};
+    publish_stage_point(ops, stage_point(stage_count));
+    ops.update_state(4, begin_time + dt, Scalar(0),
+                     make_linear_combination_view(endpoint_factors,
+                                                  endpoint_sources));
+  } else {
+    const auto &converted = canonical_converted_tableau<Scalar>(tableau.method);
+    std::array<std::optional<State>, 13> stages;
+    for (std::size_t step = 0; step < converted.a.size(); ++step) {
+      Scalar c = Scalar(0);
+      if (tableau.method == ExplicitRKMethod::rkf78) {
+        c = converted.c.at(step);
+      } else {
+        // Preserve the DP87 legacy left-to-right execution-scalar sum.
+        for (const Scalar coefficient : converted.a.at(step))
+          c += coefficient;
+      }
+      if (step > 0) {
+        std::array<Scalar, 14> factors{};
+        std::array<const State *, 14> sources{};
+        std::size_t count = 1;
+        factors[0] = Scalar(1);
+        sources[0] = &old;
+        for (std::size_t i = 0; i < converted.a.at(step).size(); ++i) {
+          const Scalar coefficient = converted.a.at(step).at(i);
+          if (coefficient != Scalar(0)) {
+            factors[count] = coefficient * dt;
+            sources[count] = &stages.at(i).value();
+            ++count;
+          }
+        }
+        publish_stage_point(ops, stage_point(static_cast<int>(step + 1)));
+        ops.update_state(static_cast<int>(step), begin_time + c * dt,
+                         Scalar(0), {factors.data(), sources.data(), count});
+      }
+      evaluate_stage(static_cast<int>(step + 1), begin_time + c * dt);
+      stages[step].emplace(ops.snapshot_rhs());
+    }
+
+    std::array<Scalar, 14> factors{};
+    std::array<const State *, 14> sources{};
+    std::size_t count = 1;
+    factors[0] = Scalar(1);
+    sources[0] = &old;
+    for (std::size_t i = 0; i < converted.b.size(); ++i) {
+      const Scalar coefficient = converted.b.at(i);
+      if (coefficient != Scalar(0)) {
+        factors[count] = coefficient * dt;
+        sources[count] = &stages.at(i).value();
+        ++count;
+      }
+    }
+    publish_stage_point(ops, stage_point(stage_count));
+    ops.update_state(static_cast<int>(converted.a.size()), begin_time + dt,
+                     Scalar(0), {factors.data(), sources.data(), count});
+  }
+  observer.accepted_endpoint(begin_time + dt, ops.state());
+}
+
+} // namespace detail
+
+template <typename Ops, typename Observer>
+void advance_explicit_rk(const ExplicitRKTableau &tableau,
+                         const typename Ops::scalar_type begin_time,
+                         const typename Ops::scalar_type dt,
+                         const InitialRHSMode initial_rhs_mode, Ops &ops,
+                         Observer &observer) {
+  validate_explicit_rk_tableau(tableau);
+  detail::validate_interval_and_mode(begin_time, dt, initial_rhs_mode);
+  if (initial_rhs_mode != InitialRHSMode::calculate)
+    throw std::invalid_argument(
+        "reuse_loaded requires an explicit loaded RHS token");
+  detail::advance_validated_explicit_rk(tableau, begin_time, dt,
+                                        false,
+                                        {ExplicitRKStageKind::primary,
+                                         {0, 1}, {1, 1}},
+                                        ops, observer);
+}
+
+template <typename Ops, typename Observer>
+void advance_explicit_rk(const ExplicitRKTableau &tableau,
+                         const typename Ops::scalar_type begin_time,
+                         const typename Ops::scalar_type dt,
+                         const InitialRHSMode initial_rhs_mode,
+                         const ExplicitRKAdvanceFrame &advance_frame, Ops &ops,
+                         Observer &observer) {
+  validate_explicit_rk_tableau(tableau);
+  detail::validate_interval_and_mode(begin_time, dt, initial_rhs_mode);
+  if (initial_rhs_mode != InitialRHSMode::calculate)
+    throw std::invalid_argument(
+        "reuse_loaded requires an explicit loaded RHS token");
+  detail::advance_validated_explicit_rk(tableau, begin_time, dt, false,
+                                        advance_frame, ops, observer);
+}
+
+template <typename Ops, typename Observer>
+void advance_explicit_rk(
+    const ExplicitRKTableau &tableau,
+    const typename Ops::scalar_type begin_time,
+    const typename Ops::scalar_type dt,
+    const InitialRHSMode initial_rhs_mode, Ops &ops, Observer &observer,
+    LoadedRHSToken<typename Ops::scalar_type> &loaded_rhs_token) {
+  validate_explicit_rk_tableau(tableau);
+  detail::validate_interval_and_mode(begin_time, dt, initial_rhs_mode);
+  if (initial_rhs_mode != InitialRHSMode::reuse_loaded)
+    throw std::invalid_argument(
+        "loaded RHS token is only valid with reuse_loaded");
+  detail::validate_and_consume_loaded_rhs(begin_time, ops, loaded_rhs_token);
+  detail::advance_validated_explicit_rk(tableau, begin_time, dt,
+                                        true,
+                                        {ExplicitRKStageKind::primary,
+                                         {0, 1}, {1, 1}},
+                                        ops, observer);
+}
+
+template <typename Ops, typename Observer>
+void advance_explicit_rk(
+    const ExplicitRKTableau &tableau,
+    const typename Ops::scalar_type begin_time,
+    const typename Ops::scalar_type dt,
+    const InitialRHSMode initial_rhs_mode,
+    const ExplicitRKAdvanceFrame &advance_frame, Ops &ops, Observer &observer,
+    LoadedRHSToken<typename Ops::scalar_type> &loaded_rhs_token) {
+  validate_explicit_rk_tableau(tableau);
+  detail::validate_interval_and_mode(begin_time, dt, initial_rhs_mode);
+  if (initial_rhs_mode != InitialRHSMode::reuse_loaded)
+    throw std::invalid_argument(
+        "loaded RHS token is only valid with reuse_loaded");
+  detail::validate_and_consume_loaded_rhs(begin_time, ops, loaded_rhs_token);
+  detail::advance_validated_explicit_rk(tableau, begin_time, dt, true,
+                                        advance_frame, ops, observer);
+}
+
+template <typename Ops, typename Observer>
+void advance_explicit_rk(const ExplicitRKMethod method,
+                         const typename Ops::scalar_type begin_time,
+                         const typename Ops::scalar_type dt,
+                         const InitialRHSMode initial_rhs_mode, Ops &ops,
+                         Observer &observer) {
+  const auto &tableau = explicit_rk_tableau(method);
+  advance_explicit_rk(tableau, begin_time, dt, initial_rhs_mode, ops, observer);
+}
+
+template <typename Ops, typename Observer>
+void advance_explicit_rk(
+    const ExplicitRKMethod method, const typename Ops::scalar_type begin_time,
+    const typename Ops::scalar_type dt,
+    const InitialRHSMode initial_rhs_mode, Ops &ops, Observer &observer,
+    LoadedRHSToken<typename Ops::scalar_type> &loaded_rhs_token) {
+  const auto &tableau = explicit_rk_tableau(method);
+  advance_explicit_rk(tableau, begin_time, dt, initial_rhs_mode, ops, observer,
+                      loaded_rhs_token);
+}
+
+template <typename Ops, typename Observer>
+void advance_explicit_rk(
+    const ExplicitRKMethod method, const typename Ops::scalar_type begin_time,
+    const typename Ops::scalar_type dt,
+    const InitialRHSMode initial_rhs_mode,
+    const ExplicitRKAdvanceFrame &advance_frame, Ops &ops, Observer &observer,
+    LoadedRHSToken<typename Ops::scalar_type> &loaded_rhs_token) {
+  const auto &tableau = explicit_rk_tableau(method);
+  advance_explicit_rk(tableau, begin_time, dt, initial_rhs_mode,
+                      advance_frame, ops, observer, loaded_rhs_token);
+}
+
+template <typename Ops>
+void advance_explicit_rk(const ExplicitRKTableau &tableau,
+                         const typename Ops::scalar_type begin_time,
+                         const typename Ops::scalar_type dt,
+                         const InitialRHSMode initial_rhs_mode, Ops &ops) {
+  NullExplicitRKObserver observer;
+  advance_explicit_rk(tableau, begin_time, dt, initial_rhs_mode, ops,
+                      observer);
+}
+
+template <typename Ops>
+void advance_explicit_rk(
+    const ExplicitRKTableau &tableau,
+    const typename Ops::scalar_type begin_time,
+    const typename Ops::scalar_type dt,
+    const InitialRHSMode initial_rhs_mode, Ops &ops,
+    LoadedRHSToken<typename Ops::scalar_type> &loaded_rhs_token) {
+  NullExplicitRKObserver observer;
+  advance_explicit_rk(tableau, begin_time, dt, initial_rhs_mode, ops, observer,
+                      loaded_rhs_token);
+}
+
+template <typename Ops>
+void advance_explicit_rk(
+    const ExplicitRKMethod method, const typename Ops::scalar_type begin_time,
+    const typename Ops::scalar_type dt,
+    const InitialRHSMode initial_rhs_mode,
+    const ExplicitRKAdvanceFrame &advance_frame, Ops &ops,
+    LoadedRHSToken<typename Ops::scalar_type> &loaded_rhs_token) {
+  NullExplicitRKObserver observer;
+  advance_explicit_rk(method, begin_time, dt, initial_rhs_mode, advance_frame,
+                      ops, observer, loaded_rhs_token);
+}
+
+template <typename Ops>
+void advance_explicit_rk(const ExplicitRKMethod method,
+                         const typename Ops::scalar_type begin_time,
+                         const typename Ops::scalar_type dt,
+                         const InitialRHSMode initial_rhs_mode, Ops &ops) {
+  NullExplicitRKObserver observer;
+  advance_explicit_rk(method, begin_time, dt, initial_rhs_mode, ops, observer);
+}
+
+template <typename Ops>
+void advance_explicit_rk(
+    const ExplicitRKMethod method, const typename Ops::scalar_type begin_time,
+    const typename Ops::scalar_type dt,
+    const InitialRHSMode initial_rhs_mode, Ops &ops,
+    LoadedRHSToken<typename Ops::scalar_type> &loaded_rhs_token) {
+  NullExplicitRKObserver observer;
+  advance_explicit_rk(method, begin_time, dt, initial_rhs_mode, ops, observer,
+                      loaded_rhs_token);
+}
+
+} // namespace ODESolvers
+
+#endif // ODESOLVERS_EXPLICIT_RK_HXX

--- a/ODESolvers/src/explicit_rk_dense_provider.hxx
+++ b/ODESolvers/src/explicit_rk_dense_provider.hxx
@@ -1,0 +1,254 @@
+#ifndef ODESOLVERS_EXPLICIT_RK_DENSE_PROVIDER_HXX
+#define ODESOLVERS_EXPLICIT_RK_DENSE_PROVIDER_HXX
+
+#include "explicit_rk.hxx"
+
+#include <subcycling_dense_output.hxx>
+#include <subcycling_dense_stencil.hxx>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace ODESolvers {
+
+template <class State> struct ReferenceDenseSample {
+  double theta;
+  CarpetX::DenseSampleKind kind;
+  State payload;
+
+  ReferenceDenseSample(const double theta_,
+                       const CarpetX::DenseSampleKind kind_, State payload_)
+      : theta(theta_), kind(kind_), payload(std::move(payload_)) {}
+
+  ReferenceDenseSample(const ReferenceDenseSample &) = delete;
+  ReferenceDenseSample &operator=(const ReferenceDenseSample &) = delete;
+  ReferenceDenseSample(ReferenceDenseSample &&) noexcept(
+      std::is_nothrow_move_constructible<State>::value) = default;
+  ReferenceDenseSample &operator=(ReferenceDenseSample &&) noexcept(
+      std::is_nothrow_move_assignable<State>::value) = default;
+};
+
+template <class State> class ReferenceDenseSampleBatch {
+public:
+  using sample_type = ReferenceDenseSample<State>;
+
+  ReferenceDenseSampleBatch(const ReferenceDenseSampleBatch &) = delete;
+  ReferenceDenseSampleBatch &operator=(const ReferenceDenseSampleBatch &) =
+      delete;
+  ReferenceDenseSampleBatch(ReferenceDenseSampleBatch &&) noexcept = default;
+  ReferenceDenseSampleBatch &
+  operator=(ReferenceDenseSampleBatch &&) noexcept = default;
+
+  const std::vector<sample_type> &samples() const noexcept { return samples_; }
+  std::size_t size() const noexcept { return samples_.size(); }
+  bool empty() const noexcept { return samples_.empty(); }
+
+private:
+  explicit ReferenceDenseSampleBatch(std::vector<sample_type> samples)
+      : samples_(std::move(samples)) {}
+
+  std::vector<sample_type> samples_;
+
+  template <class ScratchOps>
+  friend ReferenceDenseSampleBatch<typename ScratchOps::state_type>
+  collect_reference_dense_samples(
+      ExplicitRKMethod, typename ScratchOps::scalar_type,
+      typename ScratchOps::scalar_type,
+      const typename ScratchOps::state_type &,
+      const typename ScratchOps::state_type &,
+      const typename ScratchOps::state_type &, ScratchOps &);
+};
+
+inline CarpetX::SubcyclingODEMethod
+subcycling_method(const ExplicitRKMethod method) {
+  switch (method) {
+  case ExplicitRKMethod::rk4:
+    return CarpetX::SubcyclingODEMethod::rk4;
+  case ExplicitRKMethod::rkf78:
+    return CarpetX::SubcyclingODEMethod::rkf78_order7;
+  case ExplicitRKMethod::dp87:
+    return CarpetX::SubcyclingODEMethod::dp87_order8;
+  }
+  throw std::invalid_argument("unsupported explicit RK dense method");
+}
+
+inline CarpetX::DenseCapability
+reference_dense_capability(const ExplicitRKMethod method) {
+  const auto dense_method = subcycling_method(method);
+  const auto &specification =
+      CarpetX::reference_dense_stencil(dense_method).specification();
+  const auto fingerprint = explicit_rk_tableau_fingerprint(method);
+  return CarpetX::DenseCapability{
+      dense_method,
+      fingerprint,
+      specification.endpoint_order,
+      specification.dense_uniform_order,
+      specification.stage_count,
+      specification.extra_rhs_evaluations,
+      specification.dense_uniform_order + 1,
+      true,
+      true};
+}
+
+inline std::shared_ptr<const CarpetX::DenseOutputProvider>
+make_reference_dense_provider(const ExplicitRKMethod method) {
+  return std::make_shared<const CarpetX::DenseOutputProvider>(
+      reference_dense_capability(method));
+}
+
+inline RationalCoefficient
+reference_dense_sample_fraction(const ExplicitRKMethod method,
+                                const double theta) {
+  const auto match = [theta](const double expected,
+                             const RationalCoefficient exact) {
+    if (theta == expected)
+      return exact;
+    return RationalCoefficient{std::numeric_limits<std::int64_t>::min(), 1};
+  };
+  for (const auto candidate : {
+           match(0.0, {0, 1}), match(1.0, {1, 1}),
+           method == ExplicitRKMethod::rk4
+               ? match(0.5, {1, 2})
+               : RationalCoefficient{
+                     std::numeric_limits<std::int64_t>::min(), 1},
+           method == ExplicitRKMethod::rkf78
+               ? match(1.0 / 3.0, {1, 3})
+               : RationalCoefficient{
+                     std::numeric_limits<std::int64_t>::min(), 1},
+           method == ExplicitRKMethod::rkf78
+               ? match(2.0 / 3.0, {2, 3})
+               : RationalCoefficient{
+                     std::numeric_limits<std::int64_t>::min(), 1},
+           method == ExplicitRKMethod::dp87
+               ? match(0.25, {1, 4})
+               : RationalCoefficient{
+                     std::numeric_limits<std::int64_t>::min(), 1},
+           method == ExplicitRKMethod::dp87
+               ? match(0.5, {1, 2})
+               : RationalCoefficient{
+                     std::numeric_limits<std::int64_t>::min(), 1},
+           method == ExplicitRKMethod::dp87
+               ? match(0.75, {3, 4})
+               : RationalCoefficient{
+                     std::numeric_limits<std::int64_t>::min(), 1}}) {
+    if (candidate.numerator != std::numeric_limits<std::int64_t>::min())
+      return candidate;
+  }
+  throw std::logic_error(
+      "reference dense sample has no audited exact fraction");
+}
+
+template <class ScratchOps>
+ReferenceDenseSampleBatch<typename ScratchOps::state_type>
+collect_reference_dense_samples(
+    const ExplicitRKMethod method, const typename ScratchOps::scalar_type t0,
+    const typename ScratchOps::scalar_type parent_dt,
+    const typename ScratchOps::state_type &left_state,
+    const typename ScratchOps::state_type &left_rhs,
+    const typename ScratchOps::state_type &accepted_endpoint,
+    ScratchOps &scratch) {
+  using Scalar = typename ScratchOps::scalar_type;
+  using State = typename ScratchOps::state_type;
+  using Sample = ReferenceDenseSample<State>;
+
+  using std::isfinite;
+  if (!isfinite(t0) || !isfinite(parent_dt) || !(parent_dt > Scalar(0)) ||
+      !isfinite(t0 + parent_dt))
+    throw std::invalid_argument(
+        "reference dense interval must be finite with positive dt");
+
+  const auto dense_method = subcycling_method(method);
+  const auto &stencil = CarpetX::reference_dense_stencil(dense_method);
+  const auto &specification = stencil.specification();
+  const std::size_t initial_rhs_count = scratch.rhs_evaluation_count();
+  std::vector<Sample> candidate;
+  candidate.reserve(specification.constraints.size());
+
+  const auto append = [&](const CarpetX::DenseSampleConstraint constraint,
+                          State payload) {
+    candidate.emplace_back(constraint.theta, constraint.kind,
+                           std::move(payload));
+  };
+
+  std::size_t index = 0;
+  while (index < specification.constraints.size()) {
+    const auto value_constraint = specification.constraints[index];
+    if (value_constraint.kind != CarpetX::DenseSampleKind::value)
+      throw std::logic_error(
+          "reference dense stencil value/derivative order is invalid");
+
+    const Scalar theta = static_cast<Scalar>(value_constraint.theta);
+    const Scalar sample_time = t0 + theta * parent_dt;
+    const auto sample_fraction =
+        reference_dense_sample_fraction(method, value_constraint.theta);
+    if (value_constraint.theta == 0.0) {
+      scratch.restore_left(left_state, left_rhs, t0);
+      append(value_constraint, scratch.snapshot_state());
+    } else if (value_constraint.theta == 1.0) {
+      scratch.restore_state(accepted_endpoint, t0 + parent_dt);
+      append(value_constraint, scratch.snapshot_state());
+    } else {
+      scratch.restore_left(left_state, left_rhs, t0);
+      auto token = make_loaded_rhs_token(scratch, t0);
+      advance_explicit_rk(method, t0, theta * parent_dt,
+                          InitialRHSMode::reuse_loaded,
+                          {ExplicitRKStageKind::fractional, {0, 1},
+                           sample_fraction},
+                          scratch, token);
+      append(value_constraint, scratch.snapshot_state());
+    }
+    ++index;
+
+    if (index < specification.constraints.size()) {
+      const auto derivative_constraint = specification.constraints[index];
+      if (derivative_constraint.theta == value_constraint.theta) {
+        if (derivative_constraint.kind !=
+            CarpetX::DenseSampleKind::scaled_derivative)
+          throw std::logic_error(
+              "reference dense stencil has duplicate value samples");
+        if (value_constraint.theta == 0.0) {
+          scratch.restore_left(left_state, left_rhs, t0);
+          append(derivative_constraint, scratch.snapshot_rhs());
+        } else {
+          scratch.restore_state(candidate.back().payload, sample_time);
+          append(derivative_constraint,
+                 scratch.probe_endpoint_rhs(
+                     sample_time,
+                     {ExplicitRKStageKind::endpoint_probe, 1, 1,
+                      sample_fraction}));
+        }
+        ++index;
+      }
+    }
+  }
+
+  const std::size_t final_rhs_count = scratch.rhs_evaluation_count();
+  if (final_rhs_count < initial_rhs_count ||
+      final_rhs_count - initial_rhs_count !=
+          static_cast<std::size_t>(specification.extra_rhs_evaluations))
+    throw std::runtime_error(
+        "reference dense provider observed an unexpected extra RHS count");
+  if (candidate.size() != stencil.sample_count())
+    throw std::runtime_error(
+        "reference dense provider produced an incomplete sample batch");
+  for (std::size_t sample = 0; sample < candidate.size(); ++sample) {
+    const auto expected = specification.constraints[sample];
+    if (candidate[sample].theta != expected.theta ||
+        candidate[sample].kind != expected.kind)
+      throw std::runtime_error(
+          "reference dense provider sample order changed unexpectedly");
+  }
+
+  return ReferenceDenseSampleBatch<State>(std::move(candidate));
+}
+
+} // namespace ODESolvers
+
+#endif // ODESOLVERS_EXPLICIT_RK_DENSE_PROVIDER_HXX

--- a/ODESolvers/src/make.code.defn
+++ b/ODESolvers/src/make.code.defn
@@ -1,7 +1,8 @@
 # Main make.code.defn file for thorn ODESolvers
 
 # Source files in this directory
-SRCS = solve.cxx
+SRCS = explicit_rk.cxx subcycling_method_contract_schedule.cxx \
+       subcycling_ode_provider_registry.cxx solve.cxx
 
 # Subdirectories containing source files
 SUBDIRS =

--- a/ODESolvers/src/make.code.defn
+++ b/ODESolvers/src/make.code.defn
@@ -1,7 +1,9 @@
 # Main make.code.defn file for thorn ODESolvers
 
 # Source files in this directory
-SRCS = explicit_rk.cxx subcycling_method_contract_schedule.cxx \
+SRCS = explicit_rk.cxx subcycling_group_schema_builder.cxx \
+       subcycling_group_schema_cactus.cxx \
+       subcycling_method_contract_schedule.cxx \
        subcycling_ode_provider_registry.cxx solve.cxx
 
 # Subdirectories containing source files

--- a/ODESolvers/src/solve.cxx
+++ b/ODESolvers/src/solve.cxx
@@ -9,6 +9,14 @@
 #include <util_Table.h>
 
 #include <div.hxx>
+#include "cactus_explicit_rk_operations.hxx"
+#include "explicit_rk.hxx"
+#include "explicit_rk_dense_provider.hxx"
+#include "subcycling_ode_provider_registry.hxx"
+#include "subcycling_transaction_bridge.hxx"
+#include <subcycling_dense_output.hxx>
+#include <subcycling_scratch_state_transaction.hxx>
+#include <subcycling_step_context.hxx>
 
 #include <AMReX_MultiFab.H>
 
@@ -24,12 +32,14 @@ static inline int omp_get_max_threads() { return 1; }
 #include <cctype>
 #include <cmath>
 #include <cstring>
+#include <exception>
 #include <functional>
 #include <limits>
 #include <memory>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -70,6 +80,8 @@ constexpr details::return_type<D, Types...> make_array(Types &&...t) {
 
 // A state vector component, with mfabs for each level, group, and variable
 struct statecomp_t {
+  using scalar_type = CCTK_REAL;
+
   statecomp_t() = default;
 
   statecomp_t(statecomp_t &&) = default;
@@ -81,6 +93,31 @@ struct statecomp_t {
 
   std::vector<CarpetX::GHExt::PatchData::LevelData::GroupData *> groupdatas;
   std::vector<amrex::MultiFab *> mfabs;
+  std::optional<TransactionStateBackend> scratch_backend;
+
+  static statecomp_t from_scratch(TransactionStateBackend backend) {
+    statecomp_t result;
+    result.scratch_backend.emplace(std::move(backend));
+    return result;
+  }
+
+  bool is_scratch() const noexcept { return scratch_backend.has_value(); }
+  TransactionStateBackend &scratch() {
+    if (!scratch_backend)
+      throw std::logic_error("state component is not scratch-backed");
+    return *scratch_backend;
+  }
+  const TransactionStateBackend &scratch() const {
+    if (!scratch_backend)
+      throw std::logic_error("state component is not scratch-backed");
+    return *scratch_backend;
+  }
+  void replace_scratch(TransactionStateBackend backend) {
+    if (!is_scratch() || &scratch().transaction() != &backend.transaction())
+      throw std::invalid_argument(
+          "scratch state replacement changes backend or owner");
+    scratch_backend.emplace(std::move(backend));
+  }
 
   static void init_tmp_mfabs();
   static void free_tmp_mfabs();
@@ -99,6 +136,12 @@ struct statecomp_t {
   }
 
   statecomp_t copy(const CarpetX::valid_t where) const;
+  statecomp_t snapshot_state() const {
+    return copy(CarpetX::make_valid_all());
+  }
+  statecomp_t snapshot_rhs() const {
+    return copy(CarpetX::make_valid_int());
+  }
 
   template <std::size_t N>
   static void lincomb(const statecomp_t &dst, CCTK_REAL scale,
@@ -120,6 +163,10 @@ struct statecomp_t {
                       const std::vector<CCTK_REAL> &factors,
                       const std::vector<const statecomp_t *> &srcs,
                       const CarpetX::valid_t where);
+  static void lincomb(
+      const statecomp_t &dst, CCTK_REAL scale,
+      LinearCombinationView<CCTK_REAL, statecomp_t> combination,
+      const CarpetX::valid_t where);
 };
 
 template <std::size_t N> using reals = std::array<CCTK_REAL, N>;
@@ -155,6 +202,16 @@ void statecomp_t::free_tmp_mfabs() {
 
 // State that the state vector has valid data in the interior
 void statecomp_t::set_valid(const CarpetX::valid_t valid) const {
+  if (is_scratch()) {
+    auto &backend = const_cast<TransactionStateBackend &>(scratch());
+    backend.set_valid(CarpetX::ScratchStateRegion::interior,
+                      valid.valid_int);
+    backend.set_valid(CarpetX::ScratchStateRegion::outer,
+                      valid.valid_outer);
+    backend.set_valid(CarpetX::ScratchStateRegion::ghosts,
+                      valid.valid_ghosts);
+    return;
+  }
   for (auto groupdata : groupdatas) {
     for (int vi = 0; vi < groupdata->numvars; ++vi) {
       const int tl = 0;
@@ -234,6 +291,18 @@ void statecomp_t::combine_valids(const statecomp_t &dst, const CCTK_REAL scale,
 // Ensure a state vector has valid data in the interior
 void statecomp_t::check_valid(const CarpetX::valid_t required,
                               const std::function<std::string()> &why) const {
+  if (is_scratch()) {
+    const bool valid =
+        (!required.valid_int ||
+         scratch().valid(CarpetX::ScratchStateRegion::interior)) &&
+        (!required.valid_outer ||
+         scratch().valid(CarpetX::ScratchStateRegion::outer)) &&
+        (!required.valid_ghosts ||
+         scratch().valid(CarpetX::ScratchStateRegion::ghosts));
+    if (!valid)
+      throw std::runtime_error(why());
+    return;
+  }
   for (const auto groupdata : groupdatas) {
     for (int vi = 0; vi < groupdata->numvars; ++vi) {
       const int tl = 0;
@@ -251,6 +320,16 @@ void statecomp_t::check_valid(const CarpetX::valid_t required,
 
 // Copy state vector into newly allocated memory
 statecomp_t statecomp_t::copy(const CarpetX::valid_t where) const {
+  if (is_scratch()) {
+    auto result = statecomp_t::from_scratch(scratch().clone());
+    if (!where.valid_int)
+      result.scratch().set_valid(CarpetX::ScratchStateRegion::interior, false);
+    if (!where.valid_outer)
+      result.scratch().set_valid(CarpetX::ScratchStateRegion::outer, false);
+    if (!where.valid_ghosts)
+      result.scratch().set_valid(CarpetX::ScratchStateRegion::ghosts, false);
+    return result;
+  }
   const std::size_t size = mfabs.size();
   statecomp_t result;
   result.groupdatas.reserve(size);
@@ -288,6 +367,26 @@ void statecomp_t::lincomb(const statecomp_t &dst, const CCTK_REAL scale,
                           const std::array<CCTK_REAL, N> &factors,
                           const std::array<const statecomp_t *, N> &srcs,
                           const CarpetX::valid_t where) {
+  if (dst.is_scratch()) {
+    if (!where.valid_int || where.valid_outer || where.valid_ghosts)
+      throw std::invalid_argument(
+          "scratch RK arithmetic supports interior validity only");
+    std::vector<TransactionStateBackend::LinearTerm> terms;
+    terms.reserve(N);
+    for (std::size_t n = 0; n < N; ++n) {
+      if (srcs[n] == nullptr || !srcs[n]->is_scratch())
+        throw std::invalid_argument(
+            "scratch RK arithmetic cannot mix live state components");
+      terms.push_back({factors[n], &srcs[n]->scratch()});
+    }
+    const_cast<TransactionStateBackend &>(dst.scratch())
+        .linear_combination(scale, terms);
+    return;
+  }
+  for (const auto *const source : srcs)
+    if (source == nullptr || source->is_scratch())
+      throw std::invalid_argument(
+          "live RK arithmetic cannot mix scratch state components");
   const std::size_t size = dst.mfabs.size();
   for (std::size_t n = 0; n < N; ++n)
     assert(srcs[n]->mfabs.size() == size);
@@ -498,7 +597,63 @@ void call_lincomb(const statecomp_t &dst, const CCTK_REAL scale,
   }
   statecomp_t::lincomb(dst, scale, factors1, srcs1, where);
 }
+
+template <std::size_t N>
+void call_lincomb_view(
+    const statecomp_t &dst, const CCTK_REAL scale,
+    const LinearCombinationView<CCTK_REAL, statecomp_t> combination,
+    const CarpetX::valid_t where) {
+  assert(combination.size == N);
+  std::array<CCTK_REAL, N> factors;
+  std::array<const statecomp_t *, N> sources;
+  for (std::size_t n = 0; n < N; ++n) {
+    factors[n] = combination.factors[n];
+    sources[n] = combination.sources[n];
+  }
+  statecomp_t::lincomb(dst, scale, factors, sources, where);
+}
 } // namespace detail
+
+void statecomp_t::lincomb(
+    const statecomp_t &dst, const CCTK_REAL scale,
+    const LinearCombinationView<CCTK_REAL, statecomp_t> combination,
+    const CarpetX::valid_t where) {
+  switch (combination.size) {
+  case 0:
+    return detail::call_lincomb_view<0>(dst, scale, combination, where);
+  case 1:
+    return detail::call_lincomb_view<1>(dst, scale, combination, where);
+  case 2:
+    return detail::call_lincomb_view<2>(dst, scale, combination, where);
+  case 3:
+    return detail::call_lincomb_view<3>(dst, scale, combination, where);
+  case 4:
+    return detail::call_lincomb_view<4>(dst, scale, combination, where);
+  case 5:
+    return detail::call_lincomb_view<5>(dst, scale, combination, where);
+  case 6:
+    return detail::call_lincomb_view<6>(dst, scale, combination, where);
+  case 7:
+    return detail::call_lincomb_view<7>(dst, scale, combination, where);
+  case 8:
+    return detail::call_lincomb_view<8>(dst, scale, combination, where);
+  case 9:
+    return detail::call_lincomb_view<9>(dst, scale, combination, where);
+  case 10:
+    return detail::call_lincomb_view<10>(dst, scale, combination, where);
+  case 11:
+    return detail::call_lincomb_view<11>(dst, scale, combination, where);
+  case 12:
+    return detail::call_lincomb_view<12>(dst, scale, combination, where);
+  case 13:
+    return detail::call_lincomb_view<13>(dst, scale, combination, where);
+  case 14:
+    return detail::call_lincomb_view<14>(dst, scale, combination, where);
+  default:
+    CCTK_VERROR("Unsupported explicit RK vector length: %d",
+                static_cast<int>(combination.size));
+  }
+}
 
 void statecomp_t::lincomb(const statecomp_t &dst, const CCTK_REAL scale,
                           const std::vector<CCTK_REAL> &factors,
@@ -670,6 +825,53 @@ void mark_invalid(const std::vector<int> &groups) {
   });
 }
 
+CarpetX::StageKind
+carpetx_stage_kind(const ExplicitRKStageKind stage_kind) {
+  switch (stage_kind) {
+  case ExplicitRKStageKind::primary:
+    return CarpetX::StageKind::primary;
+  case ExplicitRKStageKind::fractional:
+    return CarpetX::StageKind::fractional;
+  case ExplicitRKStageKind::endpoint_probe:
+    return CarpetX::StageKind::endpoint_probe;
+  }
+  throw std::invalid_argument("explicit RK stage kind is invalid");
+}
+
+CarpetX::StagePoint
+carpetx_stage_point(const ExplicitRKStagePoint &stage_point,
+                    const double stage_time) {
+  if (stage_point.parent_fraction.denominator <= 0)
+    throw std::invalid_argument(
+        "explicit RK exact stage fraction denominator is not positive");
+  return {carpetx_stage_kind(stage_point.kind), stage_point.stage_index,
+          stage_point.stage_count,
+          CarpetX::step_clock_t(stage_point.parent_fraction.numerator,
+                                stage_point.parent_fraction.denominator),
+          stage_time};
+}
+
+void prepare_subcycling_stage(
+    const ExplicitRKStagePoint &stage_point, const double stage_time,
+    const CarpetX::SubcyclingODEMethod active_method,
+    const char *const method_name) {
+  if (!CarpetX::step_context_active())
+    return;
+
+  try {
+    CarpetX::prepare_stage(carpetx_stage_point(stage_point, stage_time),
+                           active_method);
+  } catch (const std::exception &error) {
+    CCTK_VERROR("Subcycling stage preparation failed at t=%.17g for ODE "
+                "method \"%s\": %s",
+                stage_time, method_name, error.what());
+  } catch (...) {
+    CCTK_VERROR("Subcycling stage preparation failed at t=%.17g for ODE "
+                "method \"%s\" with an unknown exception",
+                stage_time, method_name);
+  }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 extern "C" void ODESolvers_InitConstants(CCTK_ARGUMENTS) {
@@ -683,6 +885,65 @@ extern "C" void ODESolvers_Solve(CCTK_ARGUMENTS) {
   DECLARE_CCTK_ARGUMENTS_ODESolvers_Solve;
   DECLARE_CCTK_PARAMETERS;
 
+  const CCTK_REAL dt = CCTK_DELTA_TIME;
+  const CCTK_REAL saved_time = cctkGH->cctk_time;
+  const CCTK_REAL old_time = saved_time - dt;
+  auto active_method = CarpetX::SubcyclingODEMethod::rk4;
+  const CarpetX::StepContext *active_context = nullptr;
+  const SubcyclingODEProviderCapability *active_provider = nullptr;
+  CarpetX::ScratchStateTransaction *active_transaction = nullptr;
+  if (CarpetX::step_context_active()) {
+    active_context = CarpetX::current_step_context();
+    active_transaction = CarpetX::current_scratch_state_transaction();
+    try {
+      const auto &candidate =
+          require_subcycling_ode_provider(std::string_view(method));
+      if (active_context->method != candidate.dense.method)
+        throw std::invalid_argument(
+            "ODE provider method differs from the active StepContext");
+
+      const auto &tableau = explicit_rk_tableau(candidate.method);
+      if (candidate.dense.method != subcycling_method(candidate.method) ||
+          candidate.dense.tableau_fingerprint !=
+              explicit_rk_tableau_fingerprint(candidate.method) ||
+          candidate.dense.endpoint_order != tableau.endpoint_order ||
+          candidate.dense.dense_uniform_order < tableau.endpoint_order ||
+          candidate.dense.stage_count !=
+              static_cast<int>(tableau.a.size()) ||
+          !candidate.dense.arbitrary_theta || !candidate.dense.verified)
+        throw std::invalid_argument(
+            "ODE provider dense capability differs from its exact tableau");
+
+      active_provider = &candidate;
+      active_method = candidate.dense.method;
+    } catch (const std::exception &error) {
+      CCTK_VERROR("Active subcycling ODE provider validation failed for "
+                  "method \"%s\": %s",
+                  method, error.what());
+    } catch (...) {
+      CCTK_VERROR("Active subcycling ODE provider validation failed for "
+                  "method \"%s\" with an unknown exception",
+                  method);
+    }
+
+    const auto interval_time_scale =
+        std::max({1.0, std::abs(active_context->begin_time),
+                  std::abs(active_context->end_time)});
+    const auto interval_tolerance =
+        16.0 * std::numeric_limits<double>::epsilon() * interval_time_scale;
+    if (!std::isfinite(old_time) || !std::isfinite(saved_time) ||
+        !std::isfinite(dt) ||
+        std::abs(old_time - active_context->begin_time) > interval_tolerance ||
+        std::abs(saved_time - active_context->end_time) > interval_tolerance ||
+        std::abs(dt -
+                 (active_context->end_time - active_context->begin_time)) >
+            interval_tolerance)
+      CCTK_VERROR("ODE solver interval [%g,%g] with dt=%g does not match "
+                  "active subcycling StepContext [%g,%g]",
+                  double(old_time), double(saved_time), double(dt),
+                  active_context->begin_time, active_context->end_time);
+  }
+
   static bool did_output = false;
   if (verbose || !did_output)
     CCTK_VINFO("ODE integrator is %s", method);
@@ -691,7 +952,6 @@ extern "C" void ODESolvers_Solve(CCTK_ARGUMENTS) {
   static CarpetX::Timer timer("ODESolvers::Solve");
   CarpetX::Interval interval(timer);
 
-  const CCTK_REAL dt = cctk_delta_time;
   const int tl = 0;
 
   static CarpetX::Timer timer_setup("ODESolvers::Solve::setup");
@@ -699,6 +959,7 @@ extern "C" void ODESolvers_Solve(CCTK_ARGUMENTS) {
 
   statecomp_t var, rhs;
   std::vector<int> var_groups, rhs_groups, dep_groups;
+  std::vector<CarpetX::ScratchGroupPair> ordered_group_pairs;
   int nvars = 0;
   bool do_accumulate_nvars = true;
   assert(CarpetX::active_levels);
@@ -722,6 +983,7 @@ extern "C" void ODESolvers_Solve(CCTK_ARGUMENTS) {
           nvars += groupdata.numvars;
           var_groups.push_back(groupdata.groupindex);
           rhs_groups.push_back(rhs_gi);
+          ordered_group_pairs.push_back({groupdata.groupindex, rhs_gi});
           const auto &dependents = get_group_dependents(groupdata.groupindex);
           dep_groups.insert(dep_groups.end(), dependents.begin(),
                             dependents.end());
@@ -734,6 +996,21 @@ extern "C" void ODESolvers_Solve(CCTK_ARGUMENTS) {
     CCTK_VINFO("  Integrating %d variables", nvars);
   if (nvars == 0)
     CCTK_VWARN(CCTK_WARN_ALERT, "Integrating %d variables", nvars);
+
+  bool scratch_group_pairs_match = true;
+  if (active_transaction != nullptr) {
+    const auto &certified_pairs = active_transaction->group_pairs();
+    scratch_group_pairs_match =
+        certified_pairs.size() == ordered_group_pairs.size();
+    for (std::size_t pair = 0;
+         scratch_group_pairs_match && pair < ordered_group_pairs.size();
+         ++pair)
+      scratch_group_pairs_match =
+          certified_pairs[pair].evolved_group ==
+              ordered_group_pairs[pair].evolved_group &&
+          certified_pairs[pair].rhs_group ==
+              ordered_group_pairs[pair].rhs_group;
+  }
 
   {
     std::sort(var_groups.begin(), var_groups.end());
@@ -756,6 +1033,10 @@ extern "C" void ODESolvers_Solve(CCTK_ARGUMENTS) {
     dep_groups.erase(last, dep_groups.end());
   }
 
+  const bool scratch_dependent_groups_match =
+      active_transaction == nullptr ||
+      active_transaction->dependent_groups() == dep_groups;
+
   for (const int gi : var_groups)
     assert(std::find(dep_groups.begin(), dep_groups.end(), gi) ==
            dep_groups.end());
@@ -771,9 +1052,6 @@ extern "C" void ODESolvers_Solve(CCTK_ARGUMENTS) {
     statecomp_t::init_tmp_mfabs();
   }
 
-  const CCTK_REAL saved_time = cctkGH->cctk_time;
-  const CCTK_REAL old_time = cctkGH->cctk_time - dt;
-
   static CarpetX::Timer timer_lincomb("ODESolvers::Solve::lincomb");
   static CarpetX::Timer timer_rhs("ODESolvers::Solve::rhs");
   static CarpetX::Timer timer_poststep("ODESolvers::Solve::poststep");
@@ -781,37 +1059,56 @@ extern "C" void ODESolvers_Solve(CCTK_ARGUMENTS) {
   const auto copy_state = [](const auto &var, const CarpetX::valid_t where) {
     return var.copy(where);
   };
-  const auto calcrhs = [&](const int n) {
+  const auto evaluate_rhs = [&](const int n) {
     CarpetX::Interval interval_rhs(timer_rhs);
     if (verbose)
       CCTK_VINFO("Calculating RHS #%d at t=%g", n, double(cctkGH->cctk_time));
     CallScheduleGroup(cctkGH, "ODESolvers_RHS");
+  };
+  const auto validate_rhs = [&](const int) {
     rhs.check_valid(CarpetX::make_valid_int(),
                     "ODESolvers after calling ODESolvers_RHS");
   };
+  const auto calcrhs = [&](const int n) {
+    evaluate_rhs(n);
+    validate_rhs(n);
+  };
+  const auto calcupdate_at_time =
+      [&](const int n, const CCTK_REAL stage_time, const CCTK_REAL a0,
+          const auto &as, const auto &vars) {
+        {
+          CarpetX::Interval interval_lincomb(timer_lincomb);
+          statecomp_t::lincomb(var, a0, as, vars,
+                               CarpetX::make_valid_int());
+          var.check_valid(CarpetX::make_valid_int(),
+                          "ODESolvers after defining new state vector");
+          mark_invalid(dep_groups);
+        }
+        {
+          CarpetX::Interval interval_poststep(timer_poststep);
+          *const_cast<CCTK_REAL *>(&cctkGH->cctk_time) = stage_time;
+          CallScheduleGroup(cctkGH, "ODESolvers_PostStep");
+          if (verbose)
+            CCTK_VINFO("Calculated new state #%d at t=%g", n,
+                       double(cctkGH->cctk_time));
+        }
+      };
   // t = t_0 + c
   // var = a_0 * var + \Sum_i a_i * var_i
   const auto calcupdate = [&](const int n, const CCTK_REAL c,
                               const CCTK_REAL a0, const auto &as,
                               const auto &vars) {
-    {
-      CarpetX::Interval interval_lincomb(timer_lincomb);
-      statecomp_t::lincomb(var, a0, as, vars, CarpetX::make_valid_int());
-      var.check_valid(CarpetX::make_valid_int(),
-                      "ODESolvers after defining new state vector");
-      mark_invalid(dep_groups);
-    }
-    {
-      CarpetX::Interval interval_poststep(timer_poststep);
-      *const_cast<CCTK_REAL *>(&cctkGH->cctk_time) = old_time + c;
-      CallScheduleGroup(cctkGH, "ODESolvers_PostStep");
-      if (verbose)
-        CCTK_VINFO("Calculated new state #%d at t=%g", n,
-                   double(cctkGH->cctk_time));
-    }
+    calcupdate_at_time(n, old_time + c, a0, as, vars);
   };
 
-  *const_cast<CCTK_REAL *>(&cctkGH->cctk_time) = old_time;
+  const bool uses_extracted_explicit_rk =
+      active_provider != nullptr ||
+      (active_context == nullptr &&
+       (CCTK_EQUALS(method, "RK4") || CCTK_EQUALS(method, "RKF78") ||
+        CCTK_EQUALS(method, "DP87")));
+  if (!uses_extracted_explicit_rk) {
+    *const_cast<CCTK_REAL *>(&cctkGH->cctk_time) = old_time;
+  }
 
   if (CCTK_EQUALS(method, "constant")) {
 
@@ -885,264 +1182,259 @@ extern "C" void ODESolvers_Solve(CCTK_ARGUMENTS) {
     calcupdate(3, dt, 0.0, reals<4>{1.0, dt / 6, dt / 6, 2 * dt / 3},
                states<4>{&old, &k1, &k2, &rhs});
 
-  } else if (CCTK_EQUALS(method, "RK4")) {
+  } else if (uses_extracted_explicit_rk) {
 
-    // k1 = f(y0)
-    // k2 = f(y0 + h/2 k1)
-    // k3 = f(y0 + h/2 k2)
-    // k4 = f(y0 + h k3)
-    // y1 = y0 + h/6 k1 + h/3 k2 + h/3 k3 + h/6 k4
-
-    const auto old = copy_state(var, CarpetX::make_valid_all());
-
-    calcrhs(1);
-    const auto kaccum = copy_state(rhs, CarpetX::make_valid_int());
-    calcupdate(1, dt / 2, 1.0, reals<1>{dt / 2}, states<1>{&kaccum});
-
-    calcrhs(2);
-    {
-      CarpetX::Interval interval_lincomb(timer_lincomb);
-      statecomp_t::lincomb(kaccum, 1.0, reals<1>{2.0}, states<1>{&rhs},
-                           CarpetX::make_valid_int());
-    }
-    calcupdate(2, dt / 2, 0.0, reals<2>{1.0, dt / 2}, states<2>{&old, &rhs});
-
-    calcrhs(3);
-    {
-      CarpetX::Interval interval_lincomb(timer_lincomb);
-      statecomp_t::lincomb(kaccum, 1.0, reals<1>{2.0}, states<1>{&rhs},
-                           CarpetX::make_valid_int());
-    }
-    calcupdate(3, dt, 0.0, reals<2>{1.0, dt}, states<2>{&old, &rhs});
-
-    calcrhs(4);
-    calcupdate(4, dt, 0.0, reals<3>{1.0, dt / 6, dt / 6},
-               states<3>{&old, &kaccum, &rhs});
-
-  } else if (CCTK_EQUALS(method, "RKF78")) {
-
-    typedef CCTK_REAL T;
-    const auto R = [](T x, T y) { return x / y; };
-    const std::tuple<std::vector<std::tuple<T, std::vector<T> > >,
-                     std::vector<T> >
-        tableau{
-            {
-                {/* 1 */ 0, {}},                                           //
-                {/* 2 */ R(2, 27), {R(2, 27)}},                            //
-                {/* 3 */ R(1, 9), {R(1, 36), R(3, 36)}},                   //
-                {/* 4 */ R(1, 6), {R(1, 24), 0, R(3, 24)}},                //
-                {/* 5 */ R(5, 12), {R(20, 48), 0, R(-75, 48), R(75, 48)}}, //
-                {/* 6 */ R(1, 2), {R(1, 20), 0, 0, R(5, 20), R(4, 20)}},   //
-                {/* 7 */ R(5, 6),
-                 {R(-25, 108), 0, 0, R(125, 108), R(-260, 108),
-                  R(250, 108)}}, //
-                {/* 8 */ R(1, 6),
-                 {R(31, 300), 0, 0, 0, R(61, 225), R(-2, 9), R(13, 900)}}, //
-                {/* 9 */ R(2, 3),
-                 {2, 0, 0, R(-53, 6), R(704, 45), R(-107, 9), R(67, 90), 3}}, //
-                {/* 10 */ R(1, 3),
-                 {R(-91, 108), 0, 0, R(23, 108), R(-976, 135), R(311, 54),
-                  R(-19, 60), R(17, 6), R(-1, 12)}}, //
-                {/* 11 */ 1,
-                 {R(2383, 4100), 0, 0, R(-341, 164), R(4496, 1025), R(-301, 82),
-                  R(2133, 4100), R(45, 82), R(45, 164),
-                  R(18, 41)}}, //
-                               // {/* 12 */ 0,
-                //  {R(3, 205), 0, 0, 0, 0, R(-6, 41), R(-3, 205), R(-3, 41),
-                //  R(3, 41),
-                //   R(6, 41)}}, //
-                // {/* 13 */ 1,
-                //  {R(-1777, 4100), 0, 0, R(-341, 164), R(4496, 1025), R(-289,
-                //  82),
-                //   R(2193, 4100), R(51, 82), R(33, 164), R(12, 41), 0, 1}}, //
-            },
-            {
-                R(41, 840), 0, 0, 0, 0, R(34, 105), R(9, 35), R(9, 35),
-                R(9, 280), R(9, 280), R(41, 840),
-                // 0,
-                // 0,
-            }};
-
-    // Check Butcher tableau
-    const std::size_t nsteps = std::get<0>(tableau).size();
-    {
-      for (std::size_t step = 0; step < nsteps; ++step) {
-        // TODO: Could allow <=
-        assert(std::get<1>(std::get<0>(tableau).at(step)).size() == step);
-        const auto &c = std::get<0>(std::get<0>(tableau).at(step));
-        const auto &as = std::get<1>(std::get<0>(tableau).at(step));
-        T x = 0;
-        for (const auto &a : as)
-          x += a;
-        assert(fabs(x - c) <= 10 * std::numeric_limits<T>::epsilon());
-      }
-      // TODO: Could allow <=
-      assert(std::get<1>(tableau).size() == nsteps);
-      const auto &bs = std::get<1>(tableau);
-      T x = 0;
-      for (const auto &b : bs)
-        x += b;
-      assert(fabs(x - 1) <= 10 * std::numeric_limits<T>::epsilon());
+    ExplicitRKMethod explicit_method = ExplicitRKMethod::rk4;
+    if (active_provider != nullptr) {
+      explicit_method = active_provider->method;
+    } else {
+      if (CCTK_EQUALS(method, "RK4"))
+        explicit_method = ExplicitRKMethod::rk4;
+      else if (CCTK_EQUALS(method, "RKF78"))
+        explicit_method = ExplicitRKMethod::rkf78;
+      else if (CCTK_EQUALS(method, "DP87"))
+        explicit_method = ExplicitRKMethod::dp87;
+      else
+        CCTK_VERROR(
+            "Internal explicit RK method dispatch failure for \"%s\"",
+            method);
     }
 
-    const auto old = copy_state(var, CarpetX::make_valid_all());
-
-    std::vector<statecomp_t> ks;
-    ks.reserve(nsteps);
-    for (std::size_t step = 0; step < nsteps; ++step) {
-      // Skip the first state vector calculation, it is always trivial
-      if (step > 0) {
-        const auto &c = std::get<0>(std::get<0>(tableau).at(step));
-        const auto &as = std::get<1>(std::get<0>(tableau).at(step));
-
-        // Add scaled RHS to state vector
-        std::vector<CCTK_REAL> factors;
-        std::vector<const statecomp_t *> srcs;
-        factors.reserve(as.size() + 1);
-        srcs.reserve(as.size() + 1);
-        factors.push_back(1.0);
-        srcs.push_back(&old);
-        for (std::size_t i = 0; i < as.size(); ++i) {
-          if (as.at(i) != 0) {
-            factors.push_back(as.at(i) * dt);
-            srcs.push_back(&ks.at(i));
-          }
-        }
-        calcupdate(step, c * dt, 0.0, factors, srcs);
-        // TODO: Deallocate ks that are not needed any more
-      }
-
-      calcrhs(step + 1);
-      ks.push_back(copy_state(rhs, CarpetX::make_valid_int()));
-    }
-
-    // Calculate new state vector
-    const auto &bs = std::get<1>(tableau);
-    std::vector<CCTK_REAL> factors;
-    std::vector<const statecomp_t *> srcs;
-    factors.reserve(bs.size() + 1);
-    srcs.reserve(bs.size() + 1);
-    factors.push_back(1);
-    srcs.push_back(&old);
-    for (std::size_t i = 0; i < bs.size(); ++i) {
-      if (bs.at(i) != 0) {
-        factors.push_back(bs.at(i) * dt);
-        srcs.push_back(&ks.at(i));
-      }
-    }
-    calcupdate(nsteps, dt, 0.0, factors, srcs);
-
-  } else if (CCTK_EQUALS(method, "DP87")) {
-
-    typedef CCTK_REAL T;
-    const auto R = [](T x, T y) { return x / y; };
-    // These coefficients are taken from the Einstein Toolkit, thorn
-    // CactusNumerical/MoL, file RK87.c, written by Peter Diener,
-    // following P. J. Prince and J. R. Dormand, Journal of
-    // Computational and Applied Mathematics, volume 7, no 1, 1981
-    const std::tuple<std::vector<std::vector<T> >, std::vector<T> > tableau{
-        {
-            {/*1*/},                                    //
-            {/*2*/ R(1, 18)},                           //
-            {/*3*/ R(1, 48), R(1, 16)},                 //
-            {/*4*/ R(1, 32), 0, R(3, 32)},              //
-            {/*5*/ R(5, 16), 0, -R(75, 64), R(75, 64)}, //
-            {/*6*/ R(3, 80), 0, 0, R(3, 16), R(3, 20)}, //
-            {/*7*/ R(29443841, 614563906), 0, 0, R(77736538, 692538347),
-             -R(28693883, 1125000000), R(23124283, 1800000000)}, //
-            {/*8*/ R(16016141, 946692911), 0, 0, R(61564180, 158732637),
-             R(22789713, 633445777), R(545815736, 2771057229),
-             -R(180193667, 1043307555)}, //
-            {/*9*/ R(39632708, 573591083), 0, 0, -R(433636366, 683701615),
-             -R(421739975, 2616292301), R(100302831, 723423059),
-             R(790204164, 839813087), R(800635310, 3783071287)}, //
-            {/*10*/ R(246121993, 1340847787), 0, 0,
-             -R(37695042795, 15268766246), -R(309121744, 1061227803),
-             -R(12992083, 490766935), R(6005943493, 2108947869),
-             R(393006217, 1396673457), R(123872331, 1001029789)}, //
-            {/*11*/ -R(1028468189, 846180014), 0, 0, R(8478235783, 508512852),
-             R(1311729495, 1432422823), -R(10304129995, 1701304382),
-             -R(48777925059, 3047939560), R(15336726248, 1032824649),
-             -R(45442868181, 3398467696), R(3065993473, 597172653)}, //
-            {/*12*/ R(185892177, 718116043), 0, 0, -R(3185094517, 667107341),
-             -R(477755414, 1098053517), -R(703635378, 230739211),
-             R(5731566787, 1027545527), R(5232866602, 850066563),
-             -R(4093664535, 808688257), R(3962137247, 1805957418),
-             R(65686358, 487910083)}, //
-            {/*13*/ R(403863854, 491063109), 0, 0, -R(5068492393, 434740067),
-             -R(411421997, 543043805), R(652783627, 914296604),
-             R(11173962825, 925320556), -R(13158990841, 6184727034),
-             R(3936647629, 1978049680), -R(160528059, 685178525),
-             R(248638103, 1413531060), 0}, //
+    int explicit_update_index = 0;
+    CactusExplicitRKOperations operations{
+        var,
+        rhs,
+        [&](const CCTK_REAL stage_time) {
+          *const_cast<CCTK_REAL *>(&cctkGH->cctk_time) = stage_time;
         },
-        {R(14005451, 335480064), 0, 0, 0, 0, -R(59238493, 1068277825),
-         R(181606767, 758867731), R(561292985, 797845732),
-         -R(1041891430, 1371343529), R(760417239, 1151165299),
-         R(118820643, 751138087), -R(528747749, 2220607170), R(1, 4)}};
-
-    // Check Butcher tableau
-    const std::size_t nsteps = std::get<0>(tableau).size();
-    {
-      for (std::size_t step = 0; step < nsteps; ++step)
-        // TODO: Could allow <=
-        assert(std::get<0>(tableau).at(step).size() == step);
-      // TODO: Could allow <=
-      assert(std::get<1>(tableau).size() == nsteps);
-      const auto &bs = std::get<1>(tableau);
-      T x = 0;
-      for (const auto &b : bs)
-        x += b;
-      assert(fabs(x - 1) <= 10 * std::numeric_limits<T>::epsilon());
-    }
-
-    const auto old = copy_state(var, CarpetX::make_valid_all());
-
-    std::vector<statecomp_t> ks;
-    ks.reserve(nsteps);
-    for (std::size_t step = 0; step < nsteps; ++step) {
-      // Skip the first state vector calculation, it is always trivial
-      if (step > 0) {
-        const auto &as = std::get<0>(tableau).at(step);
-        T c = 0;
-        for (const auto &a : as)
-          c += a;
-
-        // Add scaled RHS to state vector
-        std::vector<CCTK_REAL> factors;
-        std::vector<const statecomp_t *> srcs;
-        factors.reserve(as.size() + 1);
-        srcs.reserve(as.size() + 1);
-        factors.push_back(1.0);
-        srcs.push_back(&old);
-        for (std::size_t i = 0; i < as.size(); ++i) {
-          if (as.at(i) != 0) {
-            factors.push_back(as.at(i) * dt);
-            srcs.push_back(&ks.at(i));
+        evaluate_rhs,
+        validate_rhs,
+        [&](const int update_index, const CCTK_REAL stage_time,
+            const CCTK_REAL destination_scale,
+            const LinearCombinationView<CCTK_REAL, statecomp_t> combination) {
+          explicit_update_index = update_index;
+          {
+            CarpetX::Interval interval_lincomb(timer_lincomb);
+            statecomp_t::lincomb(var, destination_scale, combination,
+                                 CarpetX::make_valid_int());
+            var.check_valid(CarpetX::make_valid_int(),
+                            "ODESolvers after defining new state vector");
+            mark_invalid(dep_groups);
           }
+          *const_cast<CCTK_REAL *>(&cctkGH->cctk_time) = stage_time;
+        },
+        [&](statecomp_t &accumulator, const CCTK_REAL factor,
+            const statecomp_t &increment) {
+          CarpetX::Interval interval_lincomb(timer_lincomb);
+          statecomp_t::lincomb(accumulator, 1.0, reals<1>{factor},
+                               states<1>{&increment},
+                               CarpetX::make_valid_int());
+        }};
+    operations.stage_preparation_callback =
+        [&](const ExplicitRKStagePoint &stage_point,
+            const CCTK_REAL stage_time) {
+          *const_cast<CCTK_REAL *>(&cctkGH->cctk_time) = stage_time;
+          prepare_subcycling_stage(stage_point, stage_time, active_method,
+                                   method);
+        };
+    operations.live_post_step_callback = [&](const CCTK_REAL stage_time) {
+      CarpetX::Interval interval_poststep(timer_poststep);
+      *const_cast<CCTK_REAL *>(&cctkGH->cctk_time) = stage_time;
+      CallScheduleGroup(cctkGH, "ODESolvers_PostStep");
+      if (verbose)
+        CCTK_VINFO("Calculated new state #%d at t=%g",
+                   explicit_update_index, double(cctkGH->cctk_time));
+    };
+
+    try {
+      if (active_transaction != nullptr && !scratch_group_pairs_match)
+        throw std::invalid_argument(
+            "ODESolvers ordered evolved/RHS pairs differ from the active "
+            "scratch transaction");
+      if (active_transaction != nullptr && !scratch_dependent_groups_match)
+        throw std::invalid_argument(
+            "ODESolvers dependent groups differ from the active scratch "
+            "transaction");
+      if (active_transaction == nullptr) {
+        advance_explicit_rk(explicit_method, old_time, dt,
+                            InitialRHSMode::calculate, operations);
+      } else if (active_context != nullptr &&
+                 !active_context->require_dense_output) {
+        advance_explicit_rk(explicit_method, old_time, dt,
+                            InitialRHSMode::calculate, operations);
+      } else {
+        // Only a parent level needs the independent dense-extension solves.
+        if (active_context == nullptr)
+          throw std::logic_error(
+              "scratch transaction has no active StepContext");
+
+        TransactionPrimaryObserver primary_observer(*active_transaction);
+        advance_explicit_rk(explicit_method, old_time, dt,
+                            InitialRHSMode::calculate, operations,
+                            primary_observer);
+        auto primary = primary_observer.take_complete();
+
+        auto left_state =
+            statecomp_t::from_scratch(std::move(primary.left_state));
+        auto left_rhs = statecomp_t::from_scratch(std::move(primary.left_rhs));
+        auto accepted_endpoint = statecomp_t::from_scratch(
+            std::move(primary.accepted_endpoint));
+        auto scratch_var = left_state.snapshot_state();
+        auto scratch_rhs = left_rhs.snapshot_rhs();
+
+        CactusExplicitRKOperations scratch_operations{
+            scratch_var,
+            scratch_rhs,
+            [](const CCTK_REAL) {},
+            [](const int) {},
+            [&](const int) {
+              scratch_rhs.check_valid(
+                  CarpetX::make_valid_int(),
+                  "ODESolvers scratch RHS after certified execution");
+            },
+            [&](const int, const CCTK_REAL,
+                const CCTK_REAL destination_scale,
+                const LinearCombinationView<CCTK_REAL, statecomp_t>
+                    combination) {
+              statecomp_t::lincomb(scratch_var, destination_scale, combination,
+                                   CarpetX::make_valid_int());
+              scratch_var.check_valid(
+                  CarpetX::make_valid_int(),
+                  "ODESolvers after defining scratch state vector");
+            },
+            [&](statecomp_t &accumulator, const CCTK_REAL factor,
+                const statecomp_t &increment) {
+              statecomp_t::lincomb(accumulator, 1.0, reals<1>{factor},
+                                   states<1>{&increment},
+                                   CarpetX::make_valid_int());
+            }};
+        scratch_operations.stage_preparation_callback =
+            [&](const ExplicitRKStagePoint &stage_point,
+                const CCTK_REAL stage_time) {
+              *const_cast<CCTK_REAL *>(&cctkGH->cctk_time) = stage_time;
+              prepare_subcycling_stage(stage_point, stage_time, active_method,
+                                       method);
+            };
+        scratch_operations.stage_materialization_callback =
+            [&](statecomp_t &state,
+                const ExplicitRKStagePoint &, const CCTK_REAL) {
+              if (!state.is_scratch() ||
+                  &state.scratch().transaction() != active_transaction)
+                throw std::invalid_argument(
+                    "scratch stage materialization transaction owner differs");
+              active_transaction->restore_state(state.scratch().token());
+            };
+
+        using ScratchHooks =
+            CactusExplicitRKScratchHooks<CCTK_REAL, statecomp_t>;
+        ScratchHooks scratch_hooks;
+        scratch_hooks.restore_left =
+            [&](statecomp_t &destination_state,
+                statecomp_t &destination_rhs,
+                const statecomp_t &source_state,
+                const statecomp_t &source_rhs, const CCTK_REAL) {
+              if (!source_state.is_scratch() || !source_rhs.is_scratch() ||
+                  &source_state.scratch().transaction() != active_transaction ||
+                  &source_rhs.scratch().transaction() != active_transaction)
+                throw std::invalid_argument(
+                    "scratch restore_left transaction owner differs");
+              active_transaction->restore_left(source_state.scratch().token(),
+                                               source_rhs.scratch().token());
+              destination_state = source_state.snapshot_state();
+              destination_rhs = source_rhs.snapshot_rhs();
+            };
+        scratch_hooks.restore_state =
+            [&](statecomp_t &destination, const statecomp_t &source,
+                const CCTK_REAL) {
+              if (!source.is_scratch() ||
+                  &source.scratch().transaction() != active_transaction)
+                throw std::invalid_argument(
+                    "scratch restore_state transaction owner differs");
+              active_transaction->restore_state(source.scratch().token());
+              destination = source.snapshot_state();
+            };
+        scratch_hooks.post_step_after_update =
+            [&](statecomp_t &state,
+                const ExplicitRKStagePoint &stage_point,
+                const CCTK_REAL stage_time) {
+              active_transaction->post_step_after_update(
+                  *active_context,
+                  carpetx_stage_point(stage_point, stage_time));
+              state.replace_scratch(TransactionStateBackend::from_token(
+                  *active_transaction,
+                  active_transaction->capture_scratch_evolved()));
+            };
+        scratch_hooks.evaluate_rhs =
+            [&](statecomp_t &, statecomp_t &rhs_state, const int,
+                const ExplicitRKStagePoint &stage_point,
+                const CCTK_REAL stage_time) {
+              active_transaction->evaluate_rhs(
+                  *active_context,
+                  carpetx_stage_point(stage_point, stage_time));
+              rhs_state.replace_scratch(TransactionStateBackend::from_token(
+                  *active_transaction,
+                  active_transaction->capture_scratch_rhs()));
+            };
+        scratch_hooks.probe_endpoint_rhs =
+            [&](statecomp_t &, statecomp_t &rhs_state,
+                const ExplicitRKStagePoint &stage_point,
+                const CCTK_REAL stage_time) {
+              active_transaction->evaluate_rhs(
+                  *active_context,
+                  carpetx_stage_point(stage_point, stage_time));
+              rhs_state.replace_scratch(TransactionStateBackend::from_token(
+                  *active_transaction,
+                  active_transaction->capture_scratch_rhs()));
+              return rhs_state.snapshot_rhs();
+            };
+        scratch_hooks.rhs_evaluation_count =
+            [&] { return active_transaction->rhs_evaluation_count(); };
+        scratch_operations.scratch_hooks = &scratch_hooks;
+
+        auto samples = collect_reference_dense_samples(
+            explicit_method, old_time, dt, left_state, left_rhs,
+            accepted_endpoint, scratch_operations);
+        if (active_provider == nullptr)
+          throw std::logic_error(
+              "scratch dense output has no active ODE provider");
+        CarpetX::DenseOutputProvider provider(active_provider->dense);
+        std::vector<CarpetX::ScratchDenseSampleRef> sample_refs;
+        sample_refs.reserve(samples.size());
+        for (const auto &sample : samples.samples()) {
+          if (!sample.payload.is_scratch())
+            throw std::logic_error(
+                "reference dense sample escaped the scratch backend");
+          const auto kind =
+              sample.kind == CarpetX::DenseSampleKind::value
+                  ? CarpetX::ScratchDenseSampleKind::value
+                  : CarpetX::ScratchDenseSampleKind::raw_derivative;
+          sample_refs.push_back(
+              {sample.theta, kind, &sample.payload.scratch().token()});
         }
-        calcupdate(step, c * dt, 0.0, factors, srcs);
-        // TODO: Deallocate ks that are not needed any more
+        const CarpetX::DenseIntervalId interval_id{
+            active_context->level,
+            active_context->begin_clock,
+            active_context->end_clock,
+            active_context->begin_time,
+            active_context->end_time,
+            active_provider->dense.method,
+            active_provider->dense.tableau_fingerprint};
+        active_transaction->commit_dense(*active_context, provider,
+                                         interval_id, sample_refs);
       }
-
-      calcrhs(step + 1);
-      ks.push_back(copy_state(rhs, CarpetX::make_valid_int()));
+    } catch (const std::exception &error) {
+      if (active_transaction != nullptr &&
+          !active_transaction->discarded())
+        active_transaction->discard();
+      CCTK_VERROR("Explicit RK method \"%s\" failed: %s", method,
+                  error.what());
+    } catch (...) {
+      if (active_transaction != nullptr &&
+          !active_transaction->discarded())
+        active_transaction->discard();
+      CCTK_VERROR("Explicit RK method \"%s\" failed with an unknown exception",
+                  method);
     }
-
-    // Calculate new state vector
-    const auto &bs = std::get<1>(tableau);
-    std::vector<CCTK_REAL> factors;
-    std::vector<const statecomp_t *> srcs;
-    factors.reserve(bs.size() + 1);
-    srcs.reserve(bs.size() + 1);
-    factors.push_back(1);
-    srcs.push_back(&old);
-    for (std::size_t i = 0; i < bs.size(); ++i) {
-      if (bs.at(i) != 0) {
-        factors.push_back(bs.at(i) * dt);
-        srcs.push_back(&ks.at(i));
-      }
-    }
-    calcupdate(nsteps, dt, 0.0, factors, srcs);
 
   } else if (CCTK_EQUALS(method, "IMEX122") ||
              CCTK_EQUALS(method, "Implicit Euler")) {

--- a/ODESolvers/src/solve.cxx
+++ b/ODESolvers/src/solve.cxx
@@ -12,6 +12,7 @@
 #include "cactus_explicit_rk_operations.hxx"
 #include "explicit_rk.hxx"
 #include "explicit_rk_dense_provider.hxx"
+#include "subcycling_group_schema_builder.hxx"
 #include "subcycling_ode_provider_registry.hxx"
 #include "subcycling_transaction_bridge.hxx"
 #include <subcycling_dense_output.hxx>
@@ -29,9 +30,7 @@ static inline int omp_get_max_threads() { return 1; }
 #include <algorithm>
 #include <array>
 #include <cassert>
-#include <cctype>
 #include <cmath>
-#include <cstring>
 #include <exception>
 #include <functional>
 #include <limits>
@@ -714,103 +713,6 @@ void statecomp_t::lincomb(const statecomp_t &dst, const CCTK_REAL scale,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-int groupindex(const int other_gi, std::string gn) {
-  // If the group name does not contain a colon, then prefix the current group's
-  // implementation or thorn name
-  if (gn.find(':') == std::string::npos) {
-    const char *const thorn_or_impl = CCTK_GroupImplementationI(other_gi);
-    assert(thorn_or_impl);
-    const char *const impl = CCTK_ThornImplementation(thorn_or_impl);
-    const char *const thorn = CCTK_ImplementationThorn(thorn_or_impl);
-    assert(impl || thorn);
-    const char *prefix;
-    if (!impl) {
-      prefix = thorn;
-    } else if (!thorn) {
-      prefix = impl;
-    } else {
-      assert(strcmp(impl, thorn) == 0);
-      prefix = impl;
-    }
-    std::ostringstream buf;
-    buf << prefix << "::" + gn;
-    gn = buf.str();
-  }
-  const int gi = CCTK_GroupIndex(gn.c_str());
-  return gi;
-}
-
-int get_group_rhs(const int gi) {
-  assert(gi >= 0);
-  const int tags = CCTK_GroupTagsTableI(gi);
-  assert(tags >= 0);
-  std::vector<char> rhs_buf(1000);
-  const int iret =
-      Util_TableGetString(tags, rhs_buf.size(), rhs_buf.data(), "rhs");
-  if (iret == UTIL_ERROR_TABLE_NO_SUCH_KEY) {
-    rhs_buf[0] = '\0'; // default: empty (no RHS)
-  } else if (iret >= 0) {
-    // do nothing
-  } else {
-    assert(0);
-  }
-
-  const std::string str(rhs_buf.data());
-  if (str.empty())
-    return -1; // No RHS specified
-
-  const int rhs = groupindex(gi, str);
-  if (rhs < 0)
-    CCTK_VERROR("Variable group \"%s\" declares a RHS group \"%s\". "
-                "That group does not exist.",
-                CCTK_FullGroupName(gi), str.c_str());
-  assert(rhs != gi);
-
-  return rhs;
-}
-
-std::vector<int> get_group_dependents(const int gi) {
-  assert(gi >= 0);
-  const int tags = CCTK_GroupTagsTableI(gi);
-  assert(tags >= 0);
-  std::vector<char> dependents_buf(1000);
-  const int iret = Util_TableGetString(tags, dependents_buf.size(),
-                                       dependents_buf.data(), "dependents");
-  if (iret == UTIL_ERROR_TABLE_NO_SUCH_KEY) {
-    dependents_buf[0] = '\0'; // default: empty (no DEPENDENTS)
-  } else if (iret >= 0) {
-    // do nothing
-  } else {
-    assert(0);
-  }
-
-  std::vector<int> dependents;
-  const std::string str(dependents_buf.data());
-  std::size_t pos = 0;
-  for (;;) {
-    // Skip white space
-    while (pos < str.size() && std::isspace(str[pos]))
-      ++pos;
-    if (pos == str.size())
-      break;
-    // Read group name
-    const std::size_t group_begin = pos;
-    while (pos < str.size() && !std::isspace(str[pos]))
-      ++pos;
-    const std::size_t group_end = pos;
-    const std::string groupname =
-        str.substr(group_begin, group_end - group_begin);
-    const int dep_gi = groupindex(gi, groupname);
-    if (dep_gi < 0)
-      CCTK_VERROR("Variable group \"%s\" declares a dependent group \"%s\". "
-                  "That group does not exist.",
-                  CCTK_FullGroupName(gi), groupname.c_str());
-    dependents.push_back(dep_gi);
-  }
-
-  return dependents;
-}
-
 // Mark groups as invalid
 void mark_invalid(const std::vector<int> &groups) {
   CarpetX::active_levels->loop_serially([&](const auto &leveldata) {
@@ -957,40 +859,38 @@ extern "C" void ODESolvers_Solve(CCTK_ARGUMENTS) {
   static CarpetX::Timer timer_setup("ODESolvers::Solve::setup");
   std::optional<CarpetX::Interval> interval_setup(timer_setup);
 
+  GroupSchemaBuild group_schema;
+  try {
+    group_schema =
+        build_cactus_group_schema(carpetx_subcycling_enabled());
+  } catch (const std::exception &error) {
+    CCTK_VERROR("ODE evolved/RHS group schema construction failed: %s",
+                error.what());
+  } catch (...) {
+    CCTK_ERROR("ODE evolved/RHS group schema construction failed with an "
+               "unknown exception");
+  }
+
   statecomp_t var, rhs;
-  std::vector<int> var_groups, rhs_groups, dep_groups;
-  std::vector<CarpetX::ScratchGroupPair> ordered_group_pairs;
-  int nvars = 0;
-  bool do_accumulate_nvars = true;
+  const auto &ordered_group_pairs =
+      group_schema.contract.ordered_group_pairs;
+  const auto &var_groups = group_schema.evolved_groups;
+  const auto &rhs_groups = group_schema.rhs_groups;
+  const auto &dep_groups = group_schema.contract.dependent_groups;
+  const int nvars = group_schema.evolved_variable_count;
   assert(CarpetX::active_levels);
   CarpetX::active_levels->loop_serially([&](const auto &leveldata) {
-    for (const auto &groupdataptr : leveldata.groupdata) {
-      // TODO: add support for evolving grid scalars
-      if (groupdataptr == nullptr)
-        continue;
-
-      auto &groupdata = *groupdataptr;
-      const int rhs_gi = get_group_rhs(groupdata.groupindex);
-      if (rhs_gi >= 0) {
-        assert(rhs_gi != groupdata.groupindex);
-        auto &rhs_groupdata = *leveldata.groupdata.at(rhs_gi);
-        assert(rhs_groupdata.numvars == groupdata.numvars);
-        var.groupdatas.push_back(&groupdata);
-        var.mfabs.push_back(groupdata.mfab.at(tl).get());
-        rhs.groupdatas.push_back(&rhs_groupdata);
-        rhs.mfabs.push_back(rhs_groupdata.mfab.at(tl).get());
-        if (do_accumulate_nvars) {
-          nvars += groupdata.numvars;
-          var_groups.push_back(groupdata.groupindex);
-          rhs_groups.push_back(rhs_gi);
-          ordered_group_pairs.push_back({groupdata.groupindex, rhs_gi});
-          const auto &dependents = get_group_dependents(groupdata.groupindex);
-          dep_groups.insert(dep_groups.end(), dependents.begin(),
-                            dependents.end());
-        }
-      }
+    for (const auto &pair : ordered_group_pairs) {
+      auto &groupdata = *leveldata.groupdata.at(pair.evolved_group);
+      auto &rhs_groupdata = *leveldata.groupdata.at(pair.rhs_group);
+      assert(groupdata.groupindex == pair.evolved_group);
+      assert(rhs_groupdata.groupindex == pair.rhs_group);
+      assert(rhs_groupdata.numvars == groupdata.numvars);
+      var.groupdatas.push_back(&groupdata);
+      var.mfabs.push_back(groupdata.mfab.at(tl).get());
+      rhs.groupdatas.push_back(&rhs_groupdata);
+      rhs.mfabs.push_back(rhs_groupdata.mfab.at(tl).get());
     }
-    do_accumulate_nvars = false;
   });
   if (verbose)
     CCTK_VINFO("  Integrating %d variables", nvars);
@@ -1010,27 +910,6 @@ extern "C" void ODESolvers_Solve(CCTK_ARGUMENTS) {
               ordered_group_pairs[pair].evolved_group &&
           certified_pairs[pair].rhs_group ==
               ordered_group_pairs[pair].rhs_group;
-  }
-
-  {
-    std::sort(var_groups.begin(), var_groups.end());
-    const auto last = std::unique(var_groups.begin(), var_groups.end());
-    assert(last == var_groups.end());
-  }
-
-  {
-    std::sort(rhs_groups.begin(), rhs_groups.end());
-    const auto last = std::unique(rhs_groups.begin(), rhs_groups.end());
-    assert(last == rhs_groups.end());
-  }
-
-  // Add RHS variables to dependent variables
-  dep_groups.insert(dep_groups.end(), rhs_groups.begin(), rhs_groups.end());
-
-  {
-    std::sort(dep_groups.begin(), dep_groups.end());
-    const auto last = std::unique(dep_groups.begin(), dep_groups.end());
-    dep_groups.erase(last, dep_groups.end());
   }
 
   const bool scratch_dependent_groups_match =

--- a/ODESolvers/src/subcycling_group_schema_builder.cxx
+++ b/ODESolvers/src/subcycling_group_schema_builder.cxx
@@ -1,0 +1,157 @@
+#include "subcycling_group_schema_builder.hxx"
+
+#include <algorithm>
+#include <cctype>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace ODESolvers {
+namespace {
+
+std::vector<std::string> split_group_names(const std::string &names) {
+  std::vector<std::string> result;
+  std::size_t position = 0;
+  for (;;) {
+    while (position < names.size() &&
+           std::isspace(static_cast<unsigned char>(names[position])))
+      ++position;
+    if (position == names.size())
+      break;
+    const auto begin = position;
+    while (position < names.size() &&
+           !std::isspace(static_cast<unsigned char>(names[position])))
+      ++position;
+    result.push_back(names.substr(begin, position - begin));
+  }
+  return result;
+}
+
+void require_valid_index(const int group, const int group_count,
+                         const char *const role) {
+  if (group < 0 || group >= group_count)
+    throw std::invalid_argument(std::string(role) +
+                                " group index is outside the CCTK catalog");
+}
+
+void require_grid_function(const GroupSchemaCatalog &catalog,
+                           const int group, const char *const role) {
+  if (catalog.group_type(group) != GroupSchemaGroupType::grid_function)
+    throw std::invalid_argument(
+        std::string(role) + " group \"" + catalog.full_group_name(group) +
+        "\" is not a CCTK grid-function group");
+}
+
+int resolve_required_group(const GroupSchemaCatalog &catalog,
+                           const int owner, const std::string_view name,
+                           const int group_count, const char *const role) {
+  const int resolved = catalog.resolve_group(owner, name);
+  if (resolved < 0)
+    throw std::invalid_argument(
+        "variable group \"" + catalog.full_group_name(owner) +
+        "\" declares a " + role + " group \"" + std::string(name) +
+        "\" that does not exist");
+  require_valid_index(resolved, group_count, role);
+  return resolved;
+}
+
+void sort_unique_or_reject(std::vector<int> &groups,
+                           const char *const role) {
+  std::sort(groups.begin(), groups.end());
+  const auto last = std::unique(groups.begin(), groups.end());
+  if (last != groups.end())
+    throw std::invalid_argument(std::string("duplicate ") + role +
+                                " group in ODE schema");
+}
+
+} // namespace
+
+GroupSchemaBuild build_group_schema(const GroupSchemaCatalog &catalog,
+                                    const bool require_grid_functions) {
+  const int group_count = catalog.group_count();
+  if (group_count < 0)
+    throw std::invalid_argument("CCTK group count is negative");
+
+  GroupSchemaBuild build;
+  for (int evolved_group = 0; evolved_group < group_count; ++evolved_group) {
+    const auto type = catalog.group_type(evolved_group);
+    if (type != GroupSchemaGroupType::grid_function &&
+        !require_grid_functions)
+      continue;
+
+    const auto rhs_tag = catalog.group_tag(evolved_group, "rhs");
+    if (!rhs_tag || rhs_tag->empty())
+      continue;
+
+    if (type != GroupSchemaGroupType::grid_function)
+      require_grid_function(catalog, evolved_group, "evolved");
+
+    const int rhs_group = resolve_required_group(
+        catalog, evolved_group, *rhs_tag, group_count, "RHS");
+    if (rhs_group == evolved_group)
+      throw std::invalid_argument(
+          "an evolved group cannot also be its own RHS group");
+    require_grid_function(catalog, rhs_group, "RHS");
+    if (catalog.group_numvars(evolved_group) !=
+        catalog.group_numvars(rhs_group))
+      throw std::invalid_argument(
+          "evolved and RHS groups have different variable counts");
+
+    if (build.evolved_variable_count >
+        std::numeric_limits<int>::max() -
+            catalog.group_numvars(evolved_group))
+      throw std::overflow_error("evolved variable count overflow");
+    build.evolved_variable_count += catalog.group_numvars(evolved_group);
+    build.evolved_groups.push_back(evolved_group);
+    build.rhs_groups.push_back(rhs_group);
+    build.contract.ordered_group_pairs.push_back(
+        {evolved_group, rhs_group});
+
+    const auto dependents_tag = catalog.group_tag(evolved_group, "dependents");
+    if (!dependents_tag)
+      continue;
+    for (const auto &name : split_group_names(*dependents_tag)) {
+      const int dependent_group = resolve_required_group(
+          catalog, evolved_group, name, group_count, "dependent");
+      require_grid_function(catalog, dependent_group, "dependent");
+      build.contract.dependent_groups.push_back(dependent_group);
+    }
+  }
+
+  sort_unique_or_reject(build.evolved_groups, "evolved");
+  sort_unique_or_reject(build.rhs_groups, "RHS");
+
+  build.contract.dependent_groups.insert(
+      build.contract.dependent_groups.end(), build.rhs_groups.begin(),
+      build.rhs_groups.end());
+  std::sort(build.contract.dependent_groups.begin(),
+            build.contract.dependent_groups.end());
+  build.contract.dependent_groups.erase(
+      std::unique(build.contract.dependent_groups.begin(),
+                  build.contract.dependent_groups.end()),
+      build.contract.dependent_groups.end());
+
+  for (const int evolved_group : build.evolved_groups)
+    if (std::binary_search(build.contract.dependent_groups.begin(),
+                           build.contract.dependent_groups.end(),
+                           evolved_group))
+      throw std::invalid_argument(
+          "an evolved group is also in the dependent-group closure");
+  for (const int rhs_group : build.rhs_groups)
+    if (std::binary_search(build.evolved_groups.begin(),
+                           build.evolved_groups.end(), rhs_group))
+      throw std::invalid_argument(
+          "an RHS group is also an evolved group");
+
+  return build;
+}
+
+std::optional<GroupSchemaBuild>
+maybe_build_subcycling_group_schema(const bool subcycling_enabled,
+                                    const GroupSchemaCatalog &catalog) {
+  if (!subcycling_enabled)
+    return std::nullopt;
+  return build_group_schema(catalog, true);
+}
+
+} // namespace ODESolvers

--- a/ODESolvers/src/subcycling_group_schema_builder.hxx
+++ b/ODESolvers/src/subcycling_group_schema_builder.hxx
@@ -1,0 +1,60 @@
+#ifndef ODESOLVERS_SUBCYCLING_GROUP_SCHEMA_BUILDER_HXX
+#define ODESOLVERS_SUBCYCLING_GROUP_SCHEMA_BUILDER_HXX
+
+#include <subcycling_method_contract.hxx>
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace ODESolvers {
+
+enum class GroupSchemaGroupType { grid_function, array, scalar };
+
+// Narrow metadata seam shared by the pure builder tests and the Cactus
+// adapter. Implementations must expose groups in CCTK group-index order.
+class GroupSchemaCatalog {
+public:
+  virtual ~GroupSchemaCatalog() = default;
+
+  virtual int group_count() const = 0;
+  virtual GroupSchemaGroupType group_type(int group) const = 0;
+  virtual int group_numvars(int group) const = 0;
+  virtual std::string full_group_name(int group) const = 0;
+  virtual std::optional<std::string>
+  group_tag(int group, std::string_view key) const = 0;
+  virtual int resolve_group(int owner, std::string_view name) const = 0;
+};
+
+struct GroupSchemaBuild {
+  CarpetX::SubcyclingGroupSchema contract;
+  std::vector<int> evolved_groups;
+  std::vector<int> rhs_groups;
+  int evolved_variable_count{0};
+};
+
+// Build the single canonical evolved/RHS/dependent schema. When
+// require_grid_functions is false, evolved arrays/scalars are ignored exactly
+// as in the legacy solve path. When true, every evolved, RHS, and dependent
+// group must be a CCTK grid-function group.
+GroupSchemaBuild build_group_schema(const GroupSchemaCatalog &catalog,
+                                    bool require_grid_functions);
+
+// This guard is intentionally outside the catalog: disabled subcycling must
+// return before any Cactus metadata access.
+std::optional<GroupSchemaBuild>
+maybe_build_subcycling_group_schema(bool subcycling_enabled,
+                                    const GroupSchemaCatalog &catalog);
+
+// Production adapter used by both ODESolvers_Solve and the PARAMCHECK
+// method-contract handoff. The optional form is a complete no-op when disabled.
+bool carpetx_subcycling_enabled();
+GroupSchemaBuild
+build_cactus_group_schema(bool require_grid_functions);
+std::optional<GroupSchemaBuild>
+maybe_build_cactus_subcycling_group_schema(bool subcycling_enabled);
+
+} // namespace ODESolvers
+
+#endif // ODESOLVERS_SUBCYCLING_GROUP_SCHEMA_BUILDER_HXX

--- a/ODESolvers/src/subcycling_group_schema_cactus.cxx
+++ b/ODESolvers/src/subcycling_group_schema_cactus.cxx
@@ -1,0 +1,127 @@
+#include "subcycling_group_schema_builder.hxx"
+
+#include <cctk.h>
+#include <cctk_Groups.h>
+#include <cctk_Parameter.h>
+#include <util_Table.h>
+
+#include <cstring>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace ODESolvers {
+namespace {
+
+class CactusGroupSchemaCatalog final : public GroupSchemaCatalog {
+public:
+  int group_count() const override { return CCTK_NumGroups(); }
+
+  GroupSchemaGroupType group_type(const int group) const override {
+    switch (CCTK_GroupTypeI(group)) {
+    case CCTK_GF:
+      return GroupSchemaGroupType::grid_function;
+    case CCTK_ARRAY:
+      return GroupSchemaGroupType::array;
+    case CCTK_SCALAR:
+      return GroupSchemaGroupType::scalar;
+    default:
+      throw std::invalid_argument("CCTK group has an unknown group type");
+    }
+  }
+
+  int group_numvars(const int group) const override {
+    const int count = CCTK_NumVarsInGroupI(group);
+    if (count < 0)
+      throw std::invalid_argument(
+          "could not read the CCTK group variable count");
+    return count;
+  }
+
+  std::string full_group_name(const int group) const override {
+    const char *const name = CCTK_FullGroupName(group);
+    if (name == nullptr)
+      throw std::invalid_argument("could not read the CCTK full group name");
+    return name;
+  }
+
+  std::optional<std::string>
+  group_tag(const int group, const std::string_view key) const override {
+    const int tags = CCTK_GroupTagsTableI(group);
+    if (tags < 0)
+      throw std::invalid_argument("could not read the CCTK group tag table");
+    const std::string key_string(key);
+    std::vector<char> buffer(1000);
+    const int status = Util_TableGetString(
+        tags, static_cast<int>(buffer.size()), buffer.data(),
+        key_string.c_str());
+    if (status == UTIL_ERROR_TABLE_NO_SUCH_KEY)
+      return std::nullopt;
+    if (status < 0)
+      throw std::invalid_argument("could not read CCTK group tag \"" +
+                                  key_string + "\"");
+    return std::string(buffer.data());
+  }
+
+  int resolve_group(const int owner,
+                    const std::string_view name) const override {
+    std::string qualified(name);
+    if (qualified.find(':') == std::string::npos) {
+      const char *const thorn_or_impl = CCTK_GroupImplementationI(owner);
+      if (thorn_or_impl == nullptr)
+        throw std::invalid_argument(
+            "could not read the evolved group's implementation");
+      const char *const implementation =
+          CCTK_ThornImplementation(thorn_or_impl);
+      const char *const thorn = CCTK_ImplementationThorn(thorn_or_impl);
+      if (implementation == nullptr && thorn == nullptr)
+        throw std::invalid_argument(
+            "could not resolve the evolved group's namespace");
+      const char *prefix = nullptr;
+      if (implementation == nullptr) {
+        prefix = thorn;
+      } else if (thorn == nullptr) {
+        prefix = implementation;
+      } else {
+        if (std::strcmp(implementation, thorn) != 0)
+          throw std::invalid_argument(
+              "CCTK implementation and thorn namespace differ");
+        prefix = implementation;
+      }
+      std::ostringstream stream;
+      stream << prefix << "::" << qualified;
+      qualified = stream.str();
+    }
+    return CCTK_GroupIndex(qualified.c_str());
+  }
+};
+
+} // namespace
+
+bool carpetx_subcycling_enabled() {
+  const auto *const enabled = static_cast<const CCTK_INT *>(
+      CCTK_ParameterGet("use_subcycling_wip", "CarpetX", nullptr));
+  if (enabled == nullptr)
+    throw std::logic_error(
+        "CarpetX::use_subcycling_wip parameter is unavailable");
+  return *enabled != 0;
+}
+
+GroupSchemaBuild
+build_cactus_group_schema(const bool require_grid_functions) {
+  const CactusGroupSchemaCatalog catalog;
+  return build_group_schema(catalog, require_grid_functions);
+}
+
+std::optional<GroupSchemaBuild> maybe_build_cactus_subcycling_group_schema(
+    const bool subcycling_enabled) {
+  if (!subcycling_enabled)
+    return std::nullopt;
+  const CactusGroupSchemaCatalog catalog;
+  return maybe_build_subcycling_group_schema(true, catalog);
+}
+
+} // namespace ODESolvers

--- a/ODESolvers/src/subcycling_method_contract_registration.hxx
+++ b/ODESolvers/src/subcycling_method_contract_registration.hxx
@@ -1,0 +1,40 @@
+#ifndef ODESOLVERS_SUBCYCLING_METHOD_CONTRACT_REGISTRATION_HXX
+#define ODESOLVERS_SUBCYCLING_METHOD_CONTRACT_REGISTRATION_HXX
+
+#include "subcycling_ode_provider_registry.hxx"
+
+#include <subcycling_method_contract.hxx>
+
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace ODESolvers {
+
+inline std::optional<CarpetX::SubcyclingMethodContract>
+make_subcycling_method_contract(const bool subcycling_enabled,
+                                const std::string_view method) {
+  if (!subcycling_enabled)
+    return std::nullopt;
+
+  const auto &provider = require_subcycling_ode_provider(method);
+  return CarpetX::SubcyclingMethodContract{
+      "ODESolvers::method", std::string(provider.parameter_name),
+      provider.dense};
+}
+
+inline void validate_subcycling_method_steering(
+    const CarpetX::SubcyclingMethodContractSnapshot &snapshot,
+    const std::string_view new_value) {
+  if (snapshot.contract.provider_id != "ODESolvers::method")
+    throw std::logic_error(
+        "the active subcycling method contract belongs to another provider");
+  if (new_value != snapshot.contract.parameter_value)
+    throw std::logic_error(
+        "ODESolvers::method is frozen while CarpetX subcycling is active");
+}
+
+} // namespace ODESolvers
+
+#endif // ODESOLVERS_SUBCYCLING_METHOD_CONTRACT_REGISTRATION_HXX

--- a/ODESolvers/src/subcycling_method_contract_schedule.cxx
+++ b/ODESolvers/src/subcycling_method_contract_schedule.cxx
@@ -1,0 +1,94 @@
+#include "subcycling_method_contract_registration.hxx"
+
+#include <cctk.h>
+#include <cctk_Arguments.h>
+#include <cctk_Parameter.h>
+#include <cctk_Parameters.h>
+
+#include <subcycling_method_contract.hxx>
+
+#include <exception>
+#include <stdexcept>
+
+namespace ODESolvers {
+namespace {
+
+constexpr const char *steering_guard_name =
+    "ODESolvers_SUBCYCLING_METHOD_STEERING_GUARD";
+bool steering_guard_registered = false;
+
+bool carpetx_subcycling_enabled() {
+  const auto *const enabled = static_cast<const CCTK_INT *>(
+      CCTK_ParameterGet("use_subcycling_wip", "CarpetX", nullptr));
+  if (enabled == nullptr)
+    throw std::logic_error(
+        "CarpetX::use_subcycling_wip parameter is unavailable");
+  return *enabled != 0;
+}
+
+void method_steering_callback(void *, const char *, const char *,
+                              const char *const new_value) {
+  try {
+    const auto snapshot =
+        CarpetX::require_registered_subcycling_method_contract();
+    validate_subcycling_method_steering(snapshot, new_value);
+  } catch (const std::exception &error) {
+    CCTK_VERROR("Rejected ODESolvers::method steering while CarpetX "
+                "subcycling is active: %s",
+                error.what());
+  } catch (...) {
+    CCTK_ERROR("Rejected ODESolvers::method steering while CarpetX "
+               "subcycling is active with an unknown contract error");
+  }
+}
+
+} // namespace
+} // namespace ODESolvers
+
+extern "C" void
+ODESolvers_RegisterSubcyclingMethodContract(CCTK_ARGUMENTS) {
+  static_cast<void>(cctkGH);
+  DECLARE_CCTK_PARAMETERS;
+
+  try {
+    const bool enabled = ODESolvers::carpetx_subcycling_enabled();
+    const auto contract =
+        ODESolvers::make_subcycling_method_contract(enabled, method);
+    if (!contract)
+      return;
+
+    CarpetX::register_subcycling_method_contract(*contract);
+    if (!ODESolvers::steering_guard_registered) {
+      const int status = CCTK_ParameterSetNotifyRegister(
+          ODESolvers::method_steering_callback, nullptr,
+          ODESolvers::steering_guard_name, "^ODESolvers$", "^method$");
+      if (status != 0)
+        throw std::runtime_error(
+            "could not register the ODESolvers method steering guard");
+      ODESolvers::steering_guard_registered = true;
+    }
+  } catch (const std::exception &error) {
+    CCTK_VERROR("CarpetX subcycling method-contract registration failed for "
+                "ODESolvers::method=\"%s\": %s",
+                method, error.what());
+  } catch (...) {
+    CCTK_VERROR("CarpetX subcycling method-contract registration failed for "
+                "ODESolvers::method=\"%s\" with an unknown error",
+                method);
+  }
+}
+
+extern "C" void
+ODESolvers_UnregisterSubcyclingMethodSteeringGuard(CCTK_ARGUMENTS) {
+  static_cast<void>(cctkGH);
+  if (!ODESolvers::steering_guard_registered)
+    return;
+  const int status =
+      CCTK_ParameterSetNotifyUnregister(ODESolvers::steering_guard_name);
+  if (status != 0)
+    CCTK_VWARN(CCTK_WARN_ALERT,
+               "Could not unregister the ODESolvers subcycling method "
+               "steering guard: %d",
+               status);
+  ODESolvers::steering_guard_registered = false;
+}

--- a/ODESolvers/src/subcycling_method_contract_schedule.cxx
+++ b/ODESolvers/src/subcycling_method_contract_schedule.cxx
@@ -76,11 +76,9 @@ ODESolvers_RegisterSubcyclingMethodContract(CCTK_ARGUMENTS) {
   }
 }
 
-extern "C" void
-ODESolvers_UnregisterSubcyclingMethodSteeringGuard(CCTK_ARGUMENTS) {
-  static_cast<void>(cctkGH);
+extern "C" int ODESolvers_UnregisterSubcyclingMethodSteeringGuard(void) {
   if (!ODESolvers::steering_guard_registered)
-    return;
+    return 0;
   const int status =
       CCTK_ParameterSetNotifyUnregister(ODESolvers::steering_guard_name);
   if (status != 0)
@@ -89,4 +87,5 @@ ODESolvers_UnregisterSubcyclingMethodSteeringGuard(CCTK_ARGUMENTS) {
                "steering guard: %d",
                status);
   ODESolvers::steering_guard_registered = false;
+  return 0;
 }

--- a/ODESolvers/src/subcycling_method_contract_schedule.cxx
+++ b/ODESolvers/src/subcycling_method_contract_schedule.cxx
@@ -1,8 +1,8 @@
 #include "subcycling_method_contract_registration.hxx"
+#include "subcycling_group_schema_builder.hxx"
 
 #include <cctk.h>
 #include <cctk_Arguments.h>
-#include <cctk_Parameter.h>
 #include <cctk_Parameters.h>
 
 #include <subcycling_method_contract.hxx>
@@ -16,15 +16,6 @@ namespace {
 constexpr const char *steering_guard_name =
     "ODESolvers_SUBCYCLING_METHOD_STEERING_GUARD";
 bool steering_guard_registered = false;
-
-bool carpetx_subcycling_enabled() {
-  const auto *const enabled = static_cast<const CCTK_INT *>(
-      CCTK_ParameterGet("use_subcycling_wip", "CarpetX", nullptr));
-  if (enabled == nullptr)
-    throw std::logic_error(
-        "CarpetX::use_subcycling_wip parameter is unavailable");
-  return *enabled != 0;
-}
 
 void method_steering_callback(void *, const char *, const char *,
                               const char *const new_value) {
@@ -54,10 +45,17 @@ ODESolvers_RegisterSubcyclingMethodContract(CCTK_ARGUMENTS) {
     const bool enabled = ODESolvers::carpetx_subcycling_enabled();
     const auto contract =
         ODESolvers::make_subcycling_method_contract(enabled, method);
-    if (!contract)
+    const auto group_schema =
+        ODESolvers::maybe_build_cactus_subcycling_group_schema(enabled);
+    if (contract.has_value() != group_schema.has_value())
+      throw std::logic_error(
+          "method and group-schema handoff activation differ");
+    if (!contract || !group_schema)
       return;
 
     CarpetX::register_subcycling_method_contract(*contract);
+    CarpetX::register_subcycling_group_schema(
+        contract->provider_id, group_schema->contract);
     if (!ODESolvers::steering_guard_registered) {
       const int status = CCTK_ParameterSetNotifyRegister(
           ODESolvers::method_steering_callback, nullptr,

--- a/ODESolvers/src/subcycling_ode_provider_registry.cxx
+++ b/ODESolvers/src/subcycling_ode_provider_registry.cxx
@@ -1,0 +1,71 @@
+#include "subcycling_ode_provider_registry.hxx"
+
+#include "explicit_rk_dense_provider.hxx"
+
+#include <stdexcept>
+#include <utility>
+
+namespace ODESolvers {
+namespace {
+
+template <ExplicitRKMethod Method>
+ExplicitRKStagePoint
+exact_stage_metadata(const ExplicitRKAdvanceFrame &frame,
+                     const int stage_index) {
+  return explicit_rk_stage_point(Method, frame, stage_index);
+}
+
+SubcyclingODEProviderCapability
+make_capability(const std::string_view parameter_name,
+                const ExplicitRKMethod method,
+                const ExactStageMetadataProvider metadata_provider) {
+  const auto &tableau = explicit_rk_tableau(method);
+  auto dense = reference_dense_capability(method);
+  const auto expected_stage_count = static_cast<int>(tableau.a.size());
+
+  if (parameter_name.empty() || metadata_provider == nullptr ||
+      dense.method != subcycling_method(method) ||
+      dense.tableau_fingerprint != explicit_rk_tableau_fingerprint(method) ||
+      dense.endpoint_order != tableau.endpoint_order ||
+      dense.dense_uniform_order < tableau.endpoint_order ||
+      dense.stage_count != expected_stage_count || !dense.arbitrary_theta ||
+      !dense.verified)
+    throw std::logic_error(
+        "inconsistent subcycling ODE provider capability");
+
+  return SubcyclingODEProviderCapability{parameter_name, method,
+                                         std::move(dense),
+                                         metadata_provider};
+}
+
+} // namespace
+
+const SubcyclingODEProviderRegistry &subcycling_ode_provider_registry() {
+  static const SubcyclingODEProviderRegistry registry{{
+      make_capability("RK4", ExplicitRKMethod::rk4,
+                      &exact_stage_metadata<ExplicitRKMethod::rk4>),
+      make_capability("RKF78", ExplicitRKMethod::rkf78,
+                      &exact_stage_metadata<ExplicitRKMethod::rkf78>),
+      make_capability("DP87", ExplicitRKMethod::dp87,
+                      &exact_stage_metadata<ExplicitRKMethod::dp87>),
+  }};
+  return registry;
+}
+
+const SubcyclingODEProviderCapability &
+require_subcycling_ode_provider(const ExplicitRKMethod method) {
+  for (const auto &entry : subcycling_ode_provider_registry())
+    if (entry.method == method)
+      return entry;
+  throw std::invalid_argument("unsupported subcycling ODE method");
+}
+
+const SubcyclingODEProviderCapability &
+require_subcycling_ode_provider(const std::string_view parameter_name) {
+  for (const auto &entry : subcycling_ode_provider_registry())
+    if (entry.parameter_name == parameter_name)
+      return entry;
+  throw std::invalid_argument("unsupported subcycling ODE method");
+}
+
+} // namespace ODESolvers

--- a/ODESolvers/src/subcycling_ode_provider_registry.hxx
+++ b/ODESolvers/src/subcycling_ode_provider_registry.hxx
@@ -1,0 +1,36 @@
+#ifndef ODESOLVERS_SUBCYCLING_ODE_PROVIDER_REGISTRY_HXX
+#define ODESOLVERS_SUBCYCLING_ODE_PROVIDER_REGISTRY_HXX
+
+#include "explicit_rk.hxx"
+
+#include <subcycling_dense_output.hxx>
+
+#include <array>
+#include <string_view>
+
+namespace ODESolvers {
+
+using ExactStageMetadataProvider = ExplicitRKStagePoint (*)(
+    const ExplicitRKAdvanceFrame &frame, int stage_index);
+
+struct SubcyclingODEProviderCapability {
+  std::string_view parameter_name;
+  ExplicitRKMethod method;
+  CarpetX::DenseCapability dense;
+  ExactStageMetadataProvider exact_stage_metadata;
+};
+
+using SubcyclingODEProviderRegistry =
+    std::array<SubcyclingODEProviderCapability, 3>;
+
+const SubcyclingODEProviderRegistry &subcycling_ode_provider_registry();
+
+const SubcyclingODEProviderCapability &
+require_subcycling_ode_provider(ExplicitRKMethod method);
+
+const SubcyclingODEProviderCapability &
+require_subcycling_ode_provider(std::string_view parameter_name);
+
+} // namespace ODESolvers
+
+#endif // ODESOLVERS_SUBCYCLING_ODE_PROVIDER_REGISTRY_HXX

--- a/ODESolvers/src/subcycling_transaction_bridge.hxx
+++ b/ODESolvers/src/subcycling_transaction_bridge.hxx
@@ -1,0 +1,155 @@
+#ifndef ODESOLVERS_SUBCYCLING_TRANSACTION_BRIDGE_HXX
+#define ODESOLVERS_SUBCYCLING_TRANSACTION_BRIDGE_HXX
+
+#include <subcycling_scratch_state_transaction.hxx>
+
+#include <initializer_list>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace ODESolvers {
+
+// Private ODESolvers ownership wrapper around CarpetX's opaque token.  This
+// type deliberately knows no cGH, MultiFab, GroupData, or scratch-frame type.
+class TransactionStateBackend final {
+public:
+  struct LinearTerm {
+    double coefficient;
+    const TransactionStateBackend *state;
+  };
+
+  static TransactionStateBackend
+  from_token(CarpetX::ScratchStateTransaction &transaction,
+             CarpetX::ScratchStateToken token) {
+    if (!token.valid())
+      throw std::invalid_argument("scratch state token is empty");
+    // Validate ownership/schema/epoch now rather than delaying failure until
+    // the first arithmetic operation.
+    static_cast<void>(transaction.state_kind(token));
+    return TransactionStateBackend(transaction, std::move(token));
+  }
+
+  TransactionStateBackend(const TransactionStateBackend &) = delete;
+  TransactionStateBackend &operator=(const TransactionStateBackend &) =
+      delete;
+  TransactionStateBackend(TransactionStateBackend &&) noexcept = default;
+  TransactionStateBackend &
+  operator=(TransactionStateBackend &&) noexcept = default;
+
+  CarpetX::ScratchStateTransaction &transaction() const noexcept {
+    return *transaction_;
+  }
+  CarpetX::ScratchStateToken &token() noexcept { return token_; }
+  const CarpetX::ScratchStateToken &token() const noexcept { return token_; }
+
+  CarpetX::ScratchStateKind kind() const {
+    return transaction().state_kind(token_);
+  }
+
+  bool valid(const CarpetX::ScratchStateRegion region) const {
+    return transaction().state_valid(token_, region);
+  }
+
+  void set_valid(const CarpetX::ScratchStateRegion region,
+                 const bool value) {
+    transaction().set_state_valid(token_, region, value);
+  }
+
+  TransactionStateBackend clone() const {
+    return from_token(transaction(), transaction().clone_state(token_));
+  }
+
+  void linear_combination(
+      const double destination_scale,
+      const std::initializer_list<LinearTerm> terms) {
+    linear_combination(destination_scale,
+                       std::vector<LinearTerm>(terms.begin(), terms.end()));
+  }
+
+  void linear_combination(const double destination_scale,
+                          const std::vector<LinearTerm> &terms) {
+    std::vector<CarpetX::ScratchLinearTerm> opaque_terms;
+    opaque_terms.reserve(terms.size());
+    for (const auto &term : terms) {
+      if (term.state == nullptr)
+        throw std::invalid_argument("scratch linear term is null");
+      if (&term.state->transaction() != transaction_)
+        throw std::invalid_argument(
+            "scratch linear combination mixes transaction owners");
+      opaque_terms.push_back({term.coefficient, &term.state->token()});
+    }
+    transaction().linear_combination(token_, destination_scale, opaque_terms);
+  }
+
+private:
+  TransactionStateBackend(CarpetX::ScratchStateTransaction &transaction,
+                          CarpetX::ScratchStateToken token) noexcept
+      : transaction_(&transaction), token_(std::move(token)) {}
+
+  CarpetX::ScratchStateTransaction *transaction_;
+  CarpetX::ScratchStateToken token_;
+};
+
+struct TransactionPrimaryCapture {
+  TransactionStateBackend left_state;
+  TransactionStateBackend left_rhs;
+  TransactionStateBackend accepted_endpoint;
+};
+
+// Observer for the unchanged primary RK advance.  The observer ignores the
+// live statecomp_t reference supplied by the kernel and asks the transaction
+// to snapshot the certified live identities at the exact observer events.
+class TransactionPrimaryObserver final {
+public:
+  explicit TransactionPrimaryObserver(
+      CarpetX::ScratchStateTransaction &transaction) noexcept
+      : transaction_(&transaction) {}
+
+  template <typename Scalar, typename State>
+  void initial_state(const Scalar, const State &) {
+    if (left_state_ || taken_)
+      throw std::logic_error("primary left state was captured twice");
+    left_state_.emplace(TransactionStateBackend::from_token(
+        *transaction_, transaction_->capture_live_evolved()));
+  }
+
+  template <typename Scalar, typename State>
+  void initial_rhs(const Scalar, const State &) {
+    if (!left_state_ || left_rhs_ || taken_)
+      throw std::logic_error("primary left RHS capture is out of order");
+    left_rhs_.emplace(TransactionStateBackend::from_token(
+        *transaction_, transaction_->capture_live_rhs()));
+  }
+
+  template <typename Scalar, typename State>
+  void stage_rhs(const int, const Scalar, const State &) const noexcept {}
+
+  template <typename Scalar, typename State>
+  void accepted_endpoint(const Scalar, const State &) {
+    if (!left_state_ || !left_rhs_ || accepted_endpoint_ || taken_)
+      throw std::logic_error("primary endpoint capture is out of order");
+    accepted_endpoint_.emplace(TransactionStateBackend::from_token(
+        *transaction_, transaction_->capture_live_evolved()));
+  }
+
+  TransactionPrimaryCapture take_complete() {
+    if (taken_ || !left_state_ || !left_rhs_ || !accepted_endpoint_)
+      throw std::logic_error("primary transaction capture is incomplete");
+    taken_ = true;
+    return {std::move(*left_state_), std::move(*left_rhs_),
+            std::move(*accepted_endpoint_)};
+  }
+
+private:
+  CarpetX::ScratchStateTransaction *transaction_;
+  std::optional<TransactionStateBackend> left_state_;
+  std::optional<TransactionStateBackend> left_rhs_;
+  std::optional<TransactionStateBackend> accepted_endpoint_;
+  bool taken_{false};
+};
+
+} // namespace ODESolvers
+
+#endif // ODESOLVERS_SUBCYCLING_TRANSACTION_BRIDGE_HXX

--- a/ODESolvers/test/cactus_explicit_rk_operations_unit.cxx
+++ b/ODESolvers/test/cactus_explicit_rk_operations_unit.cxx
@@ -1,0 +1,273 @@
+#include "cactus_explicit_rk_operations.hxx"
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct State {
+  using scalar_type = double;
+  double value{0.0};
+  State snapshot_state() const { return *this; }
+  State snapshot_rhs() const { return *this; }
+};
+
+void test_live_callbacks_remain_the_default_path() {
+  State state{2.0};
+  State rhs{3.0};
+  int prepared = 0;
+  int evaluated = 0;
+  int validated = 0;
+  int updated = 0;
+  int accumulated = 0;
+
+  ODESolvers::CactusExplicitRKOperations operations{
+      state,
+      rhs,
+      [&](double) { ++prepared; },
+      [&](int) { ++evaluated; },
+      [&](int) { ++validated; },
+      [&](int, double, double,
+          ODESolvers::LinearCombinationView<double, State>) { ++updated; },
+      [&](State &, double, const State &) { ++accumulated; }};
+
+  operations.prepare_initial(1.0);
+  operations.evaluate_rhs(1);
+  operations.validate_rhs(1);
+  operations.update_state(1, 1.5, 0.0, {nullptr, nullptr, 0});
+  operations.accumulate_rk4(state, 1.0, rhs);
+  assert(prepared == 1 && evaluated == 1 && validated == 1 && updated == 1 &&
+         accumulated == 1);
+  assert(operations.state_generation() == 1);
+}
+
+void test_stage_preparation_precedes_poststep_and_rhs() {
+  State state{2.0};
+  State rhs{3.0};
+  std::vector<std::string> trace;
+  ODESolvers::CactusExplicitRKOperations operations{
+      state,
+      rhs,
+      [&](double) { trace.emplace_back("set-initial-time"); },
+      [&](int) { trace.emplace_back("rhs"); },
+      [](int) {},
+      [&](int, double, double,
+          ODESolvers::LinearCombinationView<double, State>) {
+        trace.emplace_back("set-state-time");
+      },
+      [](State &, double, const State &) {}};
+  operations.stage_preparation_callback =
+      [&](const ODESolvers::ExplicitRKStagePoint &point, double) {
+        assert(point.kind == ODESolvers::ExplicitRKStageKind::primary);
+        trace.emplace_back("parent-fill-exchange-prolong");
+      };
+  operations.live_post_step_callback =
+      [&](double) { trace.emplace_back("poststep"); };
+
+  operations.set_stage_point(
+      {ODESolvers::ExplicitRKStageKind::primary, 1, 4, {0, 1}});
+  operations.prepare_initial(1.0);
+  operations.evaluate_rhs(1);
+  operations.set_stage_point(
+      {ODESolvers::ExplicitRKStageKind::primary, 2, 4, {1, 2}});
+  operations.update_state(1, 1.5, 0.0, {nullptr, nullptr, 0});
+  operations.evaluate_rhs(2);
+
+  assert((trace == std::vector<std::string>{
+                       "set-initial-time", "parent-fill-exchange-prolong",
+                       "rhs", "set-state-time",
+                       "parent-fill-exchange-prolong", "poststep", "rhs"}));
+}
+
+void test_nullable_scratch_hooks_dispatch_without_live_global_state() {
+  State state{2.0};
+  State rhs{3.0};
+  int restore_left = 0;
+  int restore_state = 0;
+  int probe = 0;
+  std::size_t rhs_count = 7;
+
+  using Hooks = ODESolvers::CactusExplicitRKScratchHooks<double, State>;
+  Hooks hooks;
+  hooks.restore_left = [&](State &dst_state, State &dst_rhs,
+                           const State &left_state, const State &left_rhs,
+                           double) {
+    ++restore_left;
+    dst_state = left_state;
+    dst_rhs = left_rhs;
+  };
+  hooks.restore_state = [&](State &dst, const State &source, double) {
+    ++restore_state;
+    dst = source;
+  };
+  hooks.probe_endpoint_rhs = [&](State &, State &dst_rhs,
+                                 const ODESolvers::ExplicitRKStagePoint &,
+                                 double) {
+    ++probe;
+    dst_rhs.value = 19.0;
+    return dst_rhs.snapshot_rhs();
+  };
+  hooks.rhs_evaluation_count = [&] { return rhs_count; };
+
+  ODESolvers::CactusExplicitRKOperations operations{
+      state,
+      rhs,
+      [](double) {},
+      [](int) {},
+      [](int) {},
+      [](int, double, double,
+         ODESolvers::LinearCombinationView<double, State>) {},
+      [](State &, double, const State &) {}};
+  operations.scratch_hooks = &hooks;
+  std::vector<std::string> endpoint_trace;
+  int stage_phase = 0;
+  operations.stage_materialization_callback =
+      [&](State &, const ODESolvers::ExplicitRKStagePoint &point, double) {
+        assert(stage_phase == 0);
+        stage_phase = 1;
+        endpoint_trace.emplace_back(
+            point.kind == ODESolvers::ExplicitRKStageKind::fractional
+                ? "materialize-fractional"
+                : "materialize-endpoint");
+      };
+  operations.stage_preparation_callback =
+      [&](const ODESolvers::ExplicitRKStagePoint &point, double) {
+        assert(stage_phase == 1);
+        stage_phase = 2;
+        endpoint_trace.emplace_back(
+            point.kind == ODESolvers::ExplicitRKStageKind::fractional
+                ? "prepare-fractional"
+                : "prepare-endpoint");
+      };
+  hooks.post_step_after_update =
+      [&](State &, const ODESolvers::ExplicitRKStagePoint &point, double) {
+        assert(stage_phase == 2);
+        stage_phase = 3;
+        endpoint_trace.emplace_back(
+            point.kind == ODESolvers::ExplicitRKStageKind::fractional
+                ? "scratch-poststep-fractional"
+                : "scratch-poststep-endpoint");
+      };
+  hooks.evaluate_rhs =
+      [&](State &, State &, int,
+          const ODESolvers::ExplicitRKStagePoint &point, double) {
+        assert(stage_phase == 2 || stage_phase == 3);
+        stage_phase = 0;
+        endpoint_trace.emplace_back(
+            point.kind == ODESolvers::ExplicitRKStageKind::fractional
+                ? "scratch-rhs-fractional"
+                : "scratch-rhs-endpoint");
+      };
+  hooks.probe_endpoint_rhs = [&](State &, State &dst_rhs,
+                                 const ODESolvers::ExplicitRKStagePoint &,
+                                 double) {
+    assert(stage_phase == 3);
+    stage_phase = 0;
+    endpoint_trace.emplace_back("scratch-rhs-endpoint");
+    ++probe;
+    dst_rhs.value = 19.0;
+    return dst_rhs.snapshot_rhs();
+  };
+
+  const State left{5.0};
+  const State left_rhs{7.0};
+  operations.restore_left(left, left_rhs, 1.0);
+  auto token = ODESolvers::make_loaded_rhs_token(operations, 1.0);
+  operations.validate_loaded_rhs_provenance(token.provenance());
+  assert(state.value == 5.0 && rhs.value == 7.0 && restore_left == 1);
+
+  operations.set_stage_point(
+      {ODESolvers::ExplicitRKStageKind::fractional, 1, 4, {0, 1}});
+  operations.prepare_initial(1.0);
+  operations.evaluate_rhs(1);
+  operations.set_stage_point(
+      {ODESolvers::ExplicitRKStageKind::fractional, 2, 4, {1, 4}});
+  operations.update_state(1, 1.25, 0.0, {nullptr, nullptr, 0});
+  operations.evaluate_rhs(2);
+
+  const State endpoint{11.0};
+  operations.restore_state(endpoint, 2.0);
+  assert(state.value == 11.0 && restore_state == 1);
+  assert(operations
+             .probe_endpoint_rhs(
+                 2.0, {ODESolvers::ExplicitRKStageKind::endpoint_probe, 1, 1,
+                       {1, 1}})
+             .value == 19.0 &&
+         probe == 1);
+  assert((endpoint_trace == std::vector<std::string>{
+                                "materialize-fractional",
+                                "prepare-fractional",
+                                "scratch-rhs-fractional",
+                                "materialize-fractional",
+                                "prepare-fractional",
+                                "scratch-poststep-fractional",
+                                "scratch-rhs-fractional",
+                                "materialize-endpoint", "prepare-endpoint",
+                                "scratch-poststep-endpoint",
+                                "scratch-rhs-endpoint"}));
+  assert(stage_phase == 0);
+  assert(operations.rhs_evaluation_count() == rhs_count);
+}
+
+void test_missing_scratch_hook_fails_closed() {
+  State state{};
+  State rhs{};
+  ODESolvers::CactusExplicitRKOperations operations{
+      state,
+      rhs,
+      [](double) {},
+      [](int) {},
+      [](int) {},
+      [](int, double, double,
+         ODESolvers::LinearCombinationView<double, State>) {},
+      [](State &, double, const State &) {}};
+  bool threw = false;
+  try {
+    operations.restore_state(state, 1.0);
+  } catch (const std::logic_error &) {
+    threw = true;
+  }
+  assert(threw);
+}
+
+void test_scratch_stage_preparation_requires_materialization() {
+  State state{};
+  State rhs{};
+  using Hooks = ODESolvers::CactusExplicitRKScratchHooks<double, State>;
+  Hooks hooks;
+  ODESolvers::CactusExplicitRKOperations operations{
+      state,
+      rhs,
+      [](double) {},
+      [](int) {},
+      [](int) {},
+      [](int, double, double,
+         ODESolvers::LinearCombinationView<double, State>) {},
+      [](State &, double, const State &) {}};
+  operations.scratch_hooks = &hooks;
+  operations.stage_preparation_callback =
+      [](const ODESolvers::ExplicitRKStagePoint &, double) {};
+  operations.set_stage_point(
+      {ODESolvers::ExplicitRKStageKind::fractional, 1, 4, {0, 1}});
+  bool threw = false;
+  try {
+    operations.prepare_initial(1.0);
+  } catch (const std::logic_error &) {
+    threw = true;
+  }
+  assert(threw);
+}
+
+} // namespace
+
+int main() {
+  test_live_callbacks_remain_the_default_path();
+  test_stage_preparation_precedes_poststep_and_rhs();
+  test_nullable_scratch_hooks_dispatch_without_live_global_state();
+  test_missing_scratch_hook_fails_closed();
+  test_scratch_stage_preparation_requires_materialization();
+}

--- a/ODESolvers/test/explicit_rk_dense_provider_unit.cxx
+++ b/ODESolvers/test/explicit_rk_dense_provider_unit.cxx
@@ -1,0 +1,812 @@
+#include "explicit_rk_dense_provider.hxx"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <new>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using ODESolvers::ExplicitRKMethod;
+using ODESolvers::InitialRHSMode;
+using ODESolvers::LoadedRHSProvenance;
+
+void require(const bool condition, const std::string &message) {
+  if (!condition)
+    throw std::runtime_error(message);
+}
+
+template <class Exception, class Function>
+void require_throws(Function &&function, const std::string &message) {
+  bool threw = false;
+  try {
+    function();
+  } catch (const Exception &) {
+    threw = true;
+  }
+  require(threw, message);
+}
+
+std::string fingerprint_hex(
+    const ODESolvers::ExplicitRKTableauFingerprint &fingerprint) {
+  std::ostringstream stream;
+  stream << std::hex << std::setfill('0');
+  for (const auto byte : fingerprint)
+    stream << std::setw(2) << static_cast<unsigned int>(byte);
+  return stream.str();
+}
+
+struct TestState {
+  static int live_count;
+  static int move_attempts;
+  static int fail_move_countdown;
+  std::vector<long double> values;
+
+  explicit TestState(std::vector<long double> values_)
+      : values(std::move(values_)) {
+    ++live_count;
+  }
+  ~TestState() { --live_count; }
+
+  TestState(const TestState &) = delete;
+  TestState &operator=(const TestState &) = delete;
+  TestState(TestState &&other) : values() {
+    ++move_attempts;
+    if (fail_move_countdown == 0) {
+      fail_move_countdown = -1;
+      throw std::bad_alloc();
+    }
+    if (fail_move_countdown > 0)
+      --fail_move_countdown;
+    values = std::move(other.values);
+    ++live_count;
+  }
+  TestState &operator=(TestState &&other) noexcept {
+    values = std::move(other.values);
+    return *this;
+  }
+};
+
+int TestState::live_count = 0;
+int TestState::move_attempts = 0;
+int TestState::fail_move_countdown = -1;
+
+TestState clone_state(const TestState &source) {
+  return TestState(source.values);
+}
+
+bool same_state(const TestState &left, const TestState &right) {
+  return left.values == right.values;
+}
+
+TestState square_state(const TestState &state) {
+  std::vector<long double> result(state.values.size());
+  for (std::size_t i = 0; i < result.size(); ++i)
+    result[i] = state.values[i] * state.values[i];
+  return TestState(std::move(result));
+}
+
+struct ScratchOps {
+  using scalar_type = long double;
+  using state_type = TestState;
+
+  TestState state_value;
+  TestState rhs_value;
+  long double time{0.0L};
+  std::uint64_t generation{0};
+  bool loaded_rhs{false};
+  std::size_t rhs_calls{0};
+  std::size_t token_consumptions{0};
+  int fail_event{0};
+  int event_count{0};
+  bool record_events{true};
+  std::vector<std::string> events;
+  std::vector<long double> restored_left_values;
+  bool require_parent_fill{false};
+  bool parent_fill_ready{false};
+  std::optional<ODESolvers::ExplicitRKStagePoint> pending_stage_point;
+  std::size_t parent_fill_count{0};
+  std::function<void(const ODESolvers::ExplicitRKStagePoint &, long double)>
+      driver_prepare;
+
+  explicit ScratchOps(const std::size_t components = 1,
+                      const int fail_event_ = 0)
+      : state_value(std::vector<long double>(components, 0.0L)),
+        rhs_value(std::vector<long double>(components, 0.0L)),
+        fail_event(fail_event_) {}
+
+  void event(const char *const name) {
+    ++event_count;
+    if (record_events)
+      events.emplace_back(name);
+    if (fail_event == event_count)
+      throw std::runtime_error(std::string("injected failure at ") + name);
+  }
+
+  const TestState &state() const noexcept { return state_value; }
+  const TestState &rhs() const noexcept { return rhs_value; }
+
+  TestState snapshot_state() {
+    event("snapshot-state");
+    return clone_state(state_value);
+  }
+  TestState snapshot_rhs() {
+    event("snapshot-rhs");
+    return clone_state(rhs_value);
+  }
+
+  void restore_left(const TestState &left, const TestState &left_rhs,
+                    const long double left_time) {
+    event("restore-left");
+    require(left.values.size() == left_rhs.values.size(),
+            "restore_left shape mismatch");
+    state_value = clone_state(left);
+    rhs_value = clone_state(left_rhs);
+    time = left_time;
+    ++generation;
+    loaded_rhs = true;
+    restored_left_values.push_back(left.values.front());
+  }
+
+  void restore_state(const TestState &state, const long double state_time) {
+    event("restore-state");
+    state_value = clone_state(state);
+    time = state_time;
+    ++generation;
+    loaded_rhs = false;
+  }
+
+  void set_stage_point(const ODESolvers::ExplicitRKStagePoint &point) {
+    pending_stage_point = point;
+    parent_fill_ready = false;
+  }
+
+  void prepare_current_stage() {
+    if (!require_parent_fill)
+      return;
+    require(pending_stage_point.has_value(),
+            "L1 auxiliary stage reached state/time without an exact stage point");
+    require(static_cast<bool>(driver_prepare),
+            "L1 auxiliary stage has no driver preparation callback");
+    driver_prepare(*pending_stage_point, time);
+    pending_stage_point.reset();
+    parent_fill_ready = true;
+    ++parent_fill_count;
+  }
+
+  void prepare_initial(const long double stage_time) {
+    time = stage_time;
+    prepare_current_stage();
+  }
+
+  void update_state(
+      const int, const long double stage_time,
+      const long double destination_scale,
+      const ODESolvers::LinearCombinationView<long double, TestState>
+          combination) {
+    event("stage-update");
+    std::vector<long double> updated(state_value.values.size(), 0.0L);
+    for (std::size_t component = 0; component < updated.size(); ++component)
+      updated[component] = destination_scale * state_value.values[component];
+    for (std::size_t source = 0; source < combination.size; ++source)
+      for (std::size_t component = 0; component < updated.size(); ++component)
+        updated[component] += combination.factors[source] *
+                              combination.sources[source]->values[component];
+    state_value.values = std::move(updated);
+    time = stage_time;
+    prepare_current_stage();
+    ++generation;
+    loaded_rhs = false;
+  }
+
+  void evaluate_rhs(const int) {
+    event("stage-rhs");
+    if (require_parent_fill)
+      require(parent_fill_ready,
+              "L1 auxiliary RHS ran before the L0 parent fill");
+    ++rhs_calls;
+    for (std::size_t component = 0; component < state_value.values.size();
+         ++component)
+      rhs_value.values[component] =
+          state_value.values[component] * state_value.values[component];
+  }
+
+  void validate_rhs(const int) {
+    event("validate-rhs");
+    for (const long double value : rhs_value.values)
+      if (!std::isfinite(value))
+        throw std::runtime_error("non-finite test RHS");
+  }
+
+  void accumulate_rk4(TestState &accumulator, const long double factor,
+                      const TestState &increment) {
+    event("rk4-accumulate");
+    for (std::size_t component = 0; component < accumulator.values.size();
+         ++component)
+      accumulator.values[component] += factor * increment.values[component];
+  }
+
+  std::uint64_t state_generation() const noexcept { return generation; }
+  LoadedRHSProvenance<long double>
+  loaded_rhs_provenance(const long double left_time) const {
+    if (!loaded_rhs || left_time != time)
+      throw std::logic_error("no loaded left RHS");
+    return {generation, left_time};
+  }
+  void validate_loaded_rhs_provenance(
+      const LoadedRHSProvenance<long double> &provenance) const {
+    if (!loaded_rhs || provenance.state_generation != generation ||
+        provenance.left_time != time)
+      throw std::logic_error("stale loaded left RHS");
+  }
+  void consume_loaded_rhs(
+      const LoadedRHSProvenance<long double> &provenance) {
+    event("consume-loaded-rhs");
+    validate_loaded_rhs_provenance(provenance);
+    loaded_rhs = false;
+    ++token_consumptions;
+  }
+
+  TestState probe_endpoint_rhs(
+      const long double probe_time,
+      const ODESolvers::ExplicitRKStagePoint &stage_point) {
+    event("endpoint-probe");
+    if (probe_time != time)
+      throw std::logic_error("endpoint probe time mismatch");
+    set_stage_point(stage_point);
+    prepare_current_stage();
+    evaluate_rhs(0);
+    validate_rhs(0);
+    return snapshot_rhs();
+  }
+
+  std::size_t rhs_evaluation_count() const noexcept { return rhs_calls; }
+};
+
+class ThreeLevelParentFill final : public CarpetX::StagePreparer {
+public:
+  std::array<std::size_t, 3> fill_generation{{1, 0, 0}};
+  std::vector<CarpetX::StagePoint> points;
+
+  void prepare_stage(const CarpetX::StepContext &context,
+                     const CarpetX::StagePoint &point) override {
+    require(context.level == 1,
+            "synthetic auxiliary solve did not target level 1");
+    fill_generation[1] = fill_generation[0] + 1;
+    points.push_back(point);
+  }
+};
+
+static_assert(!std::is_copy_constructible<TestState>::value,
+              "fixture state must remain move-only");
+static_assert(
+    !std::is_copy_constructible<
+        ODESolvers::ReferenceDenseSampleBatch<TestState>>::value,
+    "sample batch must remain move-only");
+
+struct PrimaryResult {
+  TestState endpoint;
+  TestState final_legacy_rhs;
+};
+
+PrimaryResult primary_step(const ExplicitRKMethod method,
+                           const long double t0, const long double dt,
+                           const TestState &left,
+                           const TestState &left_rhs) {
+  ScratchOps ops(left.values.size());
+  ops.restore_left(left, left_rhs, t0);
+  auto token = ODESolvers::make_loaded_rhs_token(ops, t0);
+  ODESolvers::advance_explicit_rk(method, t0, dt,
+                                  InitialRHSMode::reuse_loaded, ops, token);
+  return {ops.snapshot_state(), ops.snapshot_rhs()};
+}
+
+struct MethodExpectation {
+  ExplicitRKMethod method;
+  CarpetX::SubcyclingODEMethod dense_method;
+  const char *fingerprint;
+  int order;
+  int stages;
+  int extra_rhs;
+  int controls;
+  int fractional_solves;
+};
+
+const std::array<MethodExpectation, 3> expectations{{
+    {ExplicitRKMethod::rk4, CarpetX::SubcyclingODEMethod::rk4,
+     "5a1c84e15a045292e8478588e49ea15a8c7d1dd792ba3e13a31b9bf99556f32d",
+     4, 4, 4, 5, 1},
+    {ExplicitRKMethod::rkf78, CarpetX::SubcyclingODEMethod::rkf78_order7,
+     "3d600f326c614c8ba6f35ac84d4097bb820d7cf4e37cd3c43ae899ef5e9833a5",
+     7, 11, 23, 8, 2},
+    {ExplicitRKMethod::dp87, CarpetX::SubcyclingODEMethod::dp87_order8,
+     "a3faabaef46ae521e6aa524e6f0307f0b999dcb9414ecd50d30eb884e72fdc92",
+     8, 13, 39, 9, 3}}};
+
+void test_fingerprints_capabilities_and_registry() {
+  CarpetX::DenseOutputRegistry registry;
+  for (const auto &expected : expectations) {
+    const auto fingerprint =
+        ODESolvers::explicit_rk_tableau_fingerprint(expected.method);
+    require(fingerprint_hex(fingerprint) == expected.fingerprint,
+            "tableau fingerprint changed");
+    const auto capability =
+        ODESolvers::reference_dense_capability(expected.method);
+    require(capability.method == expected.dense_method,
+            "dense method mapping changed");
+    require(capability.tableau_fingerprint == fingerprint,
+            "capability fingerprint mismatch");
+    require(capability.endpoint_order == expected.order &&
+                capability.dense_uniform_order == expected.order &&
+                capability.stage_count == expected.stages &&
+                capability.extra_rhs_evaluations == expected.extra_rhs &&
+                capability.persistent_vector_count == expected.controls &&
+                capability.arbitrary_theta && capability.verified,
+            "dense capability fields changed");
+    registry.register_provider(
+        ODESolvers::make_reference_dense_provider(expected.method));
+    require(registry.require(expected.dense_method, fingerprint)->capability()
+                .tableau_fingerprint == fingerprint,
+            "registered provider lookup failed");
+    auto wrong = fingerprint;
+    wrong.front() ^= 0x80U;
+    require_throws<std::out_of_range>(
+        [&] { (void)registry.require(expected.dense_method, wrong); },
+        "fingerprint mismatch did not fail closed");
+  }
+  require_throws<std::invalid_argument>(
+      [] {
+        (void)ODESolvers::reference_dense_capability(
+            static_cast<ExplicitRKMethod>(99));
+      },
+      "unsupported provider method did not fail before construction");
+
+  CarpetX::DenseOutputRegistry mismatch_registry;
+  auto mismatched =
+      ODESolvers::reference_dense_capability(ExplicitRKMethod::rk4);
+  const auto canonical_rk4_fingerprint = mismatched.tableau_fingerprint;
+  mismatched.tableau_fingerprint =
+      ODESolvers::explicit_rk_tableau_fingerprint(ExplicitRKMethod::rkf78);
+  mismatch_registry.register_provider(
+      std::make_shared<const CarpetX::DenseOutputProvider>(mismatched));
+  require_throws<std::out_of_range>(
+      [&] {
+        (void)mismatch_registry.require(CarpetX::SubcyclingODEMethod::rk4,
+                                        canonical_rk4_fingerprint);
+      },
+      "coefficient/method fingerprint mismatch did not fail closed");
+}
+
+std::vector<double> numeric_controls(
+    const ExplicitRKMethod method, const long double parent_dt,
+    const ODESolvers::ReferenceDenseSampleBatch<TestState> &batch,
+    const std::size_t component) {
+  const auto dense_method = ODESolvers::subcycling_method(method);
+  const auto &stencil = CarpetX::reference_dense_stencil(dense_method);
+  require(batch.size() == stencil.sample_count(),
+          "numeric sample count mismatch");
+  std::vector<double> samples(batch.size(), 0.0);
+  for (std::size_t i = 0; i < batch.size(); ++i) {
+    const auto &sample = batch.samples()[i];
+    long double value = sample.payload.values.at(component);
+    if (sample.kind == CarpetX::DenseSampleKind::scaled_derivative)
+      value *= parent_dt;
+    samples[i] = static_cast<double>(value);
+  }
+  return stencil.make_controls(samples);
+}
+
+class TestDenseState final : public CarpetX::DenseStateVector {
+public:
+  static int live_count;
+  explicit TestDenseState(std::vector<double> values_)
+      : values(std::move(values_)) {
+    ++live_count;
+  }
+  ~TestDenseState() override { --live_count; }
+
+  bool compatible(const CarpetX::DenseStateVector &other) const noexcept
+      override {
+    const auto *const typed = dynamic_cast<const TestDenseState *>(&other);
+    return typed != nullptr && typed->values.size() == values.size();
+  }
+  void copy_from(const CarpetX::DenseStateVector &other) override {
+    const auto &typed = dynamic_cast<const TestDenseState &>(other);
+    values = typed.values;
+  }
+  void linear_combination(
+      const std::vector<double> &weights,
+      const std::vector<const CarpetX::DenseStateVector *> &sources) override {
+    require(weights.size() == sources.size(),
+            "dense state linear combination shape mismatch");
+    std::fill(values.begin(), values.end(), 0.0);
+    for (std::size_t source = 0; source < sources.size(); ++source) {
+      const auto &typed =
+          dynamic_cast<const TestDenseState &>(*sources[source]);
+      for (std::size_t component = 0; component < values.size(); ++component)
+        values[component] += weights[source] * typed.values[component];
+    }
+  }
+
+  std::vector<double> values;
+};
+
+int TestDenseState::live_count = 0;
+
+std::shared_ptr<const CarpetX::DenseInterval> build_test_interval(
+    const MethodExpectation &expected, const long double parent_dt,
+    const ODESolvers::ReferenceDenseSampleBatch<TestState> &batch,
+    const int fail_control = -1) {
+  const auto provider =
+      ODESolvers::make_reference_dense_provider(expected.method);
+  const auto capability = provider->capability();
+  const CarpetX::DenseIntervalId id{
+      0,
+      CarpetX::step_clock_t(0),
+      CarpetX::step_clock_t(1),
+      0.0,
+      static_cast<double>(parent_dt),
+      capability.method,
+      capability.tableau_fingerprint};
+  auto builder = provider->begin_interval(id);
+  std::vector<std::vector<double>> component_controls;
+  for (std::size_t component = 0;
+       component < batch.samples().front().payload.values.size(); ++component)
+    component_controls.push_back(
+        numeric_controls(expected.method, parent_dt, batch, component));
+  for (int control = 0; control < expected.controls; ++control) {
+    if (control == fail_control)
+      throw std::bad_alloc();
+    std::vector<double> values(component_controls.size(), 0.0);
+    for (std::size_t component = 0; component < values.size(); ++component)
+      values[component] =
+          component_controls[component][static_cast<std::size_t>(control)];
+    builder->add_control(
+        std::make_unique<TestDenseState>(std::move(values)));
+  }
+  return builder->seal();
+}
+
+void test_collection_and_interval(const MethodExpectation &expected) {
+  TestState left({0.2L, 0.35L});
+  TestState left_rhs = square_state(left);
+  auto primary = primary_step(expected.method, 0.125L, 0.0625L, left,
+                              left_rhs);
+  const auto left_before = left.values;
+  const auto rhs_before = left_rhs.values;
+  const auto endpoint_before = primary.endpoint.values;
+  const auto legacy_before = primary.final_legacy_rhs.values;
+
+  ScratchOps scratch(left.values.size());
+  auto batch = ODESolvers::collect_reference_dense_samples(
+      expected.method, 0.125L, 0.0625L, left, left_rhs, primary.endpoint,
+      scratch);
+  require(batch.size() == static_cast<std::size_t>(expected.controls),
+          "collector sample count changed");
+  require(scratch.rhs_calls == static_cast<std::size_t>(expected.extra_rhs),
+          "collector extra RHS count changed");
+  require(scratch.token_consumptions ==
+              static_cast<std::size_t>(expected.fractional_solves),
+          "fractional solves did not use fresh one-shot tokens");
+  require(scratch.restored_left_values.size() ==
+              static_cast<std::size_t>(expected.fractional_solves + 2),
+          "collector did not restore each fractional solve independently");
+  require(left.values == left_before && left_rhs.values == rhs_before &&
+              primary.endpoint.values == endpoint_before &&
+              primary.final_legacy_rhs.values == legacy_before,
+          "collector mutated a primary state or final legacy RHS");
+  for (const long double restored : scratch.restored_left_values)
+    require(restored == left.values.front(),
+            "fractional solve was not restored from the common left state");
+
+  const auto &constraints = CarpetX::reference_dense_stencil(
+                                expected.dense_method)
+                                .specification()
+                                .constraints;
+  for (std::size_t i = 0; i < constraints.size(); ++i) {
+    require(batch.samples()[i].theta == constraints[i].theta &&
+                batch.samples()[i].kind == constraints[i].kind,
+            "collector sample order differs from Phase 4");
+    if (batch.samples()[i].kind ==
+        CarpetX::DenseSampleKind::scaled_derivative) {
+      const auto &derivative = batch.samples()[i].payload.values;
+      const auto &value = batch.samples()[i - 1].payload.values;
+      for (std::size_t component = 0; component < derivative.size();
+           ++component)
+        require(derivative[component] == value[component] * value[component],
+                "collector scaled a raw derivative payload");
+    }
+    if (batch.samples()[i].theta == 1.0 &&
+        batch.samples()[i].kind == CarpetX::DenseSampleKind::value)
+      require(same_state(batch.samples()[i].payload, primary.endpoint),
+              "accepted endpoint sample lost bit identity");
+  }
+
+  {
+    auto interval = build_test_interval(expected, 0.0625L, batch);
+    require(interval->control_count() ==
+                static_cast<std::size_t>(expected.controls),
+            "interval control count changed");
+    TestDenseState begin(std::vector<double>(left.values.size(), -1.0));
+    TestDenseState end(std::vector<double>(left.values.size(), -1.0));
+    TestDenseState interior(std::vector<double>(left.values.size(), -1.0));
+    interval->evaluate(0.0, begin);
+    interval->evaluate(1.0, end);
+    interval->evaluate(0.37, interior);
+    for (std::size_t component = 0; component < left.values.size();
+         ++component) {
+      require(begin.values[component] == static_cast<double>(left.values[component]),
+              "theta=0 endpoint is not bit exact");
+      require(end.values[component] ==
+                  static_cast<double>(primary.endpoint.values[component]),
+              "theta=1 endpoint is not bit exact");
+      require(std::isfinite(interior.values[component]),
+              "arbitrary theta evaluation is not finite");
+    }
+  }
+  require(TestDenseState::live_count == 0,
+          "sealed interval leaked test controls");
+
+  for (int control = 0; control < expected.controls; ++control) {
+    require_throws<std::bad_alloc>(
+        [&] { (void)build_test_interval(expected, 0.0625L, batch, control); },
+        "control allocation failure did not roll back");
+    require(TestDenseState::live_count == 0,
+            "failed interval publication leaked controls");
+  }
+}
+
+void test_collector_failure_rollback(const MethodExpectation &expected) {
+  TestState left({0.24L});
+  TestState left_rhs = square_state(left);
+  auto primary = primary_step(expected.method, 0.0L, 0.1L, left, left_rhs);
+  const auto left_before = left.values;
+  const auto rhs_before = left_rhs.values;
+  const auto endpoint_before = primary.endpoint.values;
+  const auto legacy_before = primary.final_legacy_rhs.values;
+
+  ScratchOps baseline(1);
+  {
+    auto batch = ODESolvers::collect_reference_dense_samples(
+        expected.method, 0.0L, 0.1L, left, left_rhs, primary.endpoint,
+        baseline);
+    require(!batch.empty(), "baseline batch unexpectedly empty");
+  }
+  const int critical_event_count = baseline.event_count;
+  require(critical_event_count > expected.extra_rhs,
+          "failure fixture did not observe collector operations");
+
+  for (int failure = 1; failure <= critical_event_count; ++failure) {
+    const int live_before = TestState::live_count;
+    {
+      ScratchOps scratch(1, failure);
+      require_throws<std::runtime_error>(
+          [&] {
+            (void)ODESolvers::collect_reference_dense_samples(
+                expected.method, 0.0L, 0.1L, left, left_rhs,
+                primary.endpoint, scratch);
+          },
+          "injected collector operation failure was not propagated");
+    }
+    require(TestState::live_count == live_before,
+            "failed collector transaction leaked sample states");
+    require(left.values == left_before && left_rhs.values == rhs_before &&
+                primary.endpoint.values == endpoint_before &&
+                primary.final_legacy_rhs.values == legacy_before,
+            "failed collector transaction mutated primary data");
+  }
+
+  TestState::move_attempts = 0;
+  {
+    ScratchOps move_baseline(1);
+    move_baseline.record_events = false;
+    auto batch = ODESolvers::collect_reference_dense_samples(
+        expected.method, 0.0L, 0.1L, left, left_rhs, primary.endpoint,
+        move_baseline);
+    require(!batch.empty(), "move-allocation baseline batch is empty");
+  }
+  const int move_positions = TestState::move_attempts;
+  require(move_positions >= expected.controls,
+          "fixture did not observe all sample/state move positions");
+  for (int failure = 0; failure < move_positions; ++failure) {
+    const int live_before = TestState::live_count;
+    {
+      ScratchOps allocation_scratch(1);
+      allocation_scratch.record_events = false;
+      TestState::fail_move_countdown = failure;
+      require_throws<std::bad_alloc>(
+          [&] {
+            (void)ODESolvers::collect_reference_dense_samples(
+                expected.method, 0.0L, 0.1L, left, left_rhs,
+                primary.endpoint, allocation_scratch);
+          },
+          "fixture move/allocation failure was not propagated");
+      TestState::fail_move_countdown = -1;
+    }
+    require(TestState::live_count == live_before,
+            "fixture move/allocation failure leaked state");
+  }
+}
+
+long double exact_solution(const long double y0, const long double time) {
+  return y0 / (1.0L - y0 * time);
+}
+
+struct ConvergenceError {
+  long double dense;
+  long double endpoint;
+};
+
+constexpr long double convergence_initial = 0.8L;
+constexpr long double convergence_final_time = 0.85L;
+constexpr std::array<long double, 4> convergence_sample_thetas{{
+    0.13L, 0.37L, 0.61L, 0.89L}};
+
+ConvergenceError convergence_error(const MethodExpectation &expected,
+                                   const int steps) {
+  const long double dt =
+      convergence_final_time / static_cast<long double>(steps);
+  long double current = convergence_initial;
+  long double dense_error_squared = 0.0L;
+  std::size_t dense_sample_count = 0;
+  for (int step = 0; step < steps; ++step) {
+    const long double t0 = static_cast<long double>(step) * dt;
+    TestState left({current});
+    TestState left_rhs({current * current});
+    auto primary = primary_step(expected.method, t0, dt, left, left_rhs);
+    ScratchOps scratch(1);
+    auto batch = ODESolvers::collect_reference_dense_samples(
+        expected.method, t0, dt, left, left_rhs, primary.endpoint, scratch);
+    auto interval = build_test_interval(expected, dt, batch);
+    for (const long double theta : convergence_sample_thetas) {
+      TestDenseState evaluated({0.0});
+      interval->evaluate(static_cast<double>(theta), evaluated);
+      const long double computed =
+          static_cast<long double>(evaluated.values.front());
+      const long double exact =
+          exact_solution(convergence_initial, t0 + theta * dt);
+      const long double error = computed - exact;
+      dense_error_squared += error * error;
+      ++dense_sample_count;
+    }
+    current = primary.endpoint.values.front();
+  }
+  return {std::sqrt(dense_error_squared /
+                    static_cast<long double>(dense_sample_count)),
+          std::abs(current - exact_solution(convergence_initial,
+                                            convergence_final_time))};
+}
+
+void test_observed_orders(const MethodExpectation &expected) {
+  const auto coarse = convergence_error(expected, 8);
+  const auto medium = convergence_error(expected, 16);
+  const auto fine = convergence_error(expected, 32);
+  require(coarse.dense > medium.dense && medium.dense > fine.dense,
+          "dense convergence errors do not decrease");
+  require(coarse.endpoint > medium.endpoint &&
+              medium.endpoint > fine.endpoint,
+          "endpoint convergence errors do not decrease");
+  const auto observed = [](const long double left, const long double right) {
+    return std::log(left / right) / std::log(2.0L);
+  };
+  const long double threshold =
+      static_cast<long double>(expected.order) - 0.25L;
+  const long double dense_order_1 = observed(coarse.dense, medium.dense);
+  const long double dense_order_2 = observed(medium.dense, fine.dense);
+  const long double endpoint_order_1 =
+      observed(coarse.endpoint, medium.endpoint);
+  const long double endpoint_order_2 =
+      observed(medium.endpoint, fine.endpoint);
+  std::cout << std::setprecision(12) << std::scientific
+            << "ORDER_TABLE p=" << expected.order
+            << " h=" << static_cast<double>(convergence_final_time / 8.0L)
+            << ',' << static_cast<double>(convergence_final_time / 16.0L)
+            << ',' << static_cast<double>(convergence_final_time / 32.0L)
+            << " dense_error=" << static_cast<double>(coarse.dense) << ','
+            << static_cast<double>(medium.dense) << ','
+            << static_cast<double>(fine.dense)
+            << " endpoint_error=" << static_cast<double>(coarse.endpoint)
+            << ',' << static_cast<double>(medium.endpoint) << ','
+            << static_cast<double>(fine.endpoint)
+            << " dense_order=" << static_cast<double>(dense_order_1) << ','
+            << static_cast<double>(dense_order_2)
+            << " endpoint_order=" << static_cast<double>(endpoint_order_1)
+            << ',' << static_cast<double>(endpoint_order_2) << '\n';
+  std::ostringstream detail;
+  detail << "method order " << expected.order << ": dense="
+         << static_cast<double>(dense_order_1) << ','
+         << static_cast<double>(dense_order_2) << " endpoint="
+         << static_cast<double>(endpoint_order_1) << ','
+         << static_cast<double>(endpoint_order_2);
+  require(dense_order_1 >= threshold && dense_order_2 >= threshold,
+          "dense observed order is below the endpoint order gate: " +
+              detail.str());
+  require(endpoint_order_1 >= threshold && endpoint_order_2 >= threshold,
+          "primary endpoint observed order regressed: " + detail.str());
+}
+
+void test_three_level_auxiliary_dense_prepares_l0_fill_before_l1_rhs() {
+  const long double t0 = 1000000000000.0L;
+  const long double dt = 0.5L;
+  TestState left({0.25L});
+  TestState left_rhs({0.0625L});
+  auto primary = primary_step(ExplicitRKMethod::rk4, t0, dt, left, left_rhs);
+
+  ScratchOps scratch;
+  scratch.require_parent_fill = true;
+  ThreeLevelParentFill preparer;
+  const CarpetX::StepContext context{
+      1, CarpetX::step_clock_t(17, 8), CarpetX::step_clock_t(19, 8),
+      static_cast<double>(t0), static_cast<double>(t0 + dt),
+      CarpetX::SubcyclingODEMethod::rk4};
+  auto *const transaction = reinterpret_cast<CarpetX::ScratchStateTransaction *>(
+      static_cast<std::uintptr_t>(0x10));
+  CarpetX::ScopedStepContext scope(context, preparer, transaction);
+  scratch.driver_prepare = [&](const ODESolvers::ExplicitRKStagePoint &point,
+                               const long double stage_time) {
+    const auto kind =
+        point.kind == ODESolvers::ExplicitRKStageKind::fractional
+            ? CarpetX::StageKind::fractional
+            : CarpetX::StageKind::endpoint_probe;
+    CarpetX::prepare_stage(
+        {kind, point.stage_index, point.stage_count,
+         CarpetX::step_clock_t(point.parent_fraction.numerator,
+                               point.parent_fraction.denominator),
+         static_cast<double>(stage_time)},
+        context.method);
+  };
+
+  const auto samples = ODESolvers::collect_reference_dense_samples(
+      ExplicitRKMethod::rk4, t0, dt, left, left_rhs, primary.endpoint,
+      scratch);
+  require(samples.size() == 5,
+          "three-level auxiliary dense sample batch is incomplete");
+  require(scratch.parent_fill_count > 0,
+          "L1 auxiliary dense construction never invoked the L0 fill");
+  require(preparer.fill_generation[1] > preparer.fill_generation[0],
+          "L0 parent fill did not reach L1");
+  require(preparer.fill_generation[2] == 0,
+          "L1 auxiliary construction unexpectedly advanced level 2");
+  require(std::any_of(preparer.points.begin(), preparer.points.end(),
+                      [](const auto &point) {
+                        return point.kind == CarpetX::StageKind::fractional;
+                      }),
+          "fractional stages were not distinguished");
+  require(std::any_of(preparer.points.begin(), preparer.points.end(),
+                      [](const auto &point) {
+                        return point.kind == CarpetX::StageKind::endpoint_probe;
+                      }),
+          "endpoint probe was not distinguished");
+}
+
+} // namespace
+
+int main() {
+  test_fingerprints_capabilities_and_registry();
+  for (const auto &expected : expectations) {
+    test_collection_and_interval(expected);
+    test_collector_failure_rollback(expected);
+    test_observed_orders(expected);
+  }
+  test_three_level_auxiliary_dense_prepares_l0_fill_before_l1_rhs();
+  require(TestState::live_count == 0, "test states leaked at process exit");
+  require(TestDenseState::live_count == 0,
+          "dense test states leaked at process exit");
+  std::cout << "Explicit RK dense provider tests passed\n";
+  return 0;
+}

--- a/ODESolvers/test/explicit_rk_unit.cxx
+++ b/ODESolvers/test/explicit_rk_unit.cxx
@@ -1,0 +1,853 @@
+#include "explicit_rk.hxx"
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <new>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace allocation_probe {
+inline bool enabled{false};
+inline std::size_t count{0};
+}
+
+void *operator new(const std::size_t size) {
+  if (allocation_probe::enabled)
+    ++allocation_probe::count;
+  if (void *const memory = std::malloc(size))
+    return memory;
+  throw std::bad_alloc();
+}
+
+void *operator new[](const std::size_t size) { return ::operator new(size); }
+void operator delete(void *const memory) noexcept { std::free(memory); }
+void operator delete[](void *const memory) noexcept { std::free(memory); }
+void operator delete(void *const memory, std::size_t) noexcept {
+  std::free(memory);
+}
+void operator delete[](void *const memory, std::size_t) noexcept {
+  std::free(memory);
+}
+
+namespace {
+
+using ODESolvers::ExplicitRKMethod;
+using ODESolvers::ExplicitRKTableau;
+using ODESolvers::InitialRHSMode;
+using ODESolvers::LoadedRHSProvenance;
+
+std::uint64_t bits(const double value) {
+  std::uint64_t result = 0;
+  static_assert(sizeof result == sizeof value);
+  std::memcpy(&result, &value, sizeof result);
+  return result;
+}
+
+std::string encoded(const double value) {
+  std::ostringstream stream;
+  stream << std::hex << bits(value);
+  return stream.str();
+}
+
+struct VectorState {
+  std::vector<double> values;
+  int identity{-1};
+};
+
+struct RecordedStagePoint {
+  int kind;
+  int stage_index;
+  int stage_count;
+  std::int64_t numerator;
+  std::int64_t denominator;
+};
+
+struct RecordingOps {
+  using scalar_type = double;
+  using state_type = VectorState;
+
+  VectorState state_value;
+  VectorState rhs_value;
+  double time{0.0};
+  int next_identity{10};
+  int rhs_calls{0};
+  int validations{0};
+  int mutations{0};
+  std::uint64_t generation{0};
+  bool loaded_rhs{false};
+  std::vector<std::string> trace;
+  std::vector<RecordedStagePoint> stage_points;
+
+  explicit RecordingOps(std::vector<double> values)
+      : state_value{std::move(values), 1},
+        rhs_value{std::vector<double>(state_value.values.size()), 2} {}
+
+  const VectorState &state() const noexcept { return state_value; }
+  const VectorState &rhs() const noexcept { return rhs_value; }
+
+  template <class StagePoint> void set_stage_point(const StagePoint &point) {
+    stage_points.push_back(
+        {static_cast<int>(point.kind), point.stage_index, point.stage_count,
+         point.parent_fraction.numerator, point.parent_fraction.denominator});
+  }
+
+  VectorState snapshot_state() {
+    trace.push_back("copy-y:" + std::to_string(next_identity));
+    return VectorState{state_value.values, next_identity++};
+  }
+
+  VectorState snapshot_rhs() {
+    trace.push_back("copy-f:" + std::to_string(next_identity));
+    return VectorState{rhs_value.values, next_identity++};
+  }
+
+  void prepare_initial(const double stage_time) {
+    ++mutations;
+    time = stage_time;
+    trace.push_back("prepare-initial:" + encoded(stage_time));
+  }
+
+  void update_state(const int update_index, const double stage_time,
+                    const double destination_scale,
+                    const ODESolvers::LinearCombinationView<double, VectorState>
+                        combination) {
+    ++mutations;
+    ++generation;
+    loaded_rhs = false;
+    std::ostringstream entry;
+    entry << "update:" << update_index << ':' << encoded(stage_time) << ':'
+          << encoded(destination_scale);
+    std::vector<double> updated(state_value.values.size(), 0.0);
+    for (std::size_t component = 0; component < updated.size(); ++component)
+      updated[component] = destination_scale * state_value.values[component];
+    for (std::size_t source = 0; source < combination.size; ++source) {
+      entry << ':' << encoded(combination.factors[source]) << '@'
+            << combination.sources[source]->identity;
+      for (std::size_t component = 0; component < updated.size(); ++component)
+        updated[component] +=
+            combination.factors[source] *
+            combination.sources[source]->values[component];
+    }
+    state_value.values = std::move(updated);
+    time = stage_time;
+    trace.push_back(entry.str());
+    trace.push_back("prepare-stage:" + encoded(stage_time));
+    trace.push_back("poststep:" + encoded(stage_time));
+  }
+
+  void update_state(const int update_index, const double stage_time,
+                    const double destination_scale,
+                    const std::vector<double> &factors,
+                    const std::vector<const VectorState *> &sources) {
+    assert(factors.size() == sources.size());
+    update_state(update_index, stage_time, destination_scale,
+                 {factors.data(), sources.data(), factors.size()});
+  }
+
+  void evaluate_rhs(const int stage_index) {
+    ++rhs_calls;
+    trace.push_back("rhs:" + std::to_string(stage_index) + ':' +
+                    encoded(time));
+    for (std::size_t component = 0; component < state_value.values.size();
+         ++component) {
+      const double y = state_value.values[component];
+      rhs_value.values[component] =
+          static_cast<double>(component + 1) * std::sin(y) +
+          0.125 * time * y * y + 0.01 * static_cast<double>(component + 1);
+    }
+  }
+
+  void validate_rhs(const int stage_index) {
+    ++validations;
+    trace.push_back("valid:" + std::to_string(stage_index));
+    for (const double value : rhs_value.values)
+      if (!std::isfinite(value))
+        throw std::runtime_error("non-finite RHS");
+  }
+
+  void accumulate_rk4(VectorState &accumulator, const double factor,
+                      const VectorState &increment) {
+    ++mutations;
+    trace.push_back("rk4-accum:" + encoded(factor) + '@' +
+                    std::to_string(increment.identity));
+    for (std::size_t component = 0; component < accumulator.values.size();
+         ++component)
+      accumulator.values[component] += factor * increment.values[component];
+  }
+
+  void preload_exact_left_rhs() {
+    const int saved_calls = rhs_calls;
+    const auto saved_trace = trace;
+    evaluate_rhs(1);
+    rhs_calls = saved_calls;
+    trace = saved_trace;
+    loaded_rhs = true;
+  }
+
+  std::uint64_t state_generation() const noexcept { return generation; }
+  LoadedRHSProvenance<double>
+  loaded_rhs_provenance(const double left_time) const {
+    if (!loaded_rhs || time != left_time)
+      throw std::logic_error("no exact loaded left RHS");
+    return {generation, left_time};
+  }
+  void validate_loaded_rhs_provenance(
+      const LoadedRHSProvenance<double> &provenance) const {
+    if (!loaded_rhs || provenance.state_generation != generation ||
+        provenance.left_time != time)
+      throw std::logic_error("loaded RHS provenance is stale");
+  }
+  void consume_loaded_rhs(
+      const LoadedRHSProvenance<double> &provenance) {
+    validate_loaded_rhs_provenance(provenance);
+    loaded_rhs = false;
+  }
+  void invalidate_loaded_rhs_generation() noexcept { ++generation; }
+};
+
+struct RecordingObserver {
+  std::vector<std::string> events;
+
+  void initial_state(const double time, const VectorState &) {
+    events.push_back("initial-state:" + encoded(time));
+  }
+  void initial_rhs(const double time, const VectorState &) {
+    events.push_back("initial-rhs:" + encoded(time));
+  }
+  void stage_rhs(const int stage, const double time, const VectorState &) {
+    events.push_back("stage-rhs:" + std::to_string(stage) + ':' +
+                     encoded(time));
+  }
+  void accepted_endpoint(const double time, const VectorState &) {
+    events.push_back("accepted:" + encoded(time));
+  }
+};
+
+struct LegacyTableau {
+  std::vector<std::vector<double>> a;
+  std::vector<double> b;
+  std::vector<double> c;
+};
+
+LegacyTableau legacy_tableau(const ExplicitRKMethod method) {
+  const auto R = [](const double n, const double d) { return n / d; };
+  if (method == ExplicitRKMethod::rkf78) {
+    return {{{},
+             {R(2, 27)},
+             {R(1, 36), R(3, 36)},
+             {R(1, 24), 0, R(3, 24)},
+             {R(20, 48), 0, R(-75, 48), R(75, 48)},
+             {R(1, 20), 0, 0, R(5, 20), R(4, 20)},
+             {R(-25, 108), 0, 0, R(125, 108), R(-260, 108), R(250, 108)},
+             {R(31, 300), 0, 0, 0, R(61, 225), R(-2, 9), R(13, 900)},
+             {2, 0, 0, R(-53, 6), R(704, 45), R(-107, 9), R(67, 90), 3},
+             {R(-91, 108), 0, 0, R(23, 108), R(-976, 135), R(311, 54),
+              R(-19, 60), R(17, 6), R(-1, 12)},
+             {R(2383, 4100), 0, 0, R(-341, 164), R(4496, 1025), R(-301, 82),
+              R(2133, 4100), R(45, 82), R(45, 164), R(18, 41)}},
+            {R(41, 840), 0, 0, 0, 0, R(34, 105), R(9, 35), R(9, 35),
+             R(9, 280), R(9, 280), R(41, 840)},
+            {0, R(2, 27), R(1, 9), R(1, 6), R(5, 12), R(1, 2), R(5, 6),
+             R(1, 6), R(2, 3), R(1, 3), 1}};
+  }
+  if (method == ExplicitRKMethod::dp87) {
+    return {{{},
+             {R(1, 18)},
+             {R(1, 48), R(1, 16)},
+             {R(1, 32), 0, R(3, 32)},
+             {R(5, 16), 0, -R(75, 64), R(75, 64)},
+             {R(3, 80), 0, 0, R(3, 16), R(3, 20)},
+             {R(29443841, 614563906), 0, 0, R(77736538, 692538347),
+              -R(28693883, 1125000000), R(23124283, 1800000000)},
+             {R(16016141, 946692911), 0, 0, R(61564180, 158732637),
+              R(22789713, 633445777), R(545815736, 2771057229),
+              -R(180193667, 1043307555)},
+             {R(39632708, 573591083), 0, 0, -R(433636366, 683701615),
+              -R(421739975, 2616292301), R(100302831, 723423059),
+              R(790204164, 839813087), R(800635310, 3783071287)},
+             {R(246121993, 1340847787), 0, 0, -R(37695042795, 15268766246),
+              -R(309121744, 1061227803), -R(12992083, 490766935),
+              R(6005943493, 2108947869), R(393006217, 1396673457),
+              R(123872331, 1001029789)},
+             {-R(1028468189, 846180014), 0, 0, R(8478235783, 508512852),
+              R(1311729495, 1432422823), -R(10304129995, 1701304382),
+              -R(48777925059, 3047939560), R(15336726248, 1032824649),
+              -R(45442868181, 3398467696), R(3065993473, 597172653)},
+             {R(185892177, 718116043), 0, 0, -R(3185094517, 667107341),
+              -R(477755414, 1098053517), -R(703635378, 230739211),
+              R(5731566787, 1027545527), R(5232866602, 850066563),
+              -R(4093664535, 808688257), R(3962137247, 1805957418),
+              R(65686358, 487910083)},
+             {R(403863854, 491063109), 0, 0, -R(5068492393, 434740067),
+              -R(411421997, 543043805), R(652783627, 914296604),
+              R(11173962825, 925320556), -R(13158990841, 6184727034),
+              R(3936647629, 1978049680), -R(160528059, 685178525),
+              R(248638103, 1413531060), 0}},
+            {R(14005451, 335480064), 0, 0, 0, 0,
+             -R(59238493, 1068277825), R(181606767, 758867731),
+             R(561292985, 797845732), -R(1041891430, 1371343529),
+             R(760417239, 1151165299), R(118820643, 751138087),
+             -R(528747749, 2220607170), R(1, 4)},
+            {}};
+  }
+  throw std::invalid_argument("legacy table requested for non-table method");
+}
+
+void legacy_advance(const ExplicitRKMethod method, const double begin,
+                    const double dt, RecordingOps &ops,
+                    RecordingObserver &observer) {
+  ops.prepare_initial(begin);
+  const auto old = ops.snapshot_state();
+  observer.initial_state(begin, ops.state());
+  auto rhs_stage = [&](const int stage, const double time) {
+    ops.evaluate_rhs(stage);
+    ops.validate_rhs(stage);
+    if (stage == 1)
+      observer.initial_rhs(time, ops.rhs());
+    observer.stage_rhs(stage, time, ops.rhs());
+  };
+  if (method == ExplicitRKMethod::rk4) {
+    rhs_stage(1, begin);
+    auto accum = ops.snapshot_rhs();
+    ops.update_state(1, begin + dt / 2, 1.0, {dt / 2}, {&accum});
+    rhs_stage(2, begin + dt / 2);
+    ops.accumulate_rk4(accum, 2.0, ops.rhs());
+    ops.update_state(2, begin + dt / 2, 0.0, {1.0, dt / 2},
+                     {&old, &ops.rhs()});
+    rhs_stage(3, begin + dt / 2);
+    ops.accumulate_rk4(accum, 2.0, ops.rhs());
+    ops.update_state(3, begin + dt, 0.0, {1.0, dt}, {&old, &ops.rhs()});
+    rhs_stage(4, begin + dt);
+    ops.update_state(4, begin + dt, 0.0, {1.0, dt / 6, dt / 6},
+                     {&old, &accum, &ops.rhs()});
+  } else {
+    const auto table = legacy_tableau(method);
+    std::vector<VectorState> stages;
+    stages.reserve(table.a.size());
+    for (std::size_t step = 0; step < table.a.size(); ++step) {
+      double c = 0.0;
+      if (method == ExplicitRKMethod::rkf78) {
+        c = table.c[step];
+      } else {
+        for (const double coefficient : table.a[step])
+          c += coefficient;
+      }
+      if (step > 0) {
+        std::vector<double> factors{1.0};
+        std::vector<const VectorState *> sources{&old};
+        for (std::size_t i = 0; i < table.a[step].size(); ++i)
+          if (table.a[step][i] != 0.0) {
+            factors.push_back(table.a[step][i] * dt);
+            sources.push_back(&stages[i]);
+          }
+        ops.update_state(static_cast<int>(step), begin + c * dt, 0.0,
+                         factors, sources);
+      }
+      rhs_stage(static_cast<int>(step + 1), begin + c * dt);
+      stages.push_back(ops.snapshot_rhs());
+    }
+    std::vector<double> factors{1.0};
+    std::vector<const VectorState *> sources{&old};
+    for (std::size_t i = 0; i < table.b.size(); ++i)
+      if (table.b[i] != 0.0) {
+        factors.push_back(table.b[i] * dt);
+        sources.push_back(&stages[i]);
+      }
+    ops.update_state(static_cast<int>(table.a.size()), begin + dt, 0.0,
+                     factors, sources);
+  }
+  observer.accepted_endpoint(begin + dt, ops.state());
+}
+
+void assert_same_bits(const std::vector<double> &left,
+                      const std::vector<double> &right) {
+  assert(left.size() == right.size());
+  for (std::size_t i = 0; i < left.size(); ++i)
+    assert(bits(left[i]) == bits(right[i]));
+}
+
+void test_matches_frozen_legacy_arithmetic_and_complete_trace() {
+  for (const auto method : {ExplicitRKMethod::rk4, ExplicitRKMethod::rkf78,
+                            ExplicitRKMethod::dp87}) {
+    for (const auto &initial : {std::vector<double>{0.1},
+                                std::vector<double>{-0.4, 0.25},
+                                std::vector<double>{0.9, -0.2, 0.03}}) {
+      RecordingOps expected(initial);
+      RecordingObserver expected_observer;
+      legacy_advance(method, 0.375, 0.0625, expected, expected_observer);
+
+      RecordingOps actual(initial);
+      RecordingObserver actual_observer;
+      ODESolvers::advance_explicit_rk(method, 0.375, 0.0625,
+                                      InitialRHSMode::calculate, actual,
+                                      actual_observer);
+
+      assert_same_bits(actual.state().values, expected.state().values);
+      assert_same_bits(actual.rhs().values, expected.rhs().values);
+      assert(actual.trace == expected.trace);
+      assert(actual_observer.events == expected_observer.events);
+    }
+  }
+}
+
+void test_stage_counts_ordering_endpoint_and_rhs_reuse() {
+  for (const auto method : {ExplicitRKMethod::rk4, ExplicitRKMethod::rkf78,
+                            ExplicitRKMethod::dp87}) {
+    const int stages = method == ExplicitRKMethod::rk4
+                           ? 4
+                           : method == ExplicitRKMethod::rkf78 ? 11 : 13;
+    RecordingOps calculated({0.2, -0.1});
+    RecordingObserver calculated_observer;
+    ODESolvers::advance_explicit_rk(method, 0.0, 0.125,
+                                    InitialRHSMode::calculate, calculated,
+                                    calculated_observer);
+    assert(calculated.rhs_calls == stages);
+    assert(calculated.validations == stages);
+    assert(calculated_observer.events.front().find("initial-state:") == 0);
+    assert(calculated_observer.events.back().find("accepted:") == 0);
+    assert(calculated_observer.events[calculated_observer.events.size() - 2]
+               .find("stage-rhs:") == 0);
+
+    RecordingOps reused({0.2, -0.1});
+    reused.prepare_initial(0.0);
+    reused.preload_exact_left_rhs();
+    auto token = ODESolvers::make_loaded_rhs_token(reused, 0.0);
+    reused.trace.clear();
+    reused.mutations = 0;
+    RecordingObserver reused_observer;
+    ODESolvers::advance_explicit_rk(method, 0.0, 0.125,
+                                    InitialRHSMode::reuse_loaded, reused,
+                                    reused_observer, token);
+    assert(reused.rhs_calls == stages - 1);
+    assert(reused.validations == stages);
+    assert_same_bits(reused.state().values, calculated.state().values);
+    assert_same_bits(reused.rhs().values, calculated.rhs().values);
+  }
+}
+
+struct ScalarState {
+  double value{0.0};
+};
+
+struct ExponentialOps {
+  using scalar_type = double;
+  using state_type = ScalarState;
+  ScalarState y;
+  ScalarState f;
+  double time{0.0};
+  int mutations{0};
+  std::uint64_t generation{0};
+
+  const ScalarState &state() const noexcept { return y; }
+  const ScalarState &rhs() const noexcept { return f; }
+  ScalarState snapshot_state() { return y; }
+  ScalarState snapshot_rhs() { return f; }
+  void prepare_initial(const double t) {
+    ++mutations;
+    time = t;
+  }
+  void update_state(const int, const double t, const double scale,
+                    const ODESolvers::LinearCombinationView<double, ScalarState>
+                        combination) {
+    ++mutations;
+    ++generation;
+    double next = scale * y.value;
+    for (std::size_t i = 0; i < combination.size; ++i)
+      next += combination.factors[i] * combination.sources[i]->value;
+    y.value = next;
+    time = t;
+  }
+  void evaluate_rhs(const int) { f.value = y.value; }
+  void validate_rhs(const int) {
+    if (!std::isfinite(f.value))
+      throw std::runtime_error("bad RHS");
+  }
+  void accumulate_rk4(ScalarState &accumulator, const double factor,
+                      const ScalarState &increment) {
+    ++mutations;
+    accumulator.value += factor * increment.value;
+  }
+  std::uint64_t state_generation() const noexcept { return generation; }
+  LoadedRHSProvenance<double>
+  loaded_rhs_provenance(const double) const {
+    throw std::logic_error("ExponentialOps has no loaded RHS");
+  }
+  void validate_loaded_rhs_provenance(
+      const LoadedRHSProvenance<double> &) const {
+    throw std::logic_error("ExponentialOps has no loaded RHS");
+  }
+  void consume_loaded_rhs(const LoadedRHSProvenance<double> &) {
+    throw std::logic_error("ExponentialOps has no loaded RHS");
+  }
+};
+
+// The ordinary calculate path must retain the original Ops contract. In
+// particular, it must not instantiate any loaded-RHS provenance API.
+struct CalculateOnlyOps {
+  using scalar_type = double;
+  using state_type = ScalarState;
+
+  ScalarState y{1.0};
+  ScalarState f{0.0};
+  double time{0.0};
+
+  const ScalarState &state() const noexcept { return y; }
+  const ScalarState &rhs() const noexcept { return f; }
+  ScalarState snapshot_state() const { return y; }
+  ScalarState snapshot_rhs() const { return f; }
+  void prepare_initial(const double t) { time = t; }
+  void update_state(const int, const double t, const double scale,
+                    const ODESolvers::LinearCombinationView<double, ScalarState>
+                        combination) {
+    double next = scale * y.value;
+    for (std::size_t i = 0; i < combination.size; ++i)
+      next += combination.factors[i] * combination.sources[i]->value;
+    y.value = next;
+    time = t;
+  }
+  void evaluate_rhs(const int) { f.value = y.value + time; }
+  void validate_rhs(const int) const {
+    if (!std::isfinite(f.value))
+      throw std::runtime_error("bad RHS");
+  }
+  void accumulate_rk4(ScalarState &accumulator, const double factor,
+                      const ScalarState &increment) const {
+    accumulator.value += factor * increment.value;
+  }
+};
+
+void test_calculate_only_ops_does_not_require_reuse_api() {
+  CalculateOnlyOps ops;
+  ODESolvers::advance_explicit_rk(ExplicitRKMethod::rk4, 0.0, 0.1,
+                                  InitialRHSMode::calculate, ops);
+  assert(std::isfinite(ops.y.value));
+}
+
+double integrate_exp(const ExplicitRKMethod method, const int steps) {
+  ExponentialOps ops{{1.0}, {0.0}, 0.0, 0, 0};
+  for (int step = 0; step < steps; ++step)
+    ODESolvers::advance_explicit_rk(
+        method, static_cast<double>(step) / steps, 1.0 / steps,
+        InitialRHSMode::calculate, ops);
+  return ops.y.value;
+}
+
+void test_observed_fixed_interval_endpoint_orders() {
+  for (const auto &item : {std::pair{ExplicitRKMethod::rk4, 4},
+                           std::pair{ExplicitRKMethod::rkf78, 7},
+                           std::pair{ExplicitRKMethod::dp87, 8}}) {
+    const double coarse = std::abs(integrate_exp(item.first, 2) - std::exp(1.0));
+    const double fine = std::abs(integrate_exp(item.first, 4) - std::exp(1.0));
+    const double observed = std::log2(coarse / fine);
+    assert(observed > static_cast<double>(item.second) - 0.65);
+  }
+}
+
+template <typename Function> void expect_failure(Function &&function);
+
+void test_reuse_loaded_requires_fresh_one_shot_provenance() {
+  {
+    RecordingOps ops({0.2});
+    expect_failure([&] {
+      ODESolvers::advance_explicit_rk(ExplicitRKMethod::rk4, 0.0, 0.1,
+                                      InitialRHSMode::reuse_loaded, ops);
+    });
+    assert(ops.mutations == 0);
+    assert(ops.rhs_calls == 0);
+  }
+  {
+    RecordingOps ops({0.2});
+    expect_failure([&] { (void)ODESolvers::make_loaded_rhs_token(ops, 0.0); });
+    assert(ops.mutations == 0);
+    assert(ops.rhs_calls == 0);
+  }
+  {
+    RecordingOps ops({0.2});
+    ops.prepare_initial(0.0);
+    ops.preload_exact_left_rhs();
+    auto token = ODESolvers::make_loaded_rhs_token(ops, 0.0);
+    ops.invalidate_loaded_rhs_generation();
+    ops.mutations = 0;
+    expect_failure([&] {
+      ODESolvers::advance_explicit_rk(ExplicitRKMethod::rk4, 0.0, 0.1,
+                                      InitialRHSMode::reuse_loaded, ops,
+                                      token);
+    });
+    assert(ops.mutations == 0);
+    assert(ops.rhs_calls == 0);
+  }
+  {
+    RecordingOps ops({0.2});
+    ops.prepare_initial(0.0);
+    ops.preload_exact_left_rhs();
+    auto token = ODESolvers::make_loaded_rhs_token(ops, 0.0);
+    ops.mutations = 0;
+    expect_failure([&] {
+      ODESolvers::advance_explicit_rk(ExplicitRKMethod::rk4, 0.125, 0.1,
+                                      InitialRHSMode::reuse_loaded, ops,
+                                      token);
+    });
+    assert(ops.mutations == 0);
+    assert(ops.rhs_calls == 0);
+  }
+  {
+    RecordingOps ops({0.2});
+    ops.prepare_initial(0.0);
+    ops.preload_exact_left_rhs();
+    auto token = ODESolvers::make_loaded_rhs_token(ops, 0.0);
+    ops.mutations = 0;
+    ODESolvers::advance_explicit_rk(ExplicitRKMethod::rk4, 0.0, 0.1,
+                                    InitialRHSMode::reuse_loaded, ops, token);
+    const int mutations = ops.mutations;
+    const int rhs_calls = ops.rhs_calls;
+    expect_failure([&] {
+      ODESolvers::advance_explicit_rk(ExplicitRKMethod::rk4, 0.0, 0.1,
+                                      InitialRHSMode::reuse_loaded, ops,
+                                      token);
+    });
+    assert(ops.mutations == mutations);
+    assert(ops.rhs_calls == rhs_calls);
+  }
+}
+
+void test_zero_kernel_owned_allocations_after_canonical_warmup() {
+  for (const auto method : {ExplicitRKMethod::rk4, ExplicitRKMethod::rkf78,
+                            ExplicitRKMethod::dp87}) {
+    ExponentialOps warmup{{1.0}, {0.0}, 0.0, 0, 0};
+    ODESolvers::advance_explicit_rk(method, 0.0, 0.1,
+                                    InitialRHSMode::calculate, warmup);
+
+    ExponentialOps measured{{1.0}, {0.0}, 0.0, 0, 0};
+    allocation_probe::count = 0;
+    allocation_probe::enabled = true;
+    ODESolvers::advance_explicit_rk(method, 0.0, 0.1,
+                                    InitialRHSMode::calculate, measured);
+    allocation_probe::enabled = false;
+    assert(allocation_probe::count == 0);
+  }
+}
+
+template <typename Function> void expect_failure(Function &&function) {
+  bool failed = false;
+  try {
+    function();
+  } catch (...) {
+    failed = true;
+  }
+  assert(failed);
+}
+
+template <typename Function>
+void expect_failure_containing(Function &&function,
+                               const std::string &expected_text) {
+  bool failed = false;
+  try {
+    function();
+  } catch (const std::exception &error) {
+    failed = true;
+    assert(std::string(error.what()).find(expected_text) != std::string::npos);
+  } catch (...) {
+    assert(false && "expected a standard exception");
+  }
+  assert(failed);
+}
+
+struct ThrowingObserver : ODESolvers::NullExplicitRKObserver {
+  void stage_rhs(const int, const double, const VectorState &) {
+    throw std::runtime_error("observer failure");
+  }
+};
+
+void test_fail_closed_before_first_mutation_and_no_retry() {
+  for (const auto bad_method : {static_cast<ExplicitRKMethod>(99)}) {
+    RecordingOps ops({0.1});
+    expect_failure([&] {
+      ODESolvers::advance_explicit_rk(bad_method, 0.0, 0.1,
+                                      InitialRHSMode::calculate, ops);
+    });
+    assert(ops.mutations == 0);
+    assert(ops.rhs_calls == 0);
+  }
+  for (const double bad_dt : {0.0,
+                              std::numeric_limits<double>::infinity(),
+                              std::numeric_limits<double>::quiet_NaN()}) {
+    RecordingOps ops({0.1});
+    expect_failure([&] {
+      ODESolvers::advance_explicit_rk(ExplicitRKMethod::rk4, 0.0, bad_dt,
+                                      InitialRHSMode::calculate, ops);
+    });
+    assert(ops.mutations == 0);
+  }
+  {
+    RecordingOps ops({0.1});
+    expect_failure([&] {
+      ODESolvers::advance_explicit_rk(
+          ExplicitRKMethod::rk4, std::numeric_limits<double>::quiet_NaN(), 0.1,
+          InitialRHSMode::calculate, ops);
+    });
+    assert(ops.mutations == 0);
+  }
+  {
+    RecordingOps ops({0.1});
+    expect_failure([&] {
+      ODESolvers::advance_explicit_rk(
+          ExplicitRKMethod::rk4, 0.0, 0.1,
+          static_cast<InitialRHSMode>(99), ops);
+    });
+    assert(ops.mutations == 0);
+  }
+  {
+    ExplicitRKTableau malformed =
+        ODESolvers::explicit_rk_tableau(ExplicitRKMethod::rkf78);
+    malformed.a[1][0].denominator = 0;
+    RecordingOps ops({0.1});
+    expect_failure([&] {
+      ODESolvers::advance_explicit_rk(malformed, 0.0, 0.1,
+                                      InitialRHSMode::calculate, ops);
+    });
+    assert(ops.mutations == 0);
+  }
+  {
+    ExplicitRKTableau malformed =
+        ODESolvers::explicit_rk_tableau(ExplicitRKMethod::rkf78);
+    malformed.a[1][0].numerator = std::numeric_limits<std::int64_t>::min();
+    RecordingOps ops({0.1});
+    expect_failure([&] {
+      ODESolvers::advance_explicit_rk(malformed, 0.0, 0.1,
+                                      InitialRHSMode::calculate, ops);
+    });
+    assert(ops.mutations == 0);
+    assert(ops.rhs_calls == 0);
+  }
+  {
+    ExplicitRKTableau equivalent_spelling =
+        ODESolvers::explicit_rk_tableau(ExplicitRKMethod::rk4);
+    equivalent_spelling.a[1][0] = {2, 4};
+    RecordingOps ops({0.1});
+    expect_failure([&] {
+      ODESolvers::advance_explicit_rk(equivalent_spelling, 0.0, 0.1,
+                                      InitialRHSMode::calculate, ops);
+    });
+    assert(ops.mutations == 0);
+    assert(ops.rhs_calls == 0);
+  }
+  {
+    ExplicitRKTableau near_overflow =
+        ODESolvers::explicit_rk_tableau(ExplicitRKMethod::rk4);
+    near_overflow.b[0] = {std::numeric_limits<std::int64_t>::max(), 2};
+    near_overflow.b[1] = {std::numeric_limits<std::int64_t>::max(), 3};
+    RecordingOps ops({0.1});
+    expect_failure_containing(
+        [&] {
+          ODESolvers::advance_explicit_rk(near_overflow, 0.0, 0.1,
+                                          InitialRHSMode::calculate, ops);
+        },
+        "overflow");
+    assert(ops.mutations == 0);
+    assert(ops.rhs_calls == 0);
+  }
+  {
+    ExplicitRKTableau derived_minimum =
+        ODESolvers::explicit_rk_tableau(ExplicitRKMethod::rk4);
+    derived_minimum.b[0] = {
+        std::numeric_limits<std::int64_t>::min() + 1, 1};
+    derived_minimum.b[1] = {-1, 1};
+    RecordingOps ops({0.1});
+    expect_failure_containing(
+        [&] {
+          ODESolvers::advance_explicit_rk(derived_minimum, 0.0, 0.1,
+                                          InitialRHSMode::calculate, ops);
+        },
+        "overflow");
+    assert(ops.mutations == 0);
+    assert(ops.rhs_calls == 0);
+  }
+  {
+    RecordingOps ops({0.1});
+    ThrowingObserver observer;
+    expect_failure([&] {
+      ODESolvers::advance_explicit_rk(ExplicitRKMethod::rk4, 0.0, 0.1,
+                                      InitialRHSMode::calculate, ops,
+                                      observer);
+    });
+    assert(ops.rhs_calls == 1);
+  }
+}
+
+void test_descriptor_shape_orders_and_exact_rational_contract() {
+  for (const auto &expected : {
+           std::pair{ExplicitRKMethod::rk4, std::pair{4, 4}},
+           std::pair{ExplicitRKMethod::rkf78, std::pair{11, 7}},
+           std::pair{ExplicitRKMethod::dp87, std::pair{13, 8}}}) {
+    const auto &table = ODESolvers::explicit_rk_tableau(expected.first);
+    assert(static_cast<int>(table.a.size()) == expected.second.first);
+    assert(static_cast<int>(table.b.size()) == expected.second.first);
+    assert(table.endpoint_order == expected.second.second);
+    ODESolvers::validate_explicit_rk_tableau(table);
+    for (const auto &row : table.a)
+      for (const auto coefficient : row)
+        assert(coefficient.denominator > 0);
+  }
+}
+
+void test_exact_primary_stage_protocol_points() {
+  struct Expected {
+    ExplicitRKMethod method;
+    std::vector<std::pair<std::int64_t, std::int64_t>> fractions;
+  };
+  const std::array<Expected, 3> expected{{
+      {ExplicitRKMethod::rk4, {{0, 1}, {1, 2}, {1, 2}, {1, 1}}},
+      {ExplicitRKMethod::rkf78,
+       {{0, 1}, {2, 27}, {1, 9}, {1, 6}, {5, 12}, {1, 2},
+        {5, 6}, {1, 6}, {2, 3}, {1, 3}, {1, 1}}},
+      {ExplicitRKMethod::dp87,
+       {{0, 1}, {1, 18}, {1, 12}, {1, 8}, {5, 16}, {3, 8},
+        {59, 400}, {93, 200}, {5490023248LL, 9719169821LL},
+        {13, 20}, {1201146811LL, 1299019798LL}, {1, 1}, {1, 1}}},
+  }};
+
+  for (const auto &entry : expected) {
+    RecordingOps ops({0.2});
+    ODESolvers::advance_explicit_rk(entry.method, 0.0, 0.125,
+                                    InitialRHSMode::calculate, ops);
+    assert(ops.stage_points.size() == entry.fractions.size() + 1);
+    for (std::size_t stage = 0; stage < entry.fractions.size(); ++stage) {
+      const auto &point = ops.stage_points[stage];
+      assert(point.kind == 0);
+      assert(point.stage_index == static_cast<int>(stage + 1));
+      assert(point.stage_count == static_cast<int>(entry.fractions.size()));
+      assert(point.numerator == entry.fractions[stage].first);
+      assert(point.denominator == entry.fractions[stage].second);
+    }
+    const auto &endpoint = ops.stage_points.back();
+    assert(endpoint.kind == 0);
+    assert(endpoint.stage_index == endpoint.stage_count);
+    assert(endpoint.numerator == 1);
+    assert(endpoint.denominator == 1);
+  }
+}
+
+} // namespace
+
+int main() {
+  test_descriptor_shape_orders_and_exact_rational_contract();
+  test_exact_primary_stage_protocol_points();
+  test_matches_frozen_legacy_arithmetic_and_complete_trace();
+  test_stage_counts_ordering_endpoint_and_rhs_reuse();
+  test_observed_fixed_interval_endpoint_orders();
+  test_calculate_only_ops_does_not_require_reuse_api();
+  test_reuse_loaded_requires_fresh_one_shot_provenance();
+  test_zero_kernel_owned_allocations_after_canonical_warmup();
+  test_fail_closed_before_first_mutation_and_no_retry();
+  std::cout << "Explicit RK kernel tests passed\n";
+  return 0;
+}

--- a/ODESolvers/test/solve_subcycling_provider_contract_unit.cxx
+++ b/ODESolvers/test/solve_subcycling_provider_contract_unit.cxx
@@ -1,0 +1,79 @@
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+void check(const bool condition, const char *const message) {
+  if (!condition)
+    throw std::runtime_error(message);
+}
+
+std::string read_file(const char *const path) {
+  std::ifstream input(path);
+  if (!input)
+    throw std::runtime_error("could not open ODESolvers solve source");
+  std::ostringstream contents;
+  contents << input.rdbuf();
+  return contents.str();
+}
+
+std::size_t require_find(const std::string &source,
+                         const std::string &needle) {
+  const auto position = source.find(needle);
+  if (position == std::string::npos)
+    throw std::runtime_error("missing active-provider contract: " + needle);
+  return position;
+}
+
+} // namespace
+
+int main(const int argc, char **const argv) {
+  const char *const source_path =
+      argc == 2 ? argv[1] : "ODESolvers/src/solve.cxx";
+  const auto source = read_file(source_path);
+
+  require_find(source, "#include \"subcycling_ode_provider_registry.hxx\"");
+  const auto active_begin =
+      require_find(source, "if (CarpetX::step_context_active()) {");
+  const auto active_end = require_find(source, "static bool did_output");
+  check(active_begin < active_end, "active preflight is not before setup");
+  const auto active_preflight =
+      source.substr(active_begin, active_end - active_begin);
+  require_find(active_preflight,
+               "require_subcycling_ode_provider(std::string_view(method))");
+  require_find(active_preflight,
+               "active_context->method != candidate.dense.method");
+  require_find(active_preflight,
+               "candidate.dense.tableau_fingerprint !=");
+  require_find(active_preflight,
+               "explicit_rk_tableau_fingerprint(candidate.method)");
+  require_find(active_preflight,
+               "candidate.dense.endpoint_order != tableau.endpoint_order");
+  require_find(active_preflight,
+               "candidate.dense.stage_count !=");
+  check(active_preflight.find("CCTK_EQUALS(method") == std::string::npos,
+        "active StepContext still manually dispatches the method string");
+
+  const auto primary_setup = require_find(source, "statecomp_t var, rhs;");
+  check(active_begin < primary_setup && active_end < primary_setup,
+        "provider validation can occur after primary-state setup");
+
+  require_find(source,
+               "ExplicitRKMethod explicit_method = ExplicitRKMethod::rk4;");
+  require_find(source, "explicit_method = active_provider->method;");
+  require_find(source,
+               "CarpetX::DenseOutputProvider provider(active_provider->dense)");
+  require_find(source, "active_provider->dense.tableau_fingerprint");
+  check(source.find("make_reference_dense_provider(explicit_method)") ==
+            std::string::npos,
+        "solve still constructs dense providers outside the registry");
+  check(source.find("explicit_rk_tableau_fingerprint(explicit_method)") ==
+            std::string::npos,
+        "solve still constructs interval fingerprints outside the registry");
+
+  std::cout << "ODESolvers active subcycling provider contract tests passed\n";
+  return 0;
+}

--- a/ODESolvers/test/solve_subcycling_provider_contract_unit.cxx
+++ b/ODESolvers/test/solve_subcycling_provider_contract_unit.cxx
@@ -36,6 +36,7 @@ int main(const int argc, char **const argv) {
   const auto source = read_file(source_path);
 
   require_find(source, "#include \"subcycling_ode_provider_registry.hxx\"");
+  require_find(source, "#include \"subcycling_group_schema_builder.hxx\"");
   const auto active_begin =
       require_find(source, "if (CarpetX::step_context_active()) {");
   const auto active_end = require_find(source, "static bool did_output");
@@ -73,6 +74,21 @@ int main(const int argc, char **const argv) {
   check(source.find("explicit_rk_tableau_fingerprint(explicit_method)") ==
             std::string::npos,
         "solve still constructs interval fingerprints outside the registry");
+
+  require_find(source,
+               "build_cactus_group_schema(carpetx_subcycling_enabled())");
+  require_find(source,
+               "group_schema.contract.ordered_group_pairs");
+  require_find(source,
+               "group_schema.contract.dependent_groups");
+  check(source.find("int groupindex(") == std::string::npos,
+        "solve still owns group-name resolution");
+  check(source.find("int get_group_rhs(") == std::string::npos,
+        "solve still owns RHS tag parsing");
+  check(source.find("get_group_dependents(") == std::string::npos,
+        "solve still owns dependent tag parsing");
+  check(source.find("Util_TableGetString") == std::string::npos,
+        "solve still reads CCTK group tags directly");
 
   std::cout << "ODESolvers active subcycling provider contract tests passed\n";
   return 0;

--- a/ODESolvers/test/subcycling_group_schema_builder_unit.cxx
+++ b/ODESolvers/test/subcycling_group_schema_builder_unit.cxx
@@ -1,0 +1,193 @@
+#include "subcycling_group_schema_builder.hxx"
+
+#include <cassert>
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using ODESolvers::GroupSchemaCatalog;
+using ODESolvers::GroupSchemaGroupType;
+
+template <class Exception, class Function>
+void require_throws(Function &&function) {
+  bool threw = false;
+  try {
+    std::forward<Function>(function)();
+  } catch (const Exception &) {
+    threw = true;
+  }
+  assert(threw);
+}
+
+struct FakeGroup {
+  GroupSchemaGroupType type{GroupSchemaGroupType::grid_function};
+  int numvars{1};
+  std::string full_name;
+  std::optional<std::string> rhs;
+  std::optional<std::string> dependents;
+};
+
+class FakeCatalog final : public GroupSchemaCatalog {
+public:
+  mutable int calls{0};
+  std::vector<FakeGroup> groups;
+  std::map<std::pair<int, std::string>, int> resolutions;
+
+  int group_count() const override {
+    ++calls;
+    return static_cast<int>(groups.size());
+  }
+
+  GroupSchemaGroupType group_type(const int group) const override {
+    ++calls;
+    return groups.at(group).type;
+  }
+
+  int group_numvars(const int group) const override {
+    ++calls;
+    return groups.at(group).numvars;
+  }
+
+  std::string full_group_name(const int group) const override {
+    ++calls;
+    return groups.at(group).full_name;
+  }
+
+  std::optional<std::string>
+  group_tag(const int group, const std::string_view key) const override {
+    ++calls;
+    if (key == "rhs")
+      return groups.at(group).rhs;
+    if (key == "dependents")
+      return groups.at(group).dependents;
+    throw std::invalid_argument("unexpected fake group tag");
+  }
+
+  int resolve_group(const int owner,
+                    const std::string_view name) const override {
+    ++calls;
+    const auto found = resolutions.find({owner, std::string(name)});
+    return found == resolutions.end() ? -1 : found->second;
+  }
+};
+
+FakeCatalog valid_catalog() {
+  FakeCatalog catalog;
+  catalog.groups = {
+      {GroupSchemaGroupType::grid_function, 2, "Impl::evolved_z",
+       std::string("rhs_z"), std::string("aux_z aux_a aux_z")},
+      {GroupSchemaGroupType::grid_function, 1, "Impl::unused", std::nullopt,
+       std::nullopt},
+      {GroupSchemaGroupType::grid_function, 1, "Other::evolved_a",
+       std::string("Other::rhs_a"), std::string("Other::aux_a")},
+      {GroupSchemaGroupType::grid_function, 2, "Impl::rhs_z", std::nullopt,
+       std::nullopt},
+      {GroupSchemaGroupType::grid_function, 1, "Other::rhs_a", std::nullopt,
+       std::nullopt},
+      {GroupSchemaGroupType::grid_function, 1, "Other::aux_a", std::nullopt,
+       std::nullopt},
+      {GroupSchemaGroupType::grid_function, 1, "Impl::aux_z", std::nullopt,
+       std::nullopt},
+      {GroupSchemaGroupType::grid_function, 1, "Impl::aux_a", std::nullopt,
+       std::nullopt},
+  };
+  catalog.resolutions = {
+      {{0, "rhs_z"}, 3},       {{0, "aux_z"}, 6},
+      {{0, "aux_a"}, 7},       {{2, "Other::rhs_a"}, 4},
+      {{2, "Other::aux_a"}, 5},
+  };
+  return catalog;
+}
+
+void test_order_and_exact_dependent_closure() {
+  auto catalog = valid_catalog();
+  const auto build = ODESolvers::build_group_schema(catalog, true);
+
+  assert(build.contract.ordered_group_pairs.size() == 2);
+  assert(build.contract.ordered_group_pairs[0].evolved_group == 0);
+  assert(build.contract.ordered_group_pairs[0].rhs_group == 3);
+  assert(build.contract.ordered_group_pairs[1].evolved_group == 2);
+  assert(build.contract.ordered_group_pairs[1].rhs_group == 4);
+  assert((build.evolved_groups == std::vector<int>{0, 2}));
+  assert((build.rhs_groups == std::vector<int>{3, 4}));
+  assert((build.contract.dependent_groups ==
+          std::vector<int>{3, 4, 5, 6, 7}));
+  assert(build.evolved_variable_count == 3);
+}
+
+void test_duplicate_rhs_and_numvar_mismatch_fail_closed() {
+  {
+    auto catalog = valid_catalog();
+    catalog.groups[2].rhs = "Impl::rhs_z";
+    catalog.resolutions[{2, "Impl::rhs_z"}] = 3;
+    require_throws<std::invalid_argument>(
+        [&] { (void)ODESolvers::build_group_schema(catalog, true); });
+  }
+  {
+    auto catalog = valid_catalog();
+    catalog.groups[4].numvars = 2;
+    require_throws<std::invalid_argument>(
+        [&] { (void)ODESolvers::build_group_schema(catalog, true); });
+  }
+}
+
+void test_subcycling_requires_grid_functions() {
+  {
+    auto catalog = valid_catalog();
+    catalog.groups[0].type = GroupSchemaGroupType::scalar;
+    require_throws<std::invalid_argument>(
+        [&] { (void)ODESolvers::build_group_schema(catalog, true); });
+  }
+  {
+    auto catalog = valid_catalog();
+    catalog.groups[3].type = GroupSchemaGroupType::array;
+    require_throws<std::invalid_argument>(
+        [&] { (void)ODESolvers::build_group_schema(catalog, true); });
+  }
+  {
+    auto catalog = valid_catalog();
+    catalog.groups[6].type = GroupSchemaGroupType::scalar;
+    require_throws<std::invalid_argument>(
+        [&] { (void)ODESolvers::build_group_schema(catalog, true); });
+  }
+}
+
+void test_legacy_mode_ignores_non_gf_evolved_groups() {
+  auto catalog = valid_catalog();
+  catalog.groups.push_back({GroupSchemaGroupType::scalar, 1,
+                            "Impl::global_evolved", std::string("rhs_z"),
+                            std::string("aux_z")});
+  catalog.resolutions[{8, "rhs_z"}] = 3;
+  catalog.resolutions[{8, "aux_z"}] = 6;
+
+  const auto build = ODESolvers::build_group_schema(catalog, false);
+  assert(build.contract.ordered_group_pairs.size() == 2);
+  assert((build.evolved_groups == std::vector<int>{0, 2}));
+}
+
+void test_disabled_subcycling_is_a_complete_noop() {
+  FakeCatalog catalog;
+  catalog.groups.push_back({GroupSchemaGroupType::scalar, 1,
+                            "Impl::bad_global", std::string("missing"),
+                            std::nullopt});
+  const auto build =
+      ODESolvers::maybe_build_subcycling_group_schema(false, catalog);
+  assert(!build.has_value());
+  assert(catalog.calls == 0);
+}
+
+} // namespace
+
+int main() {
+  test_order_and_exact_dependent_closure();
+  test_duplicate_rhs_and_numvar_mismatch_fail_closed();
+  test_subcycling_requires_grid_functions();
+  test_legacy_mode_ignores_non_gf_evolved_groups();
+  test_disabled_subcycling_is_a_complete_noop();
+}

--- a/ODESolvers/test/subcycling_method_contract_handoff_unit.cxx
+++ b/ODESolvers/test/subcycling_method_contract_handoff_unit.cxx
@@ -1,0 +1,161 @@
+#include "subcycling_method_contract_registration.hxx"
+
+#include <subcycling_method_contract.hxx>
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace {
+
+void check(const bool condition, const char *const message) {
+  if (!condition)
+    throw std::runtime_error(message);
+}
+
+template <typename Exception, typename Function>
+void expect_throw(Function &&function, const char *const message) {
+  try {
+    std::forward<Function>(function)();
+  } catch (const Exception &) {
+    return;
+  }
+  throw std::runtime_error(message);
+}
+
+bool same_dense(const CarpetX::DenseCapability &left,
+                const CarpetX::DenseCapability &right) {
+  return left.method == right.method &&
+         left.tableau_fingerprint == right.tableau_fingerprint &&
+         left.endpoint_order == right.endpoint_order &&
+         left.dense_uniform_order == right.dense_uniform_order &&
+         left.stage_count == right.stage_count &&
+         left.extra_rhs_evaluations == right.extra_rhs_evaluations &&
+         left.persistent_vector_count == right.persistent_vector_count &&
+         left.arbitrary_theta == right.arbitrary_theta &&
+         left.verified == right.verified;
+}
+
+} // namespace
+
+int main() {
+  using CarpetX::SubcyclingGroupSchema;
+  using CarpetX::SubcyclingMethodContractRegistry;
+  using ODESolvers::make_subcycling_method_contract;
+  using ODESolvers::validate_subcycling_method_steering;
+
+  const auto disabled =
+      make_subcycling_method_contract(false, "legacy-unsupported-method");
+  check(!disabled.has_value(),
+        "disabled subcycling must not interpret the legacy method");
+
+  const auto enabled = make_subcycling_method_contract(true, "RK4");
+  check(enabled.has_value(), "RK4 subcycling contract was not created");
+  check(enabled->provider_id == "ODESolvers::method",
+        "contract provider identity is not stable");
+  check(enabled->parameter_value == "RK4",
+        "contract did not preserve the frozen parameter value");
+  check(enabled->dense.method == CarpetX::SubcyclingODEMethod::rk4,
+        "contract did not preserve the CarpetX method");
+  check(enabled->dense.verified && enabled->dense.arbitrary_theta,
+        "contract is not a verified arbitrary-theta dense provider");
+
+  SubcyclingMethodContractRegistry registry;
+  check(registry.empty(), "new method-contract registry is not empty");
+  expect_throw<std::out_of_range>(
+      [&] { static_cast<void>(registry.require_snapshot()); },
+      "empty registry returned a method contract");
+
+  const auto epoch = registry.register_contract(*enabled);
+  check(epoch == 1, "first method-contract registration epoch is not one");
+  check(!registry.empty(), "registered method contract was not retained");
+
+  const auto snapshot = registry.require_snapshot();
+  check(snapshot.registration_epoch == epoch,
+        "snapshot registration epoch differs from registration");
+  check(snapshot.contract.provider_id == enabled->provider_id &&
+            snapshot.contract.parameter_value == enabled->parameter_value &&
+            same_dense(snapshot.contract.dense, enabled->dense),
+        "snapshot differs from the registered contract");
+  check(!snapshot.group_schema.has_value(),
+        "method-only registration invented a group schema");
+  registry.validate_snapshot(snapshot);
+  expect_throw<std::out_of_range>(
+      [&] { static_cast<void>(registry.require_complete_snapshot()); },
+      "incomplete registry returned a transaction-ready snapshot");
+
+  const auto duplicate_epoch = registry.register_contract(*enabled);
+  check(duplicate_epoch == epoch,
+        "identical duplicate registration changed the epoch");
+
+  auto foreign_owner = *enabled;
+  foreign_owner.provider_id = "AnotherODESolver";
+  expect_throw<std::logic_error>(
+      [&] { static_cast<void>(registry.register_contract(foreign_owner)); },
+      "a second provider claimed the frozen contract");
+
+  const auto rkf78 = make_subcycling_method_contract(true, "RKF78");
+  check(rkf78.has_value(), "RKF78 subcycling contract was not created");
+  expect_throw<std::logic_error>(
+      [&] { static_cast<void>(registry.register_contract(*rkf78)); },
+      "a mismatched method replaced the frozen contract");
+
+  const SubcyclingGroupSchema schema{
+      {{3, 8}, {11, 14}},
+      {8, 14, 21},
+  };
+  const auto schema_epoch =
+      registry.register_group_schema("ODESolvers::method", schema);
+  check(schema_epoch == epoch + 1,
+        "first group-schema registration did not advance the epoch");
+  const auto complete = registry.require_complete_snapshot();
+  check(complete.registration_epoch == schema_epoch &&
+            complete.group_schema.has_value(),
+        "complete snapshot omitted the registered group schema");
+  check(complete.group_schema->ordered_group_pairs.size() == 2 &&
+            complete.group_schema->ordered_group_pairs[0].evolved_group == 3 &&
+            complete.group_schema->ordered_group_pairs[0].rhs_group == 8 &&
+            complete.group_schema->ordered_group_pairs[1].evolved_group == 11 &&
+            complete.group_schema->ordered_group_pairs[1].rhs_group == 14,
+        "complete snapshot changed ordered evolved/RHS pairs");
+  check(complete.group_schema->dependent_groups ==
+            std::vector<int>({8, 14, 21}),
+        "complete snapshot changed the sorted dependent group set");
+  check(registry.register_group_schema("ODESolvers::method", schema) ==
+            schema_epoch,
+        "identical duplicate group schema changed the epoch");
+
+  auto changed_schema = schema;
+  changed_schema.dependent_groups.push_back(34);
+  expect_throw<std::logic_error>(
+      [&] {
+        static_cast<void>(registry.register_group_schema(
+            "ODESolvers::method", changed_schema));
+      },
+      "mismatched group schema replaced the frozen schema");
+  expect_throw<std::logic_error>(
+      [&] {
+        static_cast<void>(
+            registry.register_group_schema("AnotherODESolver", schema));
+      },
+      "foreign provider registered a group schema");
+
+  validate_subcycling_method_steering(complete, "RK4");
+  expect_throw<std::logic_error>(
+      [&] { validate_subcycling_method_steering(complete, "RKF78"); },
+      "method steering changed a frozen subcycling contract");
+
+  expect_throw<std::logic_error>(
+      [&] { registry.validate_snapshot(snapshot); },
+      "registry accepted a snapshot made stale by schema registration");
+
+  auto tampered = complete;
+  tampered.contract.parameter_value = "DP87";
+  expect_throw<std::logic_error>(
+      [&] { registry.validate_snapshot(tampered); },
+      "registry accepted a modified read-only snapshot");
+
+  std::cout << "Subcycling method-contract handoff tests passed\n";
+  return 0;
+}

--- a/ODESolvers/test/subcycling_ode_provider_registry_unit.cxx
+++ b/ODESolvers/test/subcycling_ode_provider_registry_unit.cxx
@@ -1,0 +1,165 @@
+#include "subcycling_ode_provider_registry.hxx"
+
+#include <array>
+#include <cassert>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using ODESolvers::ExplicitRKAdvanceFrame;
+using ODESolvers::ExplicitRKMethod;
+using ODESolvers::ExplicitRKStageKind;
+using ODESolvers::RationalCoefficient;
+
+template <class Exception, class Function>
+void require_throws(Function &&function) {
+  bool threw = false;
+  try {
+    std::forward<Function>(function)();
+  } catch (const Exception &) {
+    threw = true;
+  }
+  assert(threw);
+}
+
+bool same_rational(const RationalCoefficient value, const std::int64_t numerator,
+                   const std::int64_t denominator) {
+  return value.numerator == numerator && value.denominator == denominator;
+}
+
+struct MethodExpectation {
+  std::string_view name;
+  ExplicitRKMethod method;
+  CarpetX::SubcyclingODEMethod dense_method;
+  int endpoint_order;
+  int dense_order;
+  std::vector<RationalCoefficient> stage_fractions;
+};
+
+const std::array<MethodExpectation, 3> expectations{{
+    {"RK4",
+     ExplicitRKMethod::rk4,
+     CarpetX::SubcyclingODEMethod::rk4,
+     4,
+     4,
+     {{0, 1}, {1, 2}, {1, 2}, {1, 1}}},
+    {"RKF78",
+     ExplicitRKMethod::rkf78,
+     CarpetX::SubcyclingODEMethod::rkf78_order7,
+     7,
+     7,
+     {{0, 1}, {2, 27}, {1, 9}, {1, 6}, {5, 12}, {1, 2},
+      {5, 6}, {1, 6}, {2, 3}, {1, 3}, {1, 1}}},
+    {"DP87",
+     ExplicitRKMethod::dp87,
+     CarpetX::SubcyclingODEMethod::dp87_order8,
+     8,
+     8,
+     {{0, 1},
+      {1, 18},
+      {1, 12},
+      {1, 8},
+      {5, 16},
+      {3, 8},
+      {59, 400},
+      {93, 200},
+      {5490023248LL, 9719169821LL},
+      {13, 20},
+      {1201146811LL, 1299019798LL},
+      {1, 1},
+      {1, 1}}},
+}};
+
+void test_registry_exposes_only_exact_supported_capabilities() {
+  const auto &registry = ODESolvers::subcycling_ode_provider_registry();
+  assert(registry.size() == expectations.size());
+
+  for (std::size_t index = 0; index < expectations.size(); ++index) {
+    const auto &expected = expectations[index];
+    const auto &entry = registry[index];
+    assert(entry.parameter_name == expected.name);
+    assert(entry.method == expected.method);
+    assert(entry.dense.method == expected.dense_method);
+    assert(entry.dense.endpoint_order == expected.endpoint_order);
+    assert(entry.dense.dense_uniform_order == expected.dense_order);
+    assert(entry.dense.stage_count ==
+           static_cast<int>(expected.stage_fractions.size()));
+    assert(entry.dense.arbitrary_theta);
+    assert(entry.dense.verified);
+    assert(entry.exact_stage_metadata != nullptr);
+    assert(entry.dense.tableau_fingerprint ==
+           ODESolvers::explicit_rk_tableau_fingerprint(expected.method));
+
+    assert(&ODESolvers::require_subcycling_ode_provider(expected.name) ==
+           &entry);
+    assert(&ODESolvers::require_subcycling_ode_provider(expected.method) ==
+           &entry);
+  }
+}
+
+void test_stage_metadata_provider_routes_every_exact_stage_without_cloning() {
+  const ExplicitRKAdvanceFrame primary{ExplicitRKStageKind::primary,
+                                       {0, 1}, {1, 1}};
+  for (const auto &expected : expectations) {
+    const auto &entry =
+        ODESolvers::require_subcycling_ode_provider(expected.method);
+    for (std::size_t stage = 0; stage < expected.stage_fractions.size();
+         ++stage) {
+      const auto point =
+          entry.exact_stage_metadata(primary, static_cast<int>(stage + 1));
+      assert(point.kind == ExplicitRKStageKind::primary);
+      assert(point.stage_index == static_cast<int>(stage + 1));
+      assert(point.stage_count ==
+             static_cast<int>(expected.stage_fractions.size()));
+      assert(point.parent_fraction.numerator ==
+             expected.stage_fractions[stage].numerator);
+      assert(point.parent_fraction.denominator ==
+             expected.stage_fractions[stage].denominator);
+    }
+
+    const ExplicitRKAdvanceFrame fractional{ExplicitRKStageKind::fractional,
+                                            {1, 4}, {1, 2}};
+    const auto first = entry.exact_stage_metadata(fractional, 1);
+    const auto last = entry.exact_stage_metadata(
+        fractional, static_cast<int>(expected.stage_fractions.size()));
+    assert(first.kind == ExplicitRKStageKind::fractional);
+    assert(same_rational(first.parent_fraction, 1, 4));
+    assert(same_rational(last.parent_fraction, 3, 4));
+  }
+}
+
+void test_unsupported_methods_and_invalid_stage_metadata_fail_closed() {
+  for (const std::string_view name : {std::string_view{},
+                                      std::string_view{"rk4"},
+                                      std::string_view{"RK45"},
+                                      std::string_view{"SSPRK3"}})
+    require_throws<std::invalid_argument>([name] {
+      (void)ODESolvers::require_subcycling_ode_provider(name);
+    });
+
+  require_throws<std::invalid_argument>([] {
+    (void)ODESolvers::require_subcycling_ode_provider(
+        static_cast<ExplicitRKMethod>(99));
+  });
+
+  const auto &entry =
+      ODESolvers::require_subcycling_ode_provider(ExplicitRKMethod::rk4);
+  const ExplicitRKAdvanceFrame primary{ExplicitRKStageKind::primary,
+                                       {0, 1}, {1, 1}};
+  require_throws<std::out_of_range>(
+      [&] { (void)entry.exact_stage_metadata(primary, 0); });
+  require_throws<std::out_of_range>([&] {
+    (void)entry.exact_stage_metadata(primary, entry.dense.stage_count + 1);
+  });
+}
+
+} // namespace
+
+int main() {
+  test_registry_exposes_only_exact_supported_capabilities();
+  test_stage_metadata_provider_routes_every_exact_stage_without_cloning();
+  test_unsupported_methods_and_invalid_stage_metadata_fail_closed();
+}

--- a/ODESolvers/test/subcycling_transaction_bridge_unit.cxx
+++ b/ODESolvers/test/subcycling_transaction_bridge_unit.cxx
@@ -1,0 +1,166 @@
+#include "subcycling_transaction_bridge.hxx"
+
+#include "subcycling_dense_output.hxx"
+#include "subcycling_dense_stencil.hxx"
+#include "subcycling_scratch_state_transaction_factory.hxx"
+
+#include <AMReX_MultiFab.H>
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace CarpetX;
+using ODESolvers::TransactionPrimaryObserver;
+using ODESolvers::TransactionStateBackend;
+
+template <typename Exception = std::exception, typename Function>
+void expect_throw(Function &&function) {
+  bool threw = false;
+  try {
+    function();
+  } catch (const Exception &) {
+    threw = true;
+  }
+  assert(threw);
+}
+
+struct Source {
+  int storage_token{0};
+  ScratchGFKey key{};
+  std::unique_ptr<amrex::MultiFab> multifab;
+  std::vector<ScratchValidity> validity;
+};
+
+Source make_source(const int group, const double value) {
+  static amrex::Arena arena(31);
+  static amrex::TestFabFactory factory(37);
+  Source source;
+  source.storage_token = group + 100;
+  source.key = ScratchGFKey{9, 0, 0, group};
+  source.multifab = std::make_unique<amrex::MultiFab>(
+      amrex::BoxArray(41), amrex::DistributionMapping(43), 1,
+      amrex::IntVect(1, 1, 1), &arena, factory);
+  source.validity = {{true, true, true}};
+  for (std::size_t region = 0; region < 3; ++region)
+    for (std::size_t cell = 0;
+         cell < amrex::MultiFab::test_cells_per_region(); ++cell)
+      source.multifab->test_set(static_cast<amrex::TestRegion>(region), 0,
+                                cell, value);
+  return source;
+}
+
+struct Fixture {
+  std::int64_t epoch{9};
+  int level_identity{101};
+  Source evolved{make_source(20, 10.0)};
+  Source rhs{make_source(21, 2.0)};
+  Source dependent{make_source(22, 50.0)};
+  std::vector<Source *> entries{&evolved, &rhs, &dependent};
+
+  ScratchLevelFrame frame() {
+    UncertifiedScratchLevelManifest manifest{9, 0, {}};
+    std::vector<ScratchGFView> views;
+    for (auto *source : entries) {
+      manifest.entries.push_back({source->key, &source->storage_token});
+      views.push_back({source->key, 0, &source->storage_token,
+                       source->multifab.get(), &source->validity});
+    }
+    return ScratchLevelFrame::copy_tl0(manifest, views);
+  }
+
+  ScratchStateTransactionFactoryMetadata metadata() {
+    ScratchStateTransactionFactoryMetadata result{
+        9,
+        1,
+        1,
+        3,
+        step_clock_t(1, 2),
+        0.5,
+        1,
+        false,
+        {{20, 21}},
+        {21, 22},
+        [this] { return epoch; },
+        {}};
+    for (auto *source : entries) {
+      result.live_entry_readers.push_back([this, source] {
+        return ScratchLiveEntrySnapshot{
+            source->key, &level_identity, source, &source->multifab,
+            &source->storage_token, &source->validity, source->multifab.get(),
+            source->validity, true,
+            [source](const amrex::MultiFab &state,
+                     const std::vector<ScratchValidity> &validity) {
+              amrex::MultiFab::Copy(*source->multifab, state, 0, 0,
+                                    state.nComp(), state.nGrowVect());
+              source->validity = validity;
+            }};
+      });
+    }
+    return result;
+  }
+};
+
+std::unique_ptr<ScratchStateTransaction> make_transaction(Fixture &fixture) {
+  return ScratchStateTransactionFactory::create_for_test(
+      fixture.frame(), fixture.metadata(),
+      [](const ScratchSchedulePhase phase, const StepContext &,
+         const ScratchStageCoordinates &) {
+        return ScratchScheduleExecutionReceipt{phase, 1, 1};
+      });
+}
+
+void test_backend_clone_arithmetic_and_owner_rejection() {
+  Fixture fixture;
+  auto transaction = make_transaction(fixture);
+  auto y = TransactionStateBackend::from_token(
+      *transaction, transaction->capture_live_evolved());
+  auto f = TransactionStateBackend::from_token(
+      *transaction, transaction->capture_live_rhs());
+
+  auto result = y.clone();
+  result.linear_combination(0.0, {{1.0, &y}, {0.5, &f}});
+  assert(result.kind() == ScratchStateKind::evolved);
+  transaction->restore_state(result.token());
+  const auto &working =
+      ScratchStateTransactionFactory::working_multifab_for_test(*transaction,
+                                                                 0);
+  assert(working.test_value(static_cast<amrex::TestRegion>(0), 0, 0) ==
+         11.0);
+
+  Fixture foreign_fixture;
+  auto foreign_transaction = make_transaction(foreign_fixture);
+  auto foreign = TransactionStateBackend::from_token(
+      *foreign_transaction, foreign_transaction->capture_live_evolved());
+  expect_throw<std::invalid_argument>(
+      [&] { result.linear_combination(0.0, {{1.0, &foreign}}); });
+}
+
+void test_primary_observer_captures_exact_transaction_states() {
+  Fixture fixture;
+  auto transaction = make_transaction(fixture);
+  TransactionPrimaryObserver observer(*transaction);
+  const int ignored = 0;
+  observer.initial_state(1.5, ignored);
+  observer.initial_rhs(1.5, ignored);
+  observer.accepted_endpoint(2.0, ignored);
+
+  auto capture = observer.take_complete();
+  assert(capture.left_state.kind() == ScratchStateKind::evolved);
+  assert(capture.left_rhs.kind() == ScratchStateKind::raw_rhs);
+  assert(capture.accepted_endpoint.kind() == ScratchStateKind::evolved);
+  expect_throw<std::logic_error>([&] { observer.take_complete(); });
+}
+
+} // namespace
+
+int main() {
+  test_backend_clone_arithmetic_and_owner_rejection();
+  test_primary_observer_captures_exact_transaction_states();
+}

--- a/TestODESolvers2/configuration.ccl
+++ b/TestODESolvers2/configuration.ccl
@@ -1,3 +1,3 @@
 # Configuration definitions for thorn TestODESolvers2
 
-REQUIRES Loop
+REQUIRES CarpetX Loop

--- a/TestODESolvers2/interface.ccl
+++ b/TestODESolvers2/interface.ccl
@@ -3,10 +3,13 @@
 IMPLEMENTS: TestODESolvers2
 
 USES INCLUDE HEADER: loop.hxx
+USES INCLUDE HEADER: subcycling_native_gate.hxx
 
-CCTK_REAL state TYPE=gf CENTERING={ccc} TAGS='rhs="rhs"' { time poly exp1 exp2 } "State"
+CCTK_REAL state TYPE=gf CENTERING={ccc} TAGS='rhs="TestODESolvers2::rhs" dependents="TestODESolvers2::gate_dependent"' { time poly exp1 exp2 } "State"
 
 CCTK_REAL rhs TYPE=gf CENTERING={ccc} TAGS='checkpoint="no"' { time_rhs poly_rhs exp1_rhs exp2_rhs } "RHS"
+
+CCTK_REAL gate_dependent TYPE=gf CENTERING={ccc} TAGS='checkpoint="no"' { time_dep poly_dep exp1_dep exp2_dep } "Native gate PostStep dependent"
 
 CCTK_REAL error TYPE=gf CENTERING={ccc} TAGS='checkpoint="no"' { time_err poly_err } "Error"
 

--- a/TestODESolvers2/param.ccl
+++ b/TestODESolvers2/param.ccl
@@ -4,3 +4,11 @@ CCTK_INT porder "Order of polynomial"
 {
   0:* :: ""
 } 2
+
+BOOLEAN native_subcycling_gate "Run the bounded CarpetX native subcycling gate"
+{
+} "no"
+
+SHARES: Cactus
+
+USES CCTK_INT cctk_itlast

--- a/TestODESolvers2/schedule.ccl
+++ b/TestODESolvers2/schedule.ccl
@@ -1,6 +1,6 @@
 # Schedule definitions for thorn TestODESolvers2
 
-STORAGE: state rhs error order
+STORAGE: state rhs gate_dependent error order
 
 
 
@@ -14,16 +14,34 @@ SCHEDULE TestODESolvers2_Initial AT initial
 SCHEDULE TestODESolvers2_RHS IN ODESolvers_RHS
 {
   LANG: C
-  READS: state(interior)
+  READS: state(interior) gate_dependent(interior)
   WRITES: rhs(interior)
 } "RHS function"
 
 SCHEDULE TestODESolvers2_Boundary IN ODESolvers_PostStep
 {
   LANG: C
-  OPTIONS: global
-  SYNC: state
+  READS: state(interior)
+  WRITES: state(everywhere) gate_dependent(interior)
 } "Apply boundary conditions to state vector"
+
+SCHEDULE TestODESolvers2_NativeGateInventory AT analysis BEFORE TestODESolvers2_Error
+{
+  LANG: C
+  OPTIONS: global
+} "Write the non-promoting native gate schedule inventory"
+
+SCHEDULE TestODESolvers2_NativeGateBegin AT evol BEFORE ODESolvers_Solve
+{
+  LANG: C
+  OPTIONS: level
+} "Open the bounded native gate transaction"
+
+SCHEDULE TestODESolvers2_NativeGateEnd AT evol AFTER ODESolvers_Solve
+{
+  LANG: C
+  OPTIONS: level
+} "Take and validate the native gate dense interval"
 
 SCHEDULE TestODESolvers2_Error AT analysis
 {

--- a/TestODESolvers2/src/odes.cxx
+++ b/TestODESolvers2/src/odes.cxx
@@ -114,9 +114,11 @@ extern "C" void TestODESolvers2_RHS(CCTK_ARGUMENTS) {
         abs(exp2_dep_(p.I) - (exp2_(p.I) + cctk_time)) > tolerance)
       CCTK_VERROR("Native gate PostStep dependent is stale at t=%.17g",
                   double(cctk_time));
+    const auto time_tolerance =
+        32 * numeric_limits<CCTK_REAL>::epsilon() *
+        max({CCTK_REAL(1), abs(cctk_time), abs(time_(p.I))});
     if (porder > 0)
-      if (abs(time_(p.I) - cctk_time) >
-          10 * numeric_limits<CCTK_REAL>::epsilon())
+      if (abs(time_(p.I) - cctk_time) > time_tolerance)
         CCTK_VERROR("Time is incorrect: time=%.17g, cctk_time=%.17g",
                     double(time_(p.I)), double(cctk_time));
     time_rhs_(p.I) = 1;

--- a/TestODESolvers2/src/odes.cxx
+++ b/TestODESolvers2/src/odes.cxx
@@ -1,15 +1,24 @@
 #include <loop.hxx>
+#include <subcycling_native_gate.hxx>
 
 #include <cctk.h>
 #include <cctk_Parameters.h>
 #include <cctk_Arguments.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <limits>
+#include <optional>
+#include <stdexcept>
+#include <string>
 
 namespace TestODESolvers2 {
 using namespace std;
+
+namespace {
+optional<CarpetX::NativeGateSession> native_gate_session;
+}
 
 #if 0
 // pos(t) = sin(omega t)
@@ -50,7 +59,30 @@ extern "C" void TestODESolvers2_Boundary(CCTK_ARGUMENTS) {
   DECLARE_CCTK_ARGUMENTS_TestODESolvers2_Boundary;
   DECLARE_CCTK_PARAMETERS;
 
-  // do nothing
+  const Loop::GF3D<CCTK_REAL, 1, 1, 1> time_(cctkGH, time);
+  const Loop::GF3D<CCTK_REAL, 1, 1, 1> poly_(cctkGH, poly);
+  const Loop::GF3D<CCTK_REAL, 1, 1, 1> exp1_(cctkGH, exp1);
+  const Loop::GF3D<CCTK_REAL, 1, 1, 1> exp2_(cctkGH, exp2);
+  const Loop::GF3D<CCTK_REAL, 1, 1, 1> time_dep_(cctkGH, time_dep);
+  const Loop::GF3D<CCTK_REAL, 1, 1, 1> poly_dep_(cctkGH, poly_dep);
+  const Loop::GF3D<CCTK_REAL, 1, 1, 1> exp1_dep_(cctkGH, exp1_dep);
+  const Loop::GF3D<CCTK_REAL, 1, 1, 1> exp2_dep_(cctkGH, exp2_dep);
+
+  const auto set_boundary_state = [&](const Loop::PointDesc &p) {
+    time_(p.I) = cctk_time;
+    poly_(p.I) = pow(1 + cctk_time, porder);
+    exp1_(p.I) = exp(cctk_time);
+    exp2_(p.I) = exp(cctk_time / 2);
+  };
+  Loop::loop_bnd<1, 1, 1>(cctkGH, set_boundary_state);
+  Loop::loop_ghosts<1, 1, 1>(cctkGH, set_boundary_state);
+
+  Loop::loop_int<1, 1, 1>(cctkGH, [&](const Loop::PointDesc &p) {
+    time_dep_(p.I) = time_(p.I) + cctk_time;
+    poly_dep_(p.I) = poly_(p.I) + cctk_time;
+    exp1_dep_(p.I) = exp1_(p.I) + cctk_time;
+    exp2_dep_(p.I) = exp2_(p.I) + cctk_time;
+  });
 }
 
 extern "C" void TestODESolvers2_RHS(CCTK_ARGUMENTS) {
@@ -58,8 +90,13 @@ extern "C" void TestODESolvers2_RHS(CCTK_ARGUMENTS) {
   DECLARE_CCTK_PARAMETERS;
 
   const Loop::GF3D<const CCTK_REAL, 1, 1, 1> time_(cctkGH, time);
+  const Loop::GF3D<const CCTK_REAL, 1, 1, 1> poly_(cctkGH, poly);
   const Loop::GF3D<const CCTK_REAL, 1, 1, 1> exp1_(cctkGH, exp1);
   const Loop::GF3D<const CCTK_REAL, 1, 1, 1> exp2_(cctkGH, exp2);
+  const Loop::GF3D<const CCTK_REAL, 1, 1, 1> time_dep_(cctkGH, time_dep);
+  const Loop::GF3D<const CCTK_REAL, 1, 1, 1> poly_dep_(cctkGH, poly_dep);
+  const Loop::GF3D<const CCTK_REAL, 1, 1, 1> exp1_dep_(cctkGH, exp1_dep);
+  const Loop::GF3D<const CCTK_REAL, 1, 1, 1> exp2_dep_(cctkGH, exp2_dep);
 
   const Loop::GF3D<CCTK_REAL, 1, 1, 1> time_rhs_(cctkGH, time_rhs);
   const Loop::GF3D<CCTK_REAL, 1, 1, 1> poly_rhs_(cctkGH, poly_rhs);
@@ -67,6 +104,16 @@ extern "C" void TestODESolvers2_RHS(CCTK_ARGUMENTS) {
   const Loop::GF3D<CCTK_REAL, 1, 1, 1> exp2_rhs_(cctkGH, exp2_rhs);
 
   Loop::loop_int<1, 1, 1>(cctkGH, [&](const Loop::PointDesc &p) {
+    const auto tolerance =
+        32 * numeric_limits<CCTK_REAL>::epsilon() *
+        max({CCTK_REAL(1), abs(cctk_time), abs(time_(p.I)),
+             abs(poly_(p.I)), abs(exp1_(p.I)), abs(exp2_(p.I))});
+    if (abs(time_dep_(p.I) - (time_(p.I) + cctk_time)) > tolerance ||
+        abs(poly_dep_(p.I) - (poly_(p.I) + cctk_time)) > tolerance ||
+        abs(exp1_dep_(p.I) - (exp1_(p.I) + cctk_time)) > tolerance ||
+        abs(exp2_dep_(p.I) - (exp2_(p.I) + cctk_time)) > tolerance)
+      CCTK_VERROR("Native gate PostStep dependent is stale at t=%.17g",
+                  double(cctk_time));
     if (porder > 0)
       if (abs(time_(p.I) - cctk_time) >
           10 * numeric_limits<CCTK_REAL>::epsilon())
@@ -77,6 +124,71 @@ extern "C" void TestODESolvers2_RHS(CCTK_ARGUMENTS) {
     exp1_rhs_(p.I) = exp1_(p.I);
     exp2_rhs_(p.I) = exp2_(p.I) / 2;
   });
+}
+
+extern "C" void TestODESolvers2_NativeGateInventory(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTS_TestODESolvers2_NativeGateInventory;
+  DECLARE_CCTK_PARAMETERS;
+  if (!native_subcycling_gate || cctk_itlast != 0)
+    return;
+  try {
+    CarpetX::write_native_gate_inventory(cctkGH, cctk_itlast);
+    CCTK_INFO("CARPETX_NATIVE_GATE_INVENTORY_PASS");
+  } catch (const exception &error) {
+    CCTK_VERROR("Native gate inventory failed: %s", error.what());
+  } catch (...) {
+    CCTK_ERROR("Native gate inventory failed with an unknown exception");
+  }
+}
+
+extern "C" void TestODESolvers2_NativeGateBegin(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTS_TestODESolvers2_NativeGateBegin;
+  DECLARE_CCTK_PARAMETERS;
+  if (!native_subcycling_gate)
+    return;
+  try {
+    if (native_gate_session.has_value())
+      throw logic_error("native gate session was opened twice");
+    const auto contract =
+        CarpetX::native_gate_method_contract(cctk_iteration);
+    const int status = CCTK_ParameterSet(
+        "method", "ODESolvers", contract.ode_parameter_value);
+    if (status != 0)
+      throw runtime_error("CCTK_ParameterSet(ODESolvers::method) returned " +
+                          to_string(status));
+    native_gate_session.emplace(
+        CarpetX::begin_native_gate(cctkGH, cctk_itlast));
+  } catch (const exception &error) {
+    native_gate_session.reset();
+    CCTK_VERROR("Native gate begin failed: %s", error.what());
+  } catch (...) {
+    native_gate_session.reset();
+    CCTK_ERROR("Native gate begin failed with an unknown exception");
+  }
+}
+
+extern "C" void TestODESolvers2_NativeGateEnd(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTS_TestODESolvers2_NativeGateEnd;
+  DECLARE_CCTK_PARAMETERS;
+  if (!native_subcycling_gate)
+    return;
+  try {
+    if (!native_gate_session.has_value())
+      throw logic_error("native gate session is absent");
+    const auto receipt =
+        CarpetX::end_native_gate(std::move(*native_gate_session));
+    native_gate_session.reset();
+    CCTK_VINFO("CARPETX_NATIVE_GATE_METHOD_PASS rhs=%zu controls=%zu",
+               receipt.extra_rhs_evaluations, receipt.control_count);
+    if (cctk_iteration == 3)
+      CCTK_INFO("CARPETX_NATIVE_GATE_PASS");
+  } catch (const exception &error) {
+    native_gate_session.reset();
+    CCTK_VERROR("Native gate end failed: %s", error.what());
+  } catch (...) {
+    native_gate_session.reset();
+    CCTK_ERROR("Native gate end failed with an unknown exception");
+  }
 }
 
 extern "C" void TestODESolvers2_Error(CCTK_ARGUMENTS) {

--- a/docs/superpowers/plans/2026-08-04-static-v1-checkpoint-recovery.md
+++ b/docs/superpowers/plans/2026-08-04-static-v1-checkpoint-recovery.md
@@ -1,0 +1,75 @@
+# Static-v1 P2 checkpoint/recovery plan
+
+## Goal
+
+Prove one bounded, strict checkpoint/recovery path for the existing CarpetX
+static two-level subcycling adapter without widening the geometry, schedule, or
+science scope validated by P1.
+
+## Global constraints
+
+- Work only in the existing detached worktree
+  `/home/cloud/ET/Cactus/scratch-subcycling-integration2-20260803`.
+- Keep one patch, two levels, factor-two spatial/time refinement,
+  `regrid_every=0`, CPU MPI 1 / OpenMP 1, and `TestODESolvers2` only.
+- A checkpoint is legal only after a completed coarse/fine synchronization.
+  Never serialize an in-flight dense interval or scratch transaction.
+- Reconstruct the integration state from the strict checkpoint endpoint:
+  root iteration `N`, root physical time `T`, exact clocks `{N,N}`, and
+  accepted-step counts `{N,2N}`. The AMR topology epoch remains process-local.
+- The recovery build and both halves of the smoke must use the same executable
+  SHA-256, ODE method, tableau fingerprint, group schema, parameter physics,
+  and grid layout.
+- Reuse the existing local Silo/HDF5 installation for the checkpoint backend;
+  do not rent a GPU or rebuild unrelated configurations.
+- Follow TDD: every production change begins with a focused failing unit test.
+- Preserve the P1 executable and artifacts unchanged.
+
+## Task 1: Recovery seed contract and adapter integration
+
+1. Add failing unit tests for a recovered synchronized seed at epoch 2 and
+   for rejection of desynchronized, malformed, or non-finite recovery state.
+2. Add a failing trace-equivalence unit test proving that an uninterrupted
+   `N -> N+1` epoch and a newly reconstructed stepper produce the same clocks,
+   accepted-step counts, physical time, and observer epoch.
+3. Implement the smallest pure recovery-seed helper and use it in static-v1
+   preflight/adapter construction. New starts retain the existing zero seed.
+4. On strict recovery, canonicalize the freshly rebuilt CarpetX level clocks
+   to the recovered root iteration only after all recoverable invariants pass.
+5. Keep dynamic regrid, general thorns, mid-step recovery, and changed method
+   contracts fail-closed.
+
+## Task 2: Incremental recovery-capable build
+
+1. Reuse the current p8d-native configuration and exact integration/flesh
+   source links used by P1.
+2. Add only the HDF5/Silo capabilities required by CarpetX checkpoint I/O,
+   reusing the already installed local Silo tree.
+3. Build incrementally, install a new immutable executable, record its hash,
+   and restore canonical source links on every exit path.
+
+## Task 3: One bounded native smoke
+
+Use RKF78 and the P1 static-v1 smoke geometry with final synchronized time
+`T=0.05`.
+
+1. Run an uninterrupted no-checkpoint reference.
+2. Run a seed case with Silo checkpoints at coarse epochs 2 and 4.
+3. Isolate the epoch-2 checkpoint, then perform strict recovery from epoch 2
+   to epoch 4 using the same executable.
+4. Require recovery receipt `(iteration=2, time=0.025)`, resumed epochs 3 and
+   4 exactly once, final `(iteration=4, time=0.05)`, `Done.`, and no hard fatal
+   or stale dependent-state error.
+5. Compare both levels' final `TestODESolvers2::state` against the
+   uninterrupted reference. Require identical topology and values within a
+   scale-aware roundoff tolerance; retain full raw TSVs and logs.
+
+## Task 4: Evidence and handoff
+
+1. Freeze pars, build/run logs, checkpoint inventory, comparison output,
+   executable/source hashes, patch, and `SHA256SUMS` under the canonical
+   Windows analysis tree.
+2. Record what is validated and explicitly exclude dynamic regrid,
+   Cottonmouth/BBH, tracker/AH/QLM, reflection-z, MPI scaling, and GPU.
+3. Obtain an independent spec/code/evidence review before declaring P2 done.
+


### PR DESCRIPTION
## Summary

This draft preserves the cumulative P0-P2 implementation of a bounded static two-level time-subcycling path for CarpetX and ODESolvers.

- add a hierarchy stepper with factor-two coarse/fine scheduling and synchronization
- add RK4, RKF78, and DP87 dense-output/provider plumbing and transactional stage preparation
- add a fail-closed static-v1 CarpetX adapter and native contract gates
- seed synchronized checkpoint recovery from recovered iteration/time metadata
- rebuild BoxInBox parameter-derived refinement globals after recovery

The branch is based on `ET_2026_05_v0` and targets the nearby `ET_2026_05` maintenance branch for review as a validated snapshot. It is intentionally a draft and is not yet a production BBH implementation.

## Recovery root cause

The first strict Silo recovery restored both evolved gridfunction levels, then failed before resumed evolution because BoxInBox parameter-derived global data is not part of the CCTK gridfunction checkpoint and `BoxInBox_Init` previously ran only on new starts.

The minimal repair schedules the existing initializer at `CCTK_POST_RECOVER_VARIABLES` with the same declared writes. It does not weaken validity checks or add generic non-gridfunction checkpoint I/O.

## Validation

Fresh focused tests on the final tree:

- `subcycling_runtime_clock_unit: PASS`
- `HierarchyStepper dense recursion tests passed`
- `subcycling_static_v1_top_adapter_unit: PASS`

Bounded native CPU Silo recovery smoke:

- reference, checkpoint seed, and strict recovery all exited 0 and ended with `Done.`
- recovery receipt: iteration 2, `t=0.025`
- resumed epochs exactly 3 and 4; final iteration 4, `t=0.05`
- 2,000 final state rows on both uninterrupted and recovered paths
- no missing, extra, or mismatched keys; maximum absolute difference `0.0`
- independent review: PASS / ACCEPT
- all 32 preserved evidence hashes verified

## Scope boundary

Validated scope is RKF78, two static factor-two levels, `regrid_every=0`, MPI rank 1/OpenMP thread 1, TestODESolvers2, and strict Silo recovery. This does not yet validate dynamic regrid, RK4/DP87 recovery, general evolution thorns, Cottonmouth/BBH, PunctureTracker, AH/QLM, reflection-z, MPI scaling, or GPU execution.

## Related upstream work

This branch overlaps conceptually and in `driver.cxx`/`schedule.cxx` with #371. Reconciliation with that work and retargeting/rebasing toward `main` should happen before this becomes a merge candidate.
