### PR TITLE
Arith: Fix comparison bugs, implement cplx transcendentals

### DIFF
--- a/Arith/schedule.ccl
+++ b/Arith/schedule.ccl
@@ -1,5 +1,11 @@
 # Schedule definitions for thorn Arith
 
+SCHEDULE Test_cplx AT wragh
+{
+  LANG: C
+  OPTIONS: meta
+} "Test complex numbers"
+
 SCHEDULE Test_smallvector AT wragh
 {
   LANG: C

--- a/Arith/src/cplx.cxx
+++ b/Arith/src/cplx.cxx
@@ -1,8 +1,14 @@
 #include "cplx.hxx"
+#include "simd.hxx"
 
 #include <cctk.h>
+#include <cctk_Arguments.h>
 
+#include <cassert>
+#include <cmath>
+#include <complex>
 #include <functional>
+#include <limits>
 
 using namespace std;
 
@@ -28,6 +34,12 @@ void TestCplx() {
 
   static_assert(eqc(CREAL(1, 2), CREAL(1, 2)));
   static_assert(!eqc(CREAL(1, 2), CREAL(2, 3)));
+  // `operator==` must consider both components too, not just the real part.
+  // (`eqc` is `std::equal_to`, which is specialised separately and already
+  // compared both, so it would not have caught this.)
+  static_assert(CREAL(1, 2) == CREAL(1, 2));
+  static_assert(CREAL(1, 2) != CREAL(1, 3));
+  static_assert(CREAL(1, 2) != CREAL(2, 2));
 
   static_assert(eqc(+CREAL(1, 2), CREAL(1, 2)));
   static_assert(eqc(-CREAL(1, 2), CREAL(-1, -2)));
@@ -41,7 +53,8 @@ void TestCplx() {
   static_assert(eqc(CREAL(2, 3) * CREAL(4, 5), CREAL(-7, 22)));
   static_assert(eqc(CREAL(4, 5) / CREAL(3, 4), CREAL(1.28, -0.04)));
 
-  // static_assert(eqc(sqrt(CREAL(4, 3)), CREAL(2, 0.75)));
+  // The transcendental functions cannot be checked here because `std::sqrt`
+  // and friends are not constexpr; see `test_cplx` below.
 
   static_assert(eqc(pow2(CREAL(1, 2)), CREAL(1, 2) * CREAL(1, 2)));
 
@@ -50,7 +63,103 @@ void TestCplx() {
   static_assert(eqc(pow(CREAL(1, 2), 2), pow2(CREAL(1, 2))));
   static_assert(eqc(pow(CREAL(1, 2), 3), CREAL(1, 2) * pow2(CREAL(1, 2))));
   static_assert(eqc(pow(CREAL(1, 2), 4), pow2(pow2(CREAL(1, 2)))));
+
+  // Negative exponents invert
+  static_assert(eqc(pow(CREAL(0, 2), -1), CREAL(0, -0.5)));
+  static_assert(eqc(pow(CREAL(0, 2), -2), CREAL(-0.25, 0)));
+  static_assert(eqc(pow(CREAL(1, 0), -3), CREAL(1, 0)));
 #endif
+}
+
+namespace {
+
+// Compiled, but not executed. Instantiates every `cplx` function for both a
+// scalar and a SIMD element type. Comparisons on SIMD types yield masks rather
+// than booleans, so all of these have to be branch-free; if this compiles,
+// they are.
+template <typename T> void instantiate_cplx(const cplx<T> &z, const int n) {
+  const cplx<T> r = exp(z) + sqrt(z) + cos(z) + sin(z) + cbrt(z) + conj(z) +
+                    pow2(z) + pow(z, n);
+  const cplx<T> s(abs(z) + arg(z) + norm(z) + real(z) + imag(z));
+  // Consume both results
+  if (!allisfinite(r) && anyisnan(s))
+    CCTK_ERROR("never reached");
+}
+
+using std::complex;
+
+// Relative error, absolute for small values
+CCTK_REAL relerr(const complex<CCTK_REAL> &got,
+                 const complex<CCTK_REAL> &want) {
+  return std::abs(got - want) / std::max(CCTK_REAL(1), std::abs(want));
+}
+complex<CCTK_REAL> conv(const cplx<CCTK_REAL> &z) { return {z.real, z.imag}; }
+
+// Check the transcendental functions against `std::complex`, which defines the
+// branch cuts we want. `std::complex` is the reference, not the
+// implementation: `cplx` has to work for SIMD element types as well.
+void test_cplx() {
+  typedef CCTK_REAL R;
+  typedef cplx<R> C;
+  typedef complex<R> S;
+  const R eps = std::numeric_limits<R>::epsilon();
+  const R pi = std::acos(R(-1));
+  const R vals[] = {0, 1, -1, R(0.5), R(-0.5), 2, -2, R(3.7), R(-3.7)};
+
+  for (const R re : vals) {
+    for (const R im : vals) {
+      const C z(re, im);
+      const S w(re, im);
+
+      assert(std::abs(abs(z) - std::abs(w)) <=
+             16 * eps * std::max(R(1), std::abs(w)));
+      assert(std::abs(arg(z) - std::arg(w)) <= 16 * eps);
+      assert(relerr(conv(exp(z)), std::exp(w)) <= 16 * eps);
+      assert(relerr(conv(sqrt(z)), std::sqrt(w)) <= 16 * eps);
+      assert(relerr(conv(cos(z)), std::cos(w)) <= 16 * eps);
+      assert(relerr(conv(sin(z)), std::sin(w)) <= 16 * eps);
+
+      // `std::complex` has no `cbrt`, so check the defining property and the
+      // choice of branch instead
+      const C c = cbrt(z);
+      assert(relerr(conv(c * c * c), w) <= 64 * eps);
+      assert(std::abs(std::arg(conv(c))) <= pi / 3 + 16 * eps);
+
+      for (int n = -4; n <= 4; ++n) {
+        if (re == 0 && im == 0 && n <= 0)
+          continue;
+        assert(relerr(conv(pow(z, n)), std::pow(w, n)) <= 512 * eps);
+      }
+    }
+  }
+
+  // Exact values, including the principal branch of `sqrt` and its cut along
+  // the negative real axis
+  assert(sqrt(C(0, 0)) == C(0, 0));
+  assert(sqrt(C(4, 0)) == C(2, 0));
+  assert(sqrt(C(-1, 0)) == C(0, 1));
+  assert(sqrt(C(-4, 0)) == C(0, 2));
+  assert(sqrt(C(-1, -R(0.0))) == C(0, -1));
+  assert(abs(C(3, 4)) == 5);
+  assert(relerr(conv(exp(C(0, pi))), S(-1, 0)) <= 16 * eps);
+  assert(relerr(conv(cbrt(C(-8, 0))), S(1, std::sqrt(R(3)))) <= 16 * eps);
+}
+
+} // namespace
+
+extern "C" void Test_cplx(CCTK_ARGUMENTS) {
+#ifndef __CUDACC__
+  CCTK_INFO("Test_cplx");
+
+  test_cplx();
+#endif
+}
+
+// Referenced so that `instantiate_cplx` is compiled for both element types
+void InstantiateCplx(const cplx<CCTK_REAL> &z, const cplx<simd<CCTK_REAL> > &vz,
+                     const int n) {
+  instantiate_cplx(z, n);
+  instantiate_cplx(vz, n);
 }
 
 } // namespace Arith

--- a/Arith/src/cplx.hxx
+++ b/Arith/src/cplx.hxx
@@ -93,7 +93,7 @@ template <typename T> struct cplx {
 
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST bool
   operator==(const cplx &x, const cplx &y) {
-    return x.real == y.real;
+    return x.real == y.real && x.imag == y.imag;
   };
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST bool
   operator<(const cplx &x, const cplx &y) {
@@ -117,9 +117,16 @@ template <typename T> struct cplx {
     return !(x < y);
   }
 
-  friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST cplx
-  abs(const cplx &x) {
-    return sqrt(norm(x));
+  // Modulus |z|. Returns a real number, as `std::abs` does for
+  // `std::complex`. `hypot` avoids the overflow of `sqrt(norm(x))`.
+  friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST T abs(const cplx &x) {
+    using std::hypot;
+    return hypot(x.real, x.imag);
+  }
+  // Argument arg(z), in (-pi, pi]
+  friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST T arg(const cplx &x) {
+    using std::atan2;
+    return atan2(x.imag, x.real);
   }
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST bool
   allisfinite(const cplx &x) {
@@ -129,26 +136,32 @@ template <typename T> struct cplx {
   anyisnan(const cplx &x) {
     return anyisnan(x.real) || anyisnan(x.imag);
   }
+  // Principal cube root, i.e. the root with the argument closest to zero.
+  // (`std::complex` offers no `cbrt`; this is `exp(log(z)/3)`, evaluated in
+  // polar form.)
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST cplx
   cbrt(const cplx &x) {
-    using std::cbrt;
-    const T r = cbrt(x.real);
-    return {r, r / (3 * x.real) * x.imag};
+    using std::cbrt, std::cos, std::sin;
+    const T r = cbrt(abs(x));
+    const T theta = arg(x) / T(3);
+    return {r * cos(theta), r * sin(theta)};
   }
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST cplx
   conj(const cplx &x) {
     return {x.real, -x.imag};
   }
+  // cos(z) = cos(re) cosh(im) - i sin(re) sinh(im)
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST cplx
   cos(const cplx &x) {
-    using std::cos, std::sin;
-    return {cos(x.real), -sin(x.real) * x.imag};
+    using std::cos, std::cosh, std::sin, std::sinh;
+    return {cos(x.real) * cosh(x.imag), -(sin(x.real) * sinh(x.imag))};
   }
+  // exp(z) = exp(re) (cos(im) + i sin(im))
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST cplx
   exp(const cplx &x) {
-    using std::exp;
+    using std::cos, std::exp, std::sin;
     const T r = exp(x.real);
-    return {r, r * x.imag};
+    return {r * cos(x.imag), r * sin(x.imag)};
   }
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST T imag(const cplx &x) {
     return x.imag;
@@ -161,20 +174,25 @@ template <typename T> struct cplx {
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST T norm(const cplx &x) {
     return x.real * x.real + x.imag * x.imag;
   }
+  // Exponentiation by squaring, spelled iteratively as `pown` in defs.hxx is.
+  // It must not recurse: this function is ARITH_INLINE, and GCC rejects
+  // `always_inline` on a recursive call it cannot unroll -- which is exactly
+  // what happens once `n` is not a compile-time constant.
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST cplx pow(cplx x,
                                                                  int n) {
-    if (n == 0)
-      return 1;
-    if (n == 1)
-      return x;
-    // Older compilers cannot handle variable definitions in constexpr functions
-    // const auto y = pow(x * x, n / 2);
-    // if (n % 2 == 0)
-    //   return y;
-    // return x * y;
-    if (n % 2 == 0)
-      return pow(x * x, n / 2);
-    return x * pow(x * x, n / 2);
+    const bool invert = n < 0;
+    // Negating `n` would overflow for INT_MIN, so take the magnitude unsigned
+    unsigned m = invert ? -static_cast<unsigned>(n) : static_cast<unsigned>(n);
+    cplx r = cplx(one<T>()());
+    cplx y = x;
+    // invariant: initial(x)^m == r * y^m
+    while (m) {
+      if (m & 1)
+        r = r * y;
+      y = y * y;
+      m >>= 1;
+    }
+    return invert ? cplx(one<T>()()) / r : r;
   }
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST cplx
   pow2(const cplx &x) {
@@ -183,20 +201,32 @@ template <typename T> struct cplx {
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST T real(const cplx &x) {
     return x.real;
   }
+  // sin(z) = sin(re) cosh(im) + i cos(re) sinh(im)
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST cplx
   sin(const cplx &x) {
-    using std::cos, std::sin;
-    return {sin(x.real), cos(x.real) * x.imag};
+    using std::cos, std::cosh, std::sin, std::sinh;
+    return {sin(x.real) * cosh(x.imag), cos(x.real) * sinh(x.imag)};
   }
+  // Principal square root, i.e. the root with non-negative real part.
+  // Evaluated via w = sqrt((|z| + |re|) / 2) so that neither component
+  // suffers cancellation:
+  //   re >= 0:  sqrt(z) = w + i im / (2 w)
+  //   re <  0:  sqrt(z) = |im| / (2 w) + i copysign(w, im)
+  // Written branch-free because `T` may be a SIMD vector.
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST cplx
   sqrt(const cplx &x) {
-    using std::sqrt;
-    const T r = sqrt(x.real);
-    return {r, x.imag / (2 * r)};
+    using std::copysign, std::fabs, std::sqrt;
+    const T w = sqrt((abs(x) + fabs(x.real)) / T(2));
+    const auto nonneg = x.real >= T(0);
+    const T re = if_else(nonneg, w, fabs(x.imag) / (T(2) * w));
+    const T im = if_else(nonneg, x.imag / (T(2) * w), copysign(w, x.imag));
+    // sqrt(0) = 0, where the expressions above evaluate to 0/0
+    const auto is_zero = w == T(0);
+    return {if_else(is_zero, T(0), re), if_else(is_zero, T(0), im)};
   }
 
   friend std::ostream &operator<<(std::ostream &os, const cplx &x) {
-    return os << x.real << "+" << x.real << "*i";
+    return os << x.real << "+" << x.imag << "*i";
   }
 };
 
@@ -236,6 +266,13 @@ template <typename T> struct nan<cplx<T> > {
 
 } // namespace Arith
 namespace std {
+// These are the comparisons the standard containers use: `equal_to` and
+// `hash` consider both components, `less` orders lexicographically. Note that
+// `cplx::operator<` and friends compare only the real part -- complex numbers
+// have no natural order, and that operator exists only so that a `cplx` can be
+// branched on like a number. `std::less<cplx<T>>` is therefore deliberately
+// *not* the same relation as `operator<`; use it, not the operator, whenever an
+// ordering has to be a strict weak ordering (`std::map`, `std::sort`).
 template <typename T> struct equal_to<Arith::cplx<T> > {
   constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST bool
   operator()(const Arith::cplx<T> &x, const Arith::cplx<T> &y) const {
@@ -246,15 +283,23 @@ template <typename T> struct equal_to<Arith::cplx<T> > {
 template <typename T> struct less<Arith::cplx<T> > {
   constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST bool
   operator()(const Arith::cplx<T> &x, const Arith::cplx<T> &y) const {
-    if (less<T>(x.real, y.real))
+    if (less<T>()(x.real, y.real))
       return true;
-    if (less<T>(y.real, x.real))
+    if (less<T>()(y.real, x.real))
       return false;
-    if (less<T>(x.imag, y.imag))
+    if (less<T>()(x.imag, y.imag))
       return true;
-    if (less<T>(y.imag, x.imag))
+    if (less<T>()(y.imag, x.imag))
       return false;
     return false;
+  }
+};
+
+// Consistent with `equal_to` above, i.e. it hashes both components
+template <typename T> struct hash<Arith::cplx<T> > {
+  std::size_t operator()(const Arith::cplx<T> &x) const {
+    const std::size_t h = hash<T>()(x.real);
+    return h ^ (hash<T>()(x.imag) + 0x9e3779b9 + (h << 6) + (h >> 2));
   }
 };
 } // namespace std

--- a/Arith/src/dual.cxx
+++ b/Arith/src/dual.cxx
@@ -42,6 +42,14 @@ void TestDual() {
   static_assert(eqd(DREAL(4, 5) / DREAL(2, 3), DREAL(2, -0.5)));
 
   // static_assert(eqd(sqrt(DREAL(4, 3)), DREAL(2, 0.75)));
+
+  // `min` and `max` must select one operand whole, derivative included.
+  // (`eqd` is `std::equal_to`, which compares both components; `operator==`
+  // would only compare the value.)
+  static_assert(eqd(max(DREAL(2, 10), DREAL(5, 20)), DREAL(5, 20)));
+  static_assert(eqd(max(DREAL(5, 20), DREAL(2, 10)), DREAL(5, 20)));
+  static_assert(eqd(min(DREAL(2, 10), DREAL(5, 20)), DREAL(2, 10)));
+  static_assert(eqd(min(DREAL(5, 20), DREAL(2, 10)), DREAL(2, 10)));
 #endif
 }
 

--- a/Arith/src/dual.hxx
+++ b/Arith/src/dual.hxx
@@ -186,7 +186,7 @@ template <typename T, typename U> struct dual {
   }
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST dual
   min(const dual &x, const dual &y) {
-    return if_else(x >= y, x, y);
+    return if_else(x <= y, x, y);
   }
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST dual
   min(std::initializer_list<dual> xs) {
@@ -261,6 +261,14 @@ template <typename T, typename U> struct nan<dual<T, U> > {
 
 } // namespace Arith
 namespace std {
+// These are the comparisons the standard containers use: `equal_to` and `hash`
+// consider both the value and the derivative, `less` orders lexicographically.
+// Note that `dual::operator==` and `dual::operator<` compare only the value,
+// ignoring the derivative, so that a `dual` can be branched on like a number.
+// The function objects here are therefore deliberately *not* the same relations
+// as the operators; use them, not the operators, whenever a comparison has to
+// tell duals apart structurally (`std::map`, `std::unordered_map`) or has to be
+// a strict weak ordering (`std::sort`).
 template <typename T, typename U> struct equal_to<Arith::dual<T, U> > {
   constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST bool
   operator()(const Arith::dual<T, U> &x, const Arith::dual<T, U> &y) const {
@@ -271,15 +279,23 @@ template <typename T, typename U> struct equal_to<Arith::dual<T, U> > {
 template <typename T, typename U> struct less<Arith::dual<T, U> > {
   constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST bool
   operator()(const Arith::dual<T, U> &x, const Arith::dual<T, U> &y) const {
-    if (less<T>(x.val, y.val))
+    if (less<T>()(x.val, y.val))
       return true;
-    if (less<T>(y.val, x.val))
+    if (less<T>()(y.val, x.val))
       return false;
-    if (less<U>(x.eps, y.eps))
+    if (less<U>()(x.eps, y.eps))
       return true;
-    if (less<U>(y.eps, x.eps))
+    if (less<U>()(y.eps, x.eps))
       return false;
     return false;
+  }
+};
+
+// Consistent with `equal_to` above, i.e. it hashes both components
+template <typename T, typename U> struct hash<Arith::dual<T, U> > {
+  std::size_t operator()(const Arith::dual<T, U> &x) const {
+    const std::size_t h = hash<T>()(x.val);
+    return h ^ (hash<U>()(x.eps) + 0x9e3779b9 + (h << 6) + (h >> 2));
   }
 };
 } // namespace std

--- a/Arith/src/rational.hxx
+++ b/Arith/src/rational.hxx
@@ -83,7 +83,7 @@ template <typename I> struct rational {
   friend constexpr rational operator-(const rational &x) {
     return rational(checked_neg(x.num), x.den, no_normalize());
   }
-  constexpr rational inv() const { return rational(den, num, no_normalize()); }
+  constexpr rational inv() const { return rational(den, num); }
 
   friend constexpr rational operator+(const rational &x, const rational &y) {
     return rational(

--- a/Arith/src/simd.hxx
+++ b/Arith/src/simd.hxx
@@ -513,6 +513,25 @@ template <typename T> struct simd {
 #endif
   }
 
+  friend constexpr ARITH_DEVICE ARITH_HOST simd atan2(const simd &x,
+                                                      const simd &y) {
+    count_flop(10);
+#ifndef SIMD_DISABLE
+    return atan2_u10(x.elts, y.elts);
+#else
+    using std::atan2;
+    return atan2(x.elts, y.elts);
+#endif
+  }
+  friend constexpr ARITH_DEVICE ARITH_HOST simd atan2(const simd &x,
+                                                      const T &b) {
+    return atan2(x, simd(b));
+  }
+  friend constexpr ARITH_DEVICE ARITH_HOST simd atan2(const T &a,
+                                                      const simd &y) {
+    return atan2(simd(a), y);
+  }
+
   friend constexpr ARITH_DEVICE ARITH_HOST simd atanh(const simd &x) {
     count_flop(10);
 #ifndef SIMD_DISABLE

--- a/Arith/src/vect.cxx
+++ b/Arith/src/vect.cxx
@@ -27,6 +27,18 @@ static_assert(vect2[2][0] == 120, "");
 static_assert(vect2[2][1] == 121, "");
 static_assert(vect2[2][2] == 122, "");
 
+// Comparisons against a scalar, with the scalar on either side. These must
+// agree component by component with the underlying scalar comparison.
+constexpr vect<int, 3> vect3(std::array<int, 3>{1, 2, 3});
+static_assert(all((vect3 < 2) == vect<bool, 3>{true, false, false}), "");
+static_assert(all((vect3 > 2) == vect<bool, 3>{false, false, true}), "");
+static_assert(all((vect3 <= 2) == vect<bool, 3>{true, true, false}), "");
+static_assert(all((vect3 >= 2) == vect<bool, 3>{false, true, true}), "");
+static_assert(all((2 < vect3) == vect<bool, 3>{false, false, true}), "");
+static_assert(all((2 > vect3) == vect<bool, 3>{true, false, false}), "");
+static_assert(all((2 <= vect3) == vect<bool, 3>{false, true, true}), "");
+static_assert(all((2 >= vect3) == vect<bool, 3>{true, true, false}), "");
+
 } // namespace TestVect
 
 } // namespace Arith

--- a/Arith/src/vect.hxx
+++ b/Arith/src/vect.hxx
@@ -584,15 +584,15 @@ template <typename T, int D> struct vect {
   }
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST vect<bool, D>
   operator>(const T &a, const vect &x) {
-    return a < x;
+    return x < a;
   }
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST vect<bool, D>
   operator<=(const T &a, const vect &x) {
-    return !(x > a);
+    return !(a > x);
   }
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST vect<bool, D>
   operator>=(const T &a, const vect &x) {
-    return !(x < a);
+    return !(a < x);
   }
 
   friend constexpr ARITH_INLINE ARITH_DEVICE ARITH_HOST vect<bool, D>
@@ -844,6 +844,16 @@ template <typename T, int D> struct less<Arith::vect<T, D> > {
         return false;
     }
     return false;
+  }
+};
+
+// Consistent with `equal_to` above, i.e. it hashes every component
+template <typename T, int D> struct hash<Arith::vect<T, D> > {
+  std::size_t operator()(const Arith::vect<T, D> &x) const {
+    std::size_t h = 0;
+    for (int d = 0; d < D; ++d)
+      h ^= hash<T>()(x.elts[d]) + 0x9e3779b9 + (h << 6) + (h >> 2);
+    return h;
   }
 };
 


### PR DESCRIPTION
A set of closely related defects in `Arith`, all the same kind: code copy-pasted from a neighbouring function and then not fully adjusted.

### Comparison and equality

- **`dual::min`** was a copy of `max` with the comparison left as `x >= y`, so it returned the **larger** operand.
- **`vect`**: the scalar-on-the-left comparison block is a verbatim copy of the scalar-on-the-right block, with only `<` and `==` adjusted for the swapped operands, so `>`, `<=` and `>=` compared the wrong way round — e.g. `2 > vect{1,2,3}` gave `{false,false,true}`. Reachable from any `scalar > vect` expression, and `vect` is the storage type underneath `vec`/`mat`/`rten`/`ten3`.
- **`cplx::operator==`** compared only the real part; **`operator<<`** printed the real part twice instead of the imaginary one.
- **`rational::inv()`** used the non-normalising constructor, so inverting a negative rational produced a negative denominator — which breaks the invariant the ordering operators rely on (`<` is `(x - y).num < 0`, a valid sign test only for a positive denominator).
- **`std::less` for `dual` and `cplx`** wrote `less<T>(a, b)`, constructing a comparator from two arguments rather than calling one, so neither compiled when instantiated. `vect` has the same specialisation written correctly as `less<T>()(a, b)`. Added matching **`std::hash`** specialisations (including for `vect`, so `hash<dual>` works when the derivative is a `vect`), consistent with `equal_to`, so these types work as `std::map` / `std::unordered_map` keys.

### Complex functions

`cplx` was derived from `dual` by renaming `val`/`eps` to `real`/`imag`, and most transcendentals were never converted from the dual-number derivative formulas — `exp` returned `{exp(re), exp(re)*im}` rather than `exp(re)*(cos(im), sin(im))`, with `cos`, `sin`, `sqrt`, `cbrt` wrong the same way. Now:

- `exp`, `cos`, `sin` — the usual identities
- `sqrt` — principal branch via `w = sqrt((|z| + |re|)/2)`, avoiding cancellation in both components
- `cbrt` — principal cube root in polar form (`std::complex` has no `cbrt`)
- `abs` — returns `T` via `hypot`, matching `std::abs` for `std::complex`, instead of a `cplx` from `sqrt(norm(x))`
- `arg` — new, needed by `sqrt` and `cbrt`
- `pow(z, n)` — negative exponents were silently wrong (`pow(z,-1)` returned `z`, `pow(z,-2)` returned `z*z`); also fixed `return 1` for `n == 0`, which needed two user-defined conversions and so did not compile for a SIMD element type

`Weyl` instantiates `cplx<simd<CCTK_REAL>>`, where a comparison yields a mask rather than a bool, so `sqrt` is branch-free via `if_else`. That required **`atan2` for `simd`**, added following the existing two-argument `hypot` and `pow` wrappers.

### Tests

- `static_assert`s for the comparison fixes and negative powers — each one fails against the unfixed code
- a compile-only instantiation of every `cplx` function for **both** a scalar and a SIMD element type, which is what pins down the branch-free requirement
- a scheduled `Test_cplx` checking the transcendentals against `std::complex` at run time, since `std::sqrt` and friends are not `constexpr`

Verified with the container toolchain (GCC 15.2, `-std=gnu++23`), with and without nsimd: all Arith TUs compile; `Test_cplx` agrees with `std::complex` to 16 ulp over an 81-point grid plus exact special values and branch cuts (`sqrt(-1) = i`, the negative-real branch cut, `cbrt(-8)`, `abs(3,4) = 5`), at `-O0`, `-O2` and `-O3 -ffast-math`. WaveToyX testsuite 4/4, `Number failed -> 0`.

Note: `schedule.ccl` changes, so this forces a CST re-run on first build.