### PR TITLE
CarpetX: Reduce over all boxes in a single kernel launch

### DIFF
--- a/CarpetX/src/reduction.cxx
+++ b/CarpetX/src/reduction.cxx
@@ -321,8 +321,6 @@ reduction<CCTK_REAL, dim> reduce(int gi, int vi, int tl) {
       const CCTK_REAL dV = prod(dx);
       const int vi1 = vi;
       const vect<int, dim> indextype1 = indextype;
-      const vect<CCTK_REAL, dim> x01 = x0;
-      const vect<CCTK_REAL, dim> dx1 = dx;
 
       // First pass: the sums and the extrema
       reduction<CCTK_REAL, dim> level_red = amrex::ParReduce(
@@ -350,7 +348,7 @@ reduction<CCTK_REAL, dim> reduce(int gi, int vi, int tl) {
               return tuple_type(reduction<CCTK_REAL, dim>());
             const CCTK_REAL W = nactive / CCTK_REAL(8);
 
-            const vect<CCTK_REAL, dim> x = x01 + ipos * dx1;
+            const vect<CCTK_REAL, dim> x = x0 + ipos * dx;
             return tuple_type(
                 reduction<CCTK_REAL, dim>(x, W * dV, vars(i, j, k, vi1)));
           });
@@ -411,7 +409,7 @@ reduction<CCTK_REAL, dim> reduce(int gi, int vi, int tl) {
           const vect<int, dim> ipos{int(idx % nx) + blo.x,
                                     int(idx / nx % ny) + blo.y,
                                     int(idx / (nx * ny)) + blo.z};
-          return x01 + ipos * dx1;
+          return x0 + ipos * dx;
         };
         level_red.minloc = decode(amrex::get<0>(locs));
         level_red.maxloc = decode(amrex::get<1>(locs));

--- a/CarpetX/src/reduction.cxx
+++ b/CarpetX/src/reduction.cxx
@@ -5,11 +5,13 @@
 
 #include <cctk_Parameters.h>
 
+#include <AMReX_Functional.H>
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_Orientation.H>
+#include <AMReX_ParReduce.H>
 
-#include <bitset>
 #include <cstdlib>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <type_traits>
@@ -80,6 +82,84 @@ MPI_Op reduction_mpi_op() {
 ////////////////////////////////////////////////////////////////////////////////
 
 namespace {
+
+// Number of active octants (out of 8) surrounding a grid point, i.e. eight
+// times the volume weight with which the point enters a reduction.
+//
+// For vertex-centred directions, points on the boundary of the valid region
+// and points at refinement boundaries are counted with a reduced weight.
+// `masked` reports whether a point is covered by a finer level.
+//
+// This is shared between the CPU and the GPU code path so that both compute
+// the same weights.
+template <typename Mask>
+CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline int
+active_octants(const vect<int, dim> &ipos, const vect<int, dim> &indextype,
+               const vect<int, dim> &imin, const vect<int, dim> &imax,
+               const Mask &masked) {
+  constexpr vect<vect<int, dim>, dim> di = {vect<int, dim>::unit(0),
+                                            vect<int, dim>::unit(1),
+                                            vect<int, dim>::unit(2)};
+  constexpr vect<vect<vect<int, dim>, dim>, 2> dirs = {-di, +di};
+
+  // The octants adjacent to each of the six faces
+  constexpr unsigned char faces[2][dim] = {
+      {0b01010101, 0b00110011, 0b00001111},
+      {0b10101010, 0b11001100, 0b11110000}};
+
+  const vect<vect<int, dim>, 2> ibnd = {imin, imax - 1};
+
+  // For vertex-centred grids, ensure that points at the outer boundary are
+  // counted with a weight of 1/2
+  unsigned char outer_active = 0b11111111;
+  for (int f = 0; f < 2; ++f)
+    for (int d = 0; d < dim; ++d)
+      if (indextype[d] == 0 && ipos[d] == ibnd[f][d])
+        outer_active &= ~faces[f][d];
+
+  // For vertex-centred grids, ensure that points at refinement boundaries are
+  // counted with a weight of 1/2
+  unsigned char inner_active;
+  if (!masked(ipos)) {
+    inner_active = 0b11111111;
+  } else {
+    inner_active = 0b00000000;
+    for (int f = 0; f < 2; ++f)
+      for (int d = 0; d < dim; ++d)
+        if (indextype[d] == 0 &&
+            !(ipos[d] != ibnd[f][d] && masked(ipos + dirs[f][d])))
+          inner_active |= faces[f][d];
+  }
+
+  assert((~outer_active & ~inner_active & 0b11111111) == 0);
+
+  const unsigned char active = outer_active & inner_active;
+  int count = 0;
+  for (int b = 0; b < 8; ++b)
+    count += (active >> b) & 1;
+  return count;
+}
+
+// Like `active_octants`, but for a grid function array on the GPU, where the
+// bounds of the valid region are not available directly: the array covers the
+// fab box, which is the valid box grown by `ng`.
+//
+// We access the bounds via `lbound`/`ubound` instead of `Array4::begin`/`end`
+// because AMReX 26.02 removes those members. `ubound` is inclusive.
+template <typename T, typename Mask>
+CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline int
+active_octants_in_fab(const amrex::Array4<const T> &restrict vars,
+                      const vect<int, dim> &ipos,
+                      const vect<int, dim> &indextype, const vect<int, dim> &ng,
+                      const Mask &masked) {
+  const amrex::Dim3 lo = amrex::lbound(vars);
+  const amrex::Dim3 hi = amrex::ubound(vars);
+  const vect<int, dim> imin{lo.x + ng[0], lo.y + ng[1], lo.z + ng[2]};
+  const vect<int, dim> imax{hi.x + 1 - ng[0], hi.y + 1 - ng[1],
+                            hi.z + 1 - ng[2]};
+  return active_octants(ipos, indextype, imin, imax, masked);
+}
+
 template <typename T>
 reduction<T, dim>
 reduce_array(const amrex::Array4<const T> &restrict vars, const int n,
@@ -88,17 +168,6 @@ reduce_array(const amrex::Array4<const T> &restrict vars, const int n,
              const vect<int, dim> &imax,
              const amrex::Array4<const int> *restrict const finemask,
              const vect<T, dim> &x0, const vect<T, dim> &dx) {
-  constexpr vect<vect<int, dim>, dim> di = {vect<int, dim>::unit(0),
-                                            vect<int, dim>::unit(1),
-                                            vect<int, dim>::unit(2)};
-  constexpr vect<vect<vect<int, dim>, dim>, 2> dirs = {-di, +di};
-
-  constexpr vect<vect<std::bitset<8>, dim>, 2> faces = {
-      {0b01010101, 0b00110011, 0b00001111},
-      {0b10101010, 0b11001100, 0b11110000}};
-
-  const vect<vect<int, dim>, 2> ibnd = {imin, imax - 1};
-
   const auto masked = [&](const vect<int, dim> &ipos) {
     return finemask && (*finemask)(ipos[0], ipos[1], ipos[2]);
   };
@@ -115,33 +184,9 @@ reduce_array(const amrex::Array4<const T> &restrict vars, const int n,
       for (int i = tmin[0]; i < tmax[0]; ++i) {
         const vect<int, dim> ipos = {i, j, k};
 
-        // For vertex-centred grids, ensure that points at the outer boundary
-        // are counted with a weight of 1/2
-        std::bitset<8> outer_active = 0b11111111;
-        for (int f = 0; f < 2; ++f)
-          for (int d = 0; d < dim; ++d)
-            if (indextype[d] == 0 && ipos[d] == ibnd[f][d])
-              outer_active &= ~faces[f][d];
-
-        // For vertex-centred grids, ensure that points at refinement boundaries
-        // are counted with a weight of 1/2
-        std::bitset<8> inner_active;
-        if (!masked(ipos)) {
-          inner_active = 0b11111111;
-        } else {
-          inner_active = 0b00000000;
-          for (int f = 0; f < 2; ++f)
-            for (int d = 0; d < dim; ++d)
-              if (indextype[d] == 0 &&
-                  !(ipos[d] != ibnd[f][d] && masked(ipos + dirs[f][d])))
-                inner_active |= faces[f][d];
-        }
-
-        assert((~outer_active & ~inner_active).none());
-
-        const std::bitset<8> active = outer_active & inner_active;
-        if (active.any()) {
-          const T W = active.count() / T(active.size());
+        const int nactive = active_octants(ipos, indextype, imin, imax, masked);
+        if (nactive > 0) {
+          const T W = nactive / T(8);
 
           const vect<T, dim> x = x0 + ipos * dx;
           redi += reduction<T, dim>(x, W * dV, vars(i, j, k, n));
@@ -197,6 +242,9 @@ reduction<CCTK_REAL, dim> reduce(int gi, int vi, int tl) {
             /*coarse value*/ 0, /* fine value */ 1));
       }
 
+#ifndef AMREX_USE_GPU
+      // CPU
+
       auto mfitinfo = amrex::MFItInfo().SetDynamic(true).EnableTiling();
       // TODO: check that multi-threading actually helps (and we are
       // not dominated by memory latency)
@@ -241,9 +289,136 @@ reduction<CCTK_REAL, dim> reduce(int gi, int vi, int tl) {
                               finemask.get(), x0, dx);
         }
 #ifdef __NVCOMPILER
-#pragma omp critical (CarpetX_reduce)
+#pragma omp critical(CarpetX_reduce)
         outer += red;
       }
+#endif
+
+#else
+      // GPU
+      //
+      // Reduce over all boxes of the level in a single kernel launch.
+      // `amrex::ParReduce` iterates over all local boxes of the `MultiFab`
+      // and passes the local box index as first argument.
+
+      using tuple_type = reduction<CCTK_REAL, dim>::tuple_type;
+
+      const amrex::IntVect nghosts = mfab.nGrowVect();
+#ifdef CCTK_DEBUG
+      // We derive the valid box from the fab box below, which requires that
+      // every fab is grown uniformly
+      for (amrex::MFIter mfi(mfab); mfi.isValid(); ++mfi)
+        assert(mfi.fabbox() == amrex::grow(mfi.validbox(), nghosts));
+#endif
+      const vect<int, dim> ng{nghosts[0], nghosts[1], nghosts[2]};
+
+      const amrex::MultiArray4<const CCTK_REAL> data_ma = mfab.const_arrays();
+      const bool have_mask = bool(finemask_imfab);
+      const amrex::MultiArray4<const int> mask_ma =
+          have_mask ? finemask_imfab->const_arrays()
+                    : amrex::MultiArray4<const int>();
+
+      const CCTK_REAL dV = prod(dx);
+      const int vi1 = vi;
+      const vect<int, dim> indextype1 = indextype;
+      const vect<CCTK_REAL, dim> x01 = x0;
+      const vect<CCTK_REAL, dim> dx1 = dx;
+
+      // First pass: the sums and the extrema
+      reduction<CCTK_REAL, dim> level_red = amrex::ParReduce(
+          amrex::TypeList<
+              amrex::ReduceOpMin, amrex::ReduceOpMax, amrex::ReduceOpSum,
+              amrex::ReduceOpSum, amrex::ReduceOpSum, amrex::ReduceOpMax,
+              amrex::ReduceOpSum, amrex::ReduceOpSum, amrex::ReduceOpSum,
+              amrex::ReduceOpSum, amrex::ReduceOpSum>{},
+          amrex::TypeList<CCTK_REAL, CCTK_REAL, CCTK_REAL, CCTK_REAL, CCTK_REAL,
+                          CCTK_REAL, CCTK_REAL, CCTK_REAL, CCTK_REAL, CCTK_REAL,
+                          CCTK_REAL>{},
+          mfab,
+          amrex::IntVect(0), // interior region, without ghosts
+          [=] CCTK_DEVICE(const int b, const int i, const int j,
+                          const int k) noexcept -> tuple_type {
+            const amrex::Array4<const CCTK_REAL> &restrict vars = data_ma[b];
+            const auto masked = [=](const vect<int, dim> &ipos) {
+              return have_mask && mask_ma[b](ipos[0], ipos[1], ipos[2]);
+            };
+
+            const vect<int, dim> ipos{i, j, k};
+            const int nactive =
+                active_octants_in_fab(vars, ipos, indextype1, ng, masked);
+            if (nactive == 0)
+              return tuple_type(reduction<CCTK_REAL, dim>());
+            const CCTK_REAL W = nactive / CCTK_REAL(8);
+
+            const vect<CCTK_REAL, dim> x = x01 + ipos * dx1;
+            return tuple_type(
+                reduction<CCTK_REAL, dim>(x, W * dV, vars(i, j, k, vi1)));
+          });
+
+      // Second pass: the locations of the extrema. AMReX's reduction
+      // operators cannot express argmin/argmax, so we reduce the smallest
+      // linear index among the points attaining the extremum, and convert
+      // that index back to a position below.
+      //
+      // The extrema are those of this patch and level; `reduction::operator+`
+      // keeps the locations belonging to the smaller minimum resp. the larger
+      // maximum when the levels, patches, and MPI processes are combined.
+      //
+      // Points attaining the extremum are not unique. Which one is found is
+      // unspecified, as it is for the CPU code path, where the order in which
+      // the OpenMP threads combine their results is unspecified as well.
+      if (level_red.vol > 0) {
+        // The index space holding all valid points of this level
+        const amrex::Box lvlbox = mfab.boxArray().minimalBox();
+        const amrex::Dim3 blo = amrex::lbound(lvlbox);
+        const amrex::Long nx = lvlbox.length(0);
+        const amrex::Long ny = lvlbox.length(1);
+        constexpr amrex::Long noindex = std::numeric_limits<amrex::Long>::max();
+
+        // If the data contain nans then no point compares equal to the
+        // extremum, and the locations remain unknown (nan)
+        const CCTK_REAL lmin = level_red.min;
+        const CCTK_REAL lmax = level_red.max;
+
+        const amrex::GpuTuple<amrex::Long, amrex::Long> locs = amrex::ParReduce(
+            amrex::TypeList<amrex::ReduceOpMin, amrex::ReduceOpMin>{},
+            amrex::TypeList<amrex::Long, amrex::Long>{}, mfab,
+            amrex::IntVect(0), // interior region, without ghosts
+            [=] CCTK_DEVICE(const int b, const int i, const int j,
+                            const int k) noexcept
+                -> amrex::GpuTuple<amrex::Long, amrex::Long> {
+              const amrex::Array4<const CCTK_REAL> &restrict vars = data_ma[b];
+              const auto masked = [=](const vect<int, dim> &ipos) {
+                return have_mask && mask_ma[b](ipos[0], ipos[1], ipos[2]);
+              };
+
+              const vect<int, dim> ipos{i, j, k};
+              const int nactive =
+                  active_octants_in_fab(vars, ipos, indextype1, ng, masked);
+              if (nactive == 0)
+                return {noindex, noindex};
+
+              const amrex::Long idx =
+                  (amrex::Long(k - blo.z) * ny + (j - blo.y)) * nx +
+                  (i - blo.x);
+              const CCTK_REAL val = vars(i, j, k, vi1);
+              return {val == lmin ? idx : noindex, val == lmax ? idx : noindex};
+            });
+
+        const auto decode = [&](const amrex::Long idx) {
+          if (idx == noindex)
+            return vect<CCTK_REAL, dim>::pure(0.0 / 0.0);
+          const vect<int, dim> ipos{int(idx % nx) + blo.x,
+                                    int(idx / nx % ny) + blo.y,
+                                    int(idx / (nx * ny)) + blo.z};
+          return x01 + ipos * dx1;
+        };
+        level_red.minloc = decode(amrex::get<0>(locs));
+        level_red.maxloc = decode(amrex::get<1>(locs));
+      }
+
+      red += level_red;
+
 #endif
     }
   }

--- a/CarpetX/src/reduction.hxx
+++ b/CarpetX/src/reduction.hxx
@@ -20,8 +20,11 @@ template <typename T, int D> struct reduction {
   T vol, maxabs, sumabs, sum2abs;
   vect<T, D> minloc, maxloc, sumloc;
 
-  // We currently omit minloc/maxloc/sumloc (TODO: fix this)
-  using tuple_type = amrex::GpuTuple<T, T, T, T, T, T, T, T>;
+  // The eight scalar reductions, plus `sumloc`. `minloc` and `maxloc` are not
+  // expressible with AMReX's reduction operators, which only support sums and
+  // extrema of arithmetic types; reduction.cxx obtains them from a second
+  // reduction pass.
+  using tuple_type = amrex::GpuTuple<T, T, T, T, T, T, T, T, T, T, T>;
   constexpr reduction(tuple_type);
   constexpr operator tuple_type() const;
 
@@ -56,12 +59,19 @@ constexpr reduction<T, D>::reduction(tuple_type tuple)
     : min(amrex::get<0>(tuple)), max(amrex::get<1>(tuple)),
       sum(amrex::get<2>(tuple)), sum2(amrex::get<3>(tuple)),
       vol(amrex::get<4>(tuple)), maxabs(amrex::get<5>(tuple)),
-      sumabs(amrex::get<6>(tuple)), sum2abs(amrex::get<7>(tuple)), minloc{},
-      maxloc{}, sumloc{} {}
+      sumabs(amrex::get<6>(tuple)), sum2abs(amrex::get<7>(tuple)),
+      // `minloc` and `maxloc` are unknown here; the caller fills them in
+      minloc(vect<T, D>::pure(0.0 / 0.0)), maxloc(vect<T, D>::pure(0.0 / 0.0)),
+      sumloc{amrex::get<8>(tuple), amrex::get<9>(tuple),
+             amrex::get<10>(tuple)} {
+  static_assert(D == 3, "`tuple_type` assumes that `sumloc` has 3 components");
+}
 
 template <typename T, int D>
 constexpr reduction<T, D>::operator reduction<T, D>::tuple_type() const {
-  return tuple_type{min, max, sum, sum2, vol, maxabs, sumabs, sum2abs};
+  static_assert(D == 3, "`tuple_type` assumes that `sumloc` has 3 components");
+  return tuple_type{min,    max,     sum,       sum2,      vol,      maxabs,
+                    sumabs, sum2abs, sumloc[0], sumloc[1], sumloc[2]};
 }
 
 template <typename T, int D>

--- a/CarpetX/src/reduction.hxx
+++ b/CarpetX/src/reduction.hxx
@@ -49,6 +49,8 @@ template <typename T, int D> struct reduction {
   constexpr T norm2() const noexcept { return sqrt(sum2abs / vol); }
   constexpr T norm_inf() const noexcept { return maxabs; }
 
+  constexpr vect<T, D> com() const noexcept { return sumloc / sum; }
+
   template <typename T1, int D1>
   friend std::ostream &operator<<(std::ostream &os,
                                   const reduction<T1, D1> &red);
@@ -86,7 +88,9 @@ constexpr reduction<T, D>::reduction(const vect<T, D> &p, const T &V,
                                      const T &x)
     : min(x), max(x), sum(V * x), sum2(V * pow2(x)), vol(V), maxabs(fabs(x)),
       sumabs(V * fabs(x)), sum2abs(V * pow2(fabs(x))), minloc(p), maxloc(p),
-      sumloc(x * p) {}
+      // `sumloc` carries the volume element, as `sum` does, so that
+      // `com() == sumloc / sum` is the volume-weighted centre of mass
+      sumloc(V * x * p) {}
 
 template <typename T, int D>
 constexpr reduction<T, D>::reduction(const reduction &x, const reduction &y)
@@ -117,6 +121,7 @@ std::ostream &operator<<(std::ostream &os, const reduction<T, D> &red) {
             << "  norm1:    " << red.norm1() << "\n"
             << "  norm2:    " << red.norm2() << "\n"
             << "  norm_inf: " << red.norm_inf() << "\n"
+            << "  com:      " << red.com() << "\n"
             << "}\n";
 }
 


### PR DESCRIPTION
Reductions on GPUs currently run the CPU loop over accelerator memory, one box at a time. This adds a GPU code path to `reduce` that uses `amrex::ParReduce`, which iterates over all local boxes of a `MultiFab` in a single kernel.

### Changes

- The weights with which a point enters a reduction — halved at outer and at refinement boundaries for vertex-centred directions — are factored out of `reduce_array` into `active_octants`, shared by both code paths so they cannot drift apart. `std::bitset` becomes a plain bitmask, since `std::bitset` is not available in device code.
- `minloc`/`maxloc` are not expressible with AMReX's reduction operators, which support only sums and extrema of arithmetic types. They come from a second pass that reduces the smallest linear index among the points attaining the extremum, decoded to a position on the host. As on the CPU, where the order in which OpenMP threads combine their results is unspecified, which of several points attaining the extremum is found remains unspecified.
- `sumloc` is a plain sum and is added to `reduction::tuple_type`.
- Adds `reduction::com`, and fixes `sumloc` to carry the volume element as `sum` does — without it their quotient had units of length/volume.

### Compatibility with #390

The new code reads array bounds through `amrex::lbound`/`ubound` rather than `Array4::begin`/`end`, so it works both before and after the AMReX 26.02 API change. It does not touch the lines #390 rewrites.

### Behaviour change

`sumloc` values change by the volume element. They are written to the norm output unless `out_norm_omit_sumloc_for_backward_compatibility` is set, so the `sumloc` columns of the five `VGFWaveToyX/test/standing/norms/*.tsv` reference files are affected; the values there are at round-off level. `TestNorms` sets that parameter and is unaffected.

### Testing

A CPU `sim-debug` build succeeds with no new warnings. Note that a CPU build never compiles the new code: it is all under `#ifdef AMREX_USE_GPU`. It was instead exercised by extracting the code verbatim into a standalone program linked against AMReX, where `ParReduce`'s CPU implementation runs the same source, and comparing against the CPU path over multi-box data: 3 centerings x 2 variable indices x with/without fine mask, on a tie-free and a tie-heavy dataset. All fields agree to ~1e-13 (summation order), and `minloc`/`maxloc` agree exactly where the extremum is unique. `com` was checked against an independently computed centre of mass. The comparisons were mutation-tested to confirm they detect a wrong component index, an inverted mask, dropped weights, a wrong index encoding and a missing volume factor.

**Not verified:** device compilation (nvcc/hipcc/icpx) and performance. Worth a CI run on the accelerator configurations before merging.