### PR TITLE
CI: Get POWER from GitHub instead of NCSA GitLab

### DIFF
--- a/scripts/carpetx.th
+++ b/scripts/carpetx.th
@@ -623,7 +623,7 @@ Numerical/AEILocalInterp
 # Power -- waveform extrapolation
 !TARGET    = $ROOT/utils/Analysis
 !TYPE      = git
-!URL       = https://git.ncsa.illinois.edu/elihu/Gravitational_Waveform_Extractor.git
+!URL       = https://github.com/NCSAGravity/Gravitational_Waveform_Extractor
 !REPO_PATH = $1
 !CHECKOUT  = ./POWER
 


### PR DESCRIPTION
`git.ncsa.illinois.edu` is intermittently unreachable, and when it is, the `Download Cactus` step fails for every matrix configuration:

```
  Checking out module: ./POWER
      from repository: https://git.ncsa.illinois.edu/elihu/Gravitational_Waveform_Extractor.git
fatal: unable to access '...': Failed to connect to git.ncsa.illinois.edu port 443 after 134034 ms: Couldn't connect to server
```

`GetComponents` gives up after a 134-second timeout, and `fail-fast` then cancels the remaining jobs, so the whole run goes red without ever compiling anything. Seen on both runs of #395 that were triggered by `pull_request` (for instance runs 33102332378 and 33106050562), while the `push`-triggered runs of the same commits got through.

The Einstein Toolkit thornlist already fetches this component from GitHub — `einsteintoolkit.th` has `https://github.com/NCSAGravity/Gravitational_Waveform_Extractor.git` with the same `REPO_PATH`/`CHECKOUT` — so this only repoints the URL. The GitHub repository is active (last pushed 2026-06-08).

Note that every push currently starts two full runs, because the workflow triggers on both `push` and `pull_request` and the `concurrency` block is commented out. Sixteen concurrent jobs cloning the same servers may well be what pushes the slower ones over their timeout; enabling that block would be a separate improvement.