### PR TITLE
CI: Don't build every pull request twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,17 @@ name: CI
 
 # Control when the workflow will run
 on:
+  # Pushes to the long-lived branches. Pushes to other branches are covered by
+  # `pull_request` as soon as a pull request exists; reacting to both events
+  # there would build every pull request twice.
   push:
+    branches:
+      - main
+      - 'ET_*'
+      - 'ETX_*'
+      - 'EUET_*'
+  # Pull requests, including those from forks. Those never trigger `push` in
+  # this repository, so this is their only source of CI.
   pull_request:
   # Allow running this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The workflow reacts to both `push` and `pull_request`, so every push to a branch that has an open pull request starts **two** complete runs of the matrix — 16 jobs building the same commit. For example #395 produced runs 33106048348 (`push`) and 33106050562 (`pull_request`) for one commit.

Besides the wasted runner time, this makes the flaky external clones worse: sixteen jobs fetch the same component repositories at once, and one run timing out while its twin succeeds is exactly what happened in #396.

### Change

React to `push` only for the long-lived branches — `main` and the `ET_*` / `ETX_*` / `EUET_*` release branches — and leave everything else to `pull_request`.

Keeping `pull_request` is the part that matters: pull requests from forks never trigger `push` in this repository, so it is their only source of CI. There are three such pull requests open right now (#385, #386, #390), and dropping `pull_request` instead would leave them with no CI at all.

### Consequences

- Pushing a branch that has no pull request yet no longer builds. Use the Actions tab (`workflow_dispatch`) if that is wanted.
- Checks on a pull request now describe the merge commit that `pull_request` builds, rather than the branch tip that `push` built. That is the more useful signal — a pull request can now go red because `main` moved underneath it.

The commented-out `concurrency` block is left as it is; serialising runs is a separate question from building each commit once.