### PR TITLE
Algo: Fix the root-finding algorithms

### DIFF
--- a/Algo/src/roots.cxx
+++ b/Algo/src/roots.cxx
@@ -18,13 +18,13 @@ namespace Algo {
 using Arith::mat, Arith::vec;
 
 namespace {
+// Residuals used to check the multi-dimensional solutions. The Jacobians live
+// with their call sites: SYCL cannot call a templated function from a kernel.
 template <typename T> ALGO_DEVICE vec<T, 2> gn(vec<T, 2> x) {
   return vec<T, 2>{x(0) * x(0) - 2, x(0) * x(1) - 2};
 }
-template <typename T>
-ALGO_DEVICE std::pair<vec<T, 2>, mat<T, 2> > gnd(vec<T, 2> x) {
-  return {vec<T, 2>{x(0) * x(0) - 2, x(0) * x(1) - 2},
-          mat<T, 2>{2 * x(0), x(1), 0, x(0)}};
+template <typename T> ALGO_DEVICE vec<T, 3> gn3(vec<T, 3> x) {
+  return vec<T, 3>{x(0) * x(0) - 2, x(0) * x(1) - 2, x(1) * x(2) - 2};
 }
 } // namespace
 
@@ -44,8 +44,6 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
     const int maxiters = 100;
     int iters;
     auto [lo, hi] = bisect(fn, 1.0, 2.0, minbits, maxiters, iters);
-    // CCTK_VINFO("maxiters=%d iters=%d", maxiters, iters);
-    // CCTK_VINFO("lo=%.17g hi=%.17g", double(lo), double(hi));
     assert(iters < maxiters);
     assert(hi >= lo && hi - lo <= std::scalbn(2.0, -minbits));
     assert(fn(lo) <= 0 && fn(hi) >= 0);
@@ -58,8 +56,6 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
     int iters;
     auto [lo, hi] =
         bracket_and_solve_root(fn, 1.0, 2.0, true, minbits, maxiters, iters);
-    // CCTK_VINFO("maxiters=%d iters=%d", maxiters, iters);
-    // CCTK_VINFO("lo=%.17g hi=%.17g", double(lo), double(hi));
     assert(iters < maxiters);
     assert(hi >= lo && hi - lo <= std::scalbn(2.0, -minbits));
     assert(fn(lo) <= 0 && fn(hi) >= 0);
@@ -72,8 +68,6 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
     const int maxiters = 100;
     int iters;
     auto x = newton_raphson(fnd, 1.0, 0.0, 10.0, minbits, maxiters, iters);
-    // CCTK_VINFO("maxiters=%d iters=%d", maxiters, iters);
-    // CCTK_VINFO("lo=%.17g hi=%.17g", double(lo), double(hi));
     assert(iters < maxiters);
     CCTK_REAL delta = std::scalbn(CCTK_REAL(1), -minbits);
     assert(fn(x - delta) * fn(x + delta) < 0);
@@ -86,8 +80,6 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
     const int maxiters = 100;
     int iters;
     auto x = halley(fnd2, 1.0, 0.0, 10.0, minbits, maxiters, iters);
-    // CCTK_VINFO("maxiters=%d iters=%d", maxiters, iters);
-    // CCTK_VINFO("lo=%.17g hi=%.17g", double(lo), double(hi));
     assert(iters < maxiters);
     CCTK_REAL delta = std::scalbn(CCTK_REAL(1), -minbits);
     assert(fn(x - delta) * fn(x + delta) < 0);
@@ -100,15 +92,133 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
     const int maxiters = 100;
     int iters;
     auto x = schroder(fnd2, 1.0, 0.0, 10.0, minbits, maxiters, iters);
-    // CCTK_VINFO("maxiters=%d iters=%d", maxiters, iters);
-    // CCTK_VINFO("lo=%.17g hi=%.17g", double(lo), double(hi));
     assert(iters < maxiters);
     CCTK_REAL delta = std::scalbn(CCTK_REAL(1), -minbits);
     assert(fn(x - delta) * fn(x + delta) < 0);
+
+    // Schroder and Halley must not be the same iteration. On `x^2-2` they
+    // happen to land on the same double, so separate them on a function where
+    // the two methods genuinely take different paths.
+    auto expfn = [](CCTK_REAL x) {
+      using std::exp;
+      return std::make_tuple(exp(x) - 3, exp(x), exp(x));
+    };
+    int iters_h, iters_s;
+    auto xh = halley(expfn, 0.1, -5.0, 5.0, minbits, maxiters, iters_h);
+    auto xs = schroder(expfn, 0.1, -5.0, 5.0, minbits, maxiters, iters_s);
+    using std::abs, std::log;
+    assert(abs(xh - log(CCTK_REAL(3))) < 1.0e-9);
+    assert(abs(xs - log(CCTK_REAL(3))) < 1.0e-9);
+    assert(iters_h != iters_s);
     CCTK_VINFO("Test_schroder succeeded in %d iterations", iters);
   }
 
-  amrex::Gpu::Buffer<int> niters({0});
+  // Bracketing edge cases for `brent`. These are all cases where deciding the
+  // sign of a product, or demanding an unreachable tolerance, used to make the
+  // search fail on perfectly good input.
+  {
+    const int minbits = std::numeric_limits<CCTK_REAL>::digits - 4;
+    const int maxiters = 100;
+    const CCTK_REAL root = std::sqrt(CCTK_REAL(2));
+    int iters;
+    bool failed;
+
+    // Function values so small that their product underflows to -0, which is
+    // not less than zero. Both the initial bracket test and the in-loop one
+    // must decide the sign without multiplying.
+    auto tiny = [] ALGO_HOST ALGO_DEVICE(CCTK_REAL x) {
+      return 1.0e-200 * (x * x - 2);
+    };
+    auto [tlo, thi] = brent(tiny, 1.0, 2.0, minbits, maxiters, iters, failed);
+    assert(!failed);
+    assert(tlo <= root && root <= thi);
+
+    // `minbits == digits` asks for more precision than any two distinct
+    // doubles have; the tolerance must be clamped rather than never met.
+    auto [plo, phi] =
+        brent(fn, 1.0, 2.0, std::numeric_limits<CCTK_REAL>::digits, maxiters,
+              iters, failed);
+    assert(!failed);
+    assert(plo <= root && root <= phi);
+
+    // An interval that does not bracket a root must say so.
+    brent(fn, 2.0, 3.0, minbits, maxiters, iters, failed);
+    assert(failed);
+
+    // A root sitting exactly on an endpoint is returned as a degenerate
+    // bracket.
+    auto lin = [] ALGO_HOST ALGO_DEVICE(CCTK_REAL x) { return x - 1; };
+    auto [llo, lhi] = brent(lin, 1.0, 2.0, minbits, maxiters, iters, failed);
+    assert(!failed);
+    assert(llo == lhi && llo == 1);
+
+    CCTK_VINFO("Test_brent_edge_cases succeeded");
+  }
+
+  // Bounds, singular Jacobians and the iteration budget for the
+  // multi-dimensional solver.
+  {
+    const int minbits =
+        static_cast<int>(0.6 * std::numeric_limits<CCTK_REAL>::digits);
+    const CCTK_REAL root = std::sqrt(CCTK_REAL(2));
+    int iters;
+    bool failed;
+
+    auto g1d = [](vec<CCTK_REAL, 1> x)
+        -> std::pair<vec<CCTK_REAL, 1>, mat<CCTK_REAL, 1> > {
+      return {vec<CCTK_REAL, 1>{x(0) * x(0) - 2},
+              mat<CCTK_REAL, 1>{2 * x(0)}};
+    };
+
+    // N == 1 exercises the same code path as N == 2 and N == 3, and would read
+    // out of range if the step were summed over a hardcoded dimension.
+    using std::abs;
+    auto x1 = newton_raphson_nd(g1d, vec<CCTK_REAL, 1>{1.0},
+                                vec<CCTK_REAL, 1>{0.0},
+                                vec<CCTK_REAL, 1>{10.0}, minbits, 100, iters,
+                                failed);
+    assert(!failed);
+    assert(abs(x1(0) - root) < 1.0e-9);
+
+    // Bounds that exclude the root must be honoured, and the failure reported.
+    auto x2 = newton_raphson_nd(g1d, vec<CCTK_REAL, 1>{1.0},
+                                vec<CCTK_REAL, 1>{0.0},
+                                vec<CCTK_REAL, 1>{1.2}, minbits, 100, iters,
+                                failed);
+    assert(failed);
+    assert(x2(0) <= 1.2);
+
+    // A solution reached on the last permitted step is a success, not a
+    // failure. Four steps is exactly what this problem needs.
+    auto g2d = [](vec<CCTK_REAL, 2> x)
+        -> std::pair<vec<CCTK_REAL, 2>, mat<CCTK_REAL, 2> > {
+      return {vec<CCTK_REAL, 2>{x(0) * x(0) - 2, x(0) * x(1) - 2},
+              mat<CCTK_REAL, 2>{2 * x(0), 0, x(1), x(0)}};
+    };
+    auto x3 = newton_raphson_nd(g2d, vec<CCTK_REAL, 2>{1.0, 1.0},
+                                vec<CCTK_REAL, 2>{0.0, 0.0},
+                                vec<CCTK_REAL, 2>{10.0, 10.0}, minbits, 4,
+                                iters, failed);
+    assert(!failed);
+    assert(sumabs(gn(x3)) < 1.0e-9);
+
+    // A singular Jacobian offers no step to take; it must be reported at once
+    // rather than iterated on until the budget runs out.
+    auto gsing = [](vec<CCTK_REAL, 2> x)
+        -> std::pair<vec<CCTK_REAL, 2>, mat<CCTK_REAL, 2> > {
+      return {vec<CCTK_REAL, 2>{1.0, 1.0}, mat<CCTK_REAL, 2>{0, 0, 0, 0}};
+    };
+    newton_raphson_nd(gsing, vec<CCTK_REAL, 2>{1.0, 1.0},
+                      vec<CCTK_REAL, 2>{-10.0, -10.0},
+                      vec<CCTK_REAL, 2>{10.0, 10.0}, minbits, 100, iters,
+                      failed);
+    assert(failed);
+    assert(iters < 100);
+
+    CCTK_VINFO("Test_newton_raphson_nd_edge_cases succeeded");
+  }
+
+  amrex::Gpu::Buffer<int> niters({0, 0});
   auto *pniters = niters.data();
   const amrex::Box box(amrex::IntVect(0), amrex::IntVect(0, 0, 0));
 
@@ -121,8 +231,6 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
       bool failed;
       auto [lo, hi] = brent(fn, 1.0, 2.0, minbits, maxiters, iters, failed);
       assert(!failed);
-      // CCTK_VINFO("maxiters=%d iters=%d", maxiters, iters);
-      // CCTK_VINFO("lo=%.17g hi=%.17g", double(lo), double(hi));
       assert(iters < maxiters);
       assert(hi >= lo && hi - lo <= std::scalbn(2.0, -minbits));
       assert(fn(lo) <= 0 && fn(hi) >= 0);
@@ -145,22 +253,45 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
       // local copy
       auto gnd_CCTK_REAL = [](vec<CCTK_REAL, 2> x)
           -> std::pair<vec<CCTK_REAL, 2>, mat<CCTK_REAL, 2> > {
+        // Row-major, so this is {d0/dx0, d0/dx1, d1/dx0, d1/dx1}
         return {vec<CCTK_REAL, 2>{x(0) * x(0) - 2, x(0) * x(1) - 2},
-                mat<CCTK_REAL, 2>{2 * x(0), x(1), 0, x(0)}};
+                mat<CCTK_REAL, 2>{2 * x(0), 0, x(1), x(0)}};
       };
 
       auto x = newton_raphson_nd(gnd_CCTK_REAL, vec<CCTK_REAL, 2>{1.0, 1.0},
                                  vec<CCTK_REAL, 2>{0.0, 0.0},
                                  vec<CCTK_REAL, 2>{10.0, 10.0}, minbits,
                                  maxiters, iters, failed);
-      // CCTK_VINFO("maxiters=%d iters=%d", maxiters, iters);
-      // CCTK_VINFO("lo=%.17g hi=%.17g", double(lo), double(hi));
-      assert(iters < maxiters);
+      assert(!failed);
+      // Newton's method converges quadratically given the correct Jacobian.
+      // A transposed one still converges, but only linearly, and would need
+      // some 67 iterations to get here.
+      assert(iters <= 10);
       assert(sumabs(gn(x)) < 1.0e-9);
-      *pniters = iters;
+      pniters[0] = iters;
+
+      // The same problem in three dimensions. A step summed over a hardcoded
+      // dimension silently drops a term and gets the last component wrong.
+      auto gnd3_CCTK_REAL = [](vec<CCTK_REAL, 3> x)
+          -> std::pair<vec<CCTK_REAL, 3>, mat<CCTK_REAL, 3> > {
+        return {vec<CCTK_REAL, 3>{x(0) * x(0) - 2, x(0) * x(1) - 2,
+                                  x(1) * x(2) - 2},
+                mat<CCTK_REAL, 3>{2 * x(0), 0, 0, x(1), x(0), 0, 0, x(2),
+                                  x(1)}};
+      };
+      auto x3 = newton_raphson_nd(
+          gnd3_CCTK_REAL, vec<CCTK_REAL, 3>{1.0, 1.0, 1.0},
+          vec<CCTK_REAL, 3>{0.0, 0.0, 0.0}, vec<CCTK_REAL, 3>{10.0, 10.0, 10.0},
+          minbits, maxiters, iters, failed);
+      assert(!failed);
+      assert(iters <= 10);
+      assert(sumabs(gn3(x3)) < 1.0e-9);
+      pniters[1] = iters;
     });
     auto *hp = niters.copyToHost();
-    CCTK_VINFO("Test_newton_raphson_nd succeeded in %d iterations", *hp);
+    CCTK_VINFO("Test_newton_raphson_nd succeeded in %d iterations (2D), "
+               "%d iterations (3D)",
+               hp[0], hp[1]);
   }
 }
 

--- a/Algo/src/roots.cxx
+++ b/Algo/src/roots.cxx
@@ -118,7 +118,9 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
       const int minbits = std::numeric_limits<CCTK_REAL>::digits - 4;
       const int maxiters = 100;
       int iters;
-      auto [lo, hi] = brent(fn, 1.0, 2.0, minbits, maxiters, iters);
+      bool failed;
+      auto [lo, hi] = brent(fn, 1.0, 2.0, minbits, maxiters, iters, failed);
+      assert(!failed);
       // CCTK_VINFO("maxiters=%d iters=%d", maxiters, iters);
       // CCTK_VINFO("lo=%.17g hi=%.17g", double(lo), double(hi));
       assert(iters < maxiters);

--- a/Algo/src/roots.cxx
+++ b/Algo/src/roots.cxx
@@ -43,7 +43,9 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
     const int minbits = std::numeric_limits<CCTK_REAL>::digits - 4;
     const int maxiters = 100;
     int iters;
-    auto [lo, hi] = bisect(fn, 1.0, 2.0, minbits, maxiters, iters);
+    bool failed;
+    auto [lo, hi] = bisect(fn, 1.0, 2.0, minbits, maxiters, iters, failed);
+    assert(!failed);
     assert(iters < maxiters);
     assert(hi >= lo && hi - lo <= std::scalbn(2.0, -minbits));
     assert(fn(lo) <= 0 && fn(hi) >= 0);
@@ -54,8 +56,10 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
     const int minbits = std::numeric_limits<CCTK_REAL>::digits - 4;
     const int maxiters = 100;
     int iters;
-    auto [lo, hi] =
-        bracket_and_solve_root(fn, 1.0, 2.0, true, minbits, maxiters, iters);
+    bool failed;
+    auto [lo, hi] = bracket_and_solve_root(fn, 1.0, 2.0, true, minbits,
+                                           maxiters, iters, failed);
+    assert(!failed);
     assert(iters < maxiters);
     assert(hi >= lo && hi - lo <= std::scalbn(2.0, -minbits));
     assert(fn(lo) <= 0 && fn(hi) >= 0);
@@ -67,7 +71,10 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
         static_cast<int>(0.6 * std::numeric_limits<CCTK_REAL>::digits);
     const int maxiters = 100;
     int iters;
-    auto x = newton_raphson(fnd, 1.0, 0.0, 10.0, minbits, maxiters, iters);
+    bool failed;
+    auto x =
+        newton_raphson(fnd, 1.0, 0.0, 10.0, minbits, maxiters, iters, failed);
+    assert(!failed);
     assert(iters < maxiters);
     CCTK_REAL delta = std::scalbn(CCTK_REAL(1), -minbits);
     assert(fn(x - delta) * fn(x + delta) < 0);
@@ -79,7 +86,9 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
         static_cast<int>(0.6 * std::numeric_limits<CCTK_REAL>::digits);
     const int maxiters = 100;
     int iters;
-    auto x = halley(fnd2, 1.0, 0.0, 10.0, minbits, maxiters, iters);
+    bool failed;
+    auto x = halley(fnd2, 1.0, 0.0, 10.0, minbits, maxiters, iters, failed);
+    assert(!failed);
     assert(iters < maxiters);
     CCTK_REAL delta = std::scalbn(CCTK_REAL(1), -minbits);
     assert(fn(x - delta) * fn(x + delta) < 0);
@@ -91,7 +100,9 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
         static_cast<int>(0.6 * std::numeric_limits<CCTK_REAL>::digits);
     const int maxiters = 100;
     int iters;
-    auto x = schroder(fnd2, 1.0, 0.0, 10.0, minbits, maxiters, iters);
+    bool failed;
+    auto x = schroder(fnd2, 1.0, 0.0, 10.0, minbits, maxiters, iters, failed);
+    assert(!failed);
     assert(iters < maxiters);
     CCTK_REAL delta = std::scalbn(CCTK_REAL(1), -minbits);
     assert(fn(x - delta) * fn(x + delta) < 0);
@@ -104,13 +115,49 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
       return std::make_tuple(exp(x) - 3, exp(x), exp(x));
     };
     int iters_h, iters_s;
-    auto xh = halley(expfn, 0.1, -5.0, 5.0, minbits, maxiters, iters_h);
-    auto xs = schroder(expfn, 0.1, -5.0, 5.0, minbits, maxiters, iters_s);
+    bool failed_h, failed_s;
+    auto xh =
+        halley(expfn, 0.1, -5.0, 5.0, minbits, maxiters, iters_h, failed_h);
+    auto xs =
+        schroder(expfn, 0.1, -5.0, 5.0, minbits, maxiters, iters_s, failed_s);
+    assert(!failed_h && !failed_s);
     using std::abs, std::log;
     assert(abs(xh - log(CCTK_REAL(3))) < 1.0e-9);
     assert(abs(xs - log(CCTK_REAL(3))) < 1.0e-9);
     assert(iters_h != iters_s);
     CCTK_VINFO("Test_schroder succeeded in %d iterations", iters);
+  }
+
+  // The Boost-backed wrappers must report failure rather than let Boost's
+  // `evaluation_error` escape into the flesh.
+  {
+    const int minbits =
+        static_cast<int>(0.6 * std::numeric_limits<CCTK_REAL>::digits);
+    const int maxiters = 100;
+    int iters;
+    bool failed;
+
+    // Boost raises for a reversed range...
+    newton_raphson(fnd, 1.0, 10.0, 0.0, minbits, maxiters, iters, failed);
+    assert(failed);
+
+    // ...and when it decides it sits at a local minimum rather than a root.
+    auto noroot = [](CCTK_REAL x) { return std::make_tuple(x * x + 1, 2 * x); };
+    newton_raphson(noroot, 1.0, -10.0, 10.0, minbits, maxiters, iters, failed);
+    assert(failed);
+    auto noroot2 = [](CCTK_REAL x) {
+      return std::make_tuple(x * x + 1, 2 * x, 2);
+    };
+    halley(noroot2, 1.0, -10.0, 10.0, minbits, maxiters, iters, failed);
+    assert(failed);
+    schroder(noroot2, 1.0, -10.0, 10.0, minbits, maxiters, iters, failed);
+    assert(failed);
+
+    // An interval with no sign change is a failure, not an exception.
+    bisect(fn, 2.0, 3.0, minbits, maxiters, iters, failed);
+    assert(failed);
+
+    CCTK_VINFO("Test_wrapper_exceptions succeeded");
   }
 
   // Bracketing edge cases for `brent`. These are all cases where deciding the
@@ -166,25 +213,22 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
 
     auto g1d = [](vec<CCTK_REAL, 1> x)
         -> std::pair<vec<CCTK_REAL, 1>, mat<CCTK_REAL, 1> > {
-      return {vec<CCTK_REAL, 1>{x(0) * x(0) - 2},
-              mat<CCTK_REAL, 1>{2 * x(0)}};
+      return {vec<CCTK_REAL, 1>{x(0) * x(0) - 2}, mat<CCTK_REAL, 1>{2 * x(0)}};
     };
 
     // N == 1 exercises the same code path as N == 2 and N == 3, and would read
     // out of range if the step were summed over a hardcoded dimension.
     using std::abs;
-    auto x1 = newton_raphson_nd(g1d, vec<CCTK_REAL, 1>{1.0},
-                                vec<CCTK_REAL, 1>{0.0},
-                                vec<CCTK_REAL, 1>{10.0}, minbits, 100, iters,
-                                failed);
+    auto x1 =
+        newton_raphson_nd(g1d, vec<CCTK_REAL, 1>{1.0}, vec<CCTK_REAL, 1>{0.0},
+                          vec<CCTK_REAL, 1>{10.0}, minbits, 100, iters, failed);
     assert(!failed);
     assert(abs(x1(0) - root) < 1.0e-9);
 
     // Bounds that exclude the root must be honoured, and the failure reported.
-    auto x2 = newton_raphson_nd(g1d, vec<CCTK_REAL, 1>{1.0},
-                                vec<CCTK_REAL, 1>{0.0},
-                                vec<CCTK_REAL, 1>{1.2}, minbits, 100, iters,
-                                failed);
+    auto x2 =
+        newton_raphson_nd(g1d, vec<CCTK_REAL, 1>{1.0}, vec<CCTK_REAL, 1>{0.0},
+                          vec<CCTK_REAL, 1>{1.2}, minbits, 100, iters, failed);
     assert(failed);
     assert(x2(0) <= 1.2);
 
@@ -195,10 +239,9 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
       return {vec<CCTK_REAL, 2>{x(0) * x(0) - 2, x(0) * x(1) - 2},
               mat<CCTK_REAL, 2>{2 * x(0), 0, x(1), x(0)}};
     };
-    auto x3 = newton_raphson_nd(g2d, vec<CCTK_REAL, 2>{1.0, 1.0},
-                                vec<CCTK_REAL, 2>{0.0, 0.0},
-                                vec<CCTK_REAL, 2>{10.0, 10.0}, minbits, 4,
-                                iters, failed);
+    auto x3 = newton_raphson_nd(
+        g2d, vec<CCTK_REAL, 2>{1.0, 1.0}, vec<CCTK_REAL, 2>{0.0, 0.0},
+        vec<CCTK_REAL, 2>{10.0, 10.0}, minbits, 4, iters, failed);
     assert(!failed);
     assert(sumabs(gn(x3)) < 1.0e-9);
 
@@ -208,10 +251,9 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
         -> std::pair<vec<CCTK_REAL, 2>, mat<CCTK_REAL, 2> > {
       return {vec<CCTK_REAL, 2>{1.0, 1.0}, mat<CCTK_REAL, 2>{0, 0, 0, 0}};
     };
-    newton_raphson_nd(gsing, vec<CCTK_REAL, 2>{1.0, 1.0},
-                      vec<CCTK_REAL, 2>{-10.0, -10.0},
-                      vec<CCTK_REAL, 2>{10.0, 10.0}, minbits, 100, iters,
-                      failed);
+    newton_raphson_nd(
+        gsing, vec<CCTK_REAL, 2>{1.0, 1.0}, vec<CCTK_REAL, 2>{-10.0, -10.0},
+        vec<CCTK_REAL, 2>{10.0, 10.0}, minbits, 100, iters, failed);
     assert(failed);
     assert(iters < 100);
 
@@ -274,10 +316,10 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
       // dimension silently drops a term and gets the last component wrong.
       auto gnd3_CCTK_REAL = [](vec<CCTK_REAL, 3> x)
           -> std::pair<vec<CCTK_REAL, 3>, mat<CCTK_REAL, 3> > {
-        return {vec<CCTK_REAL, 3>{x(0) * x(0) - 2, x(0) * x(1) - 2,
-                                  x(1) * x(2) - 2},
-                mat<CCTK_REAL, 3>{2 * x(0), 0, 0, x(1), x(0), 0, 0, x(2),
-                                  x(1)}};
+        return {
+            vec<CCTK_REAL, 3>{x(0) * x(0) - 2, x(0) * x(1) - 2,
+                              x(1) * x(2) - 2},
+            mat<CCTK_REAL, 3>{2 * x(0), 0, 0, x(1), x(0), 0, 0, x(2), x(1)}};
       };
       auto x3 = newton_raphson_nd(
           gnd3_CCTK_REAL, vec<CCTK_REAL, 3>{1.0, 1.0, 1.0},

--- a/Algo/src/roots.cxx
+++ b/Algo/src/roots.cxx
@@ -20,10 +20,12 @@ using Arith::mat, Arith::vec;
 namespace {
 // Residuals used to check the multi-dimensional solutions. The Jacobians live
 // with their call sites: SYCL cannot call a templated function from a kernel.
-template <typename T> ALGO_DEVICE vec<T, 2> gn(vec<T, 2> x) {
+// These are called from both the host-side and the kernel-side checks, so they
+// must be available in both places.
+template <typename T> ALGO_HOST ALGO_DEVICE vec<T, 2> gn(vec<T, 2> x) {
   return vec<T, 2>{x(0) * x(0) - 2, x(0) * x(1) - 2};
 }
-template <typename T> ALGO_DEVICE vec<T, 3> gn3(vec<T, 3> x) {
+template <typename T> ALGO_HOST ALGO_DEVICE vec<T, 3> gn3(vec<T, 3> x) {
   return vec<T, 3>{x(0) * x(0) - 2, x(0) * x(1) - 2, x(1) * x(2) - 2};
 }
 } // namespace

--- a/Algo/src/roots.cxx
+++ b/Algo/src/roots.cxx
@@ -29,7 +29,7 @@ template <typename T> ALGO_DEVICE vec<T, 3> gn3(vec<T, 3> x) {
 } // namespace
 
 extern "C" void Test_roots(CCTK_ARGUMENTS) {
-  DECLARE_CCTK_ARGUMENTS;
+  DECLARE_CCTK_ARGUMENTSX_Test_roots;
 
   auto fn = [] ALGO_HOST ALGO_DEVICE(CCTK_REAL x) { return x * x - 2; };
   auto fnd = [] ALGO_HOST ALGO_DEVICE(CCTK_REAL x) {

--- a/Algo/src/roots.cxx
+++ b/Algo/src/roots.cxx
@@ -129,7 +129,8 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
   }
 
   // The Boost-backed wrappers must report failure rather than let Boost's
-  // `evaluation_error` escape into the flesh.
+  // `evaluation_error` escape into the flesh, and must refuse an empty
+  // iteration budget rather than hand Boost one it would read as unbounded.
   {
     const int minbits =
         static_cast<int>(0.6 * std::numeric_limits<CCTK_REAL>::digits);
@@ -157,7 +158,14 @@ extern "C" void Test_roots(CCTK_ARGUMENTS) {
     bisect(fn, 2.0, 3.0, minbits, maxiters, iters, failed);
     assert(failed);
 
-    CCTK_VINFO("Test_wrapper_exceptions succeeded");
+    // A zero budget must be an empty search. Boost decrements before it tests,
+    // so passing zero through would underflow into an unbounded one.
+    bisect(fn, 1.0, 2.0, minbits, 0, iters, failed);
+    assert(failed && iters == 0);
+    newton_raphson(fnd, 1.0, 0.0, 10.0, minbits, 0, iters, failed);
+    assert(failed && iters == 0);
+
+    CCTK_VINFO("Test_wrapper_failure_modes succeeded");
   }
 
   // Bracketing edge cases for `brent`. These are all cases where deciding the

--- a/Algo/src/roots.hxx
+++ b/Algo/src/roots.hxx
@@ -35,8 +35,13 @@
 
 namespace Algo {
 
+// These helpers exist so that the `using std::...` declaration can live in a
+// function body. That matters for `clamp1`, which is called with arguments
+// named `min` and `max` that would otherwise shadow `std::min` and `std::max`.
+
 namespace {
-template <typename T> constexpr void swap1(T &x, T &y) {
+template <typename T>
+constexpr ALGO_HOST ALGO_DEVICE void swap1(T &x, T &y) {
   T z = std::move(x);
   x = std::move(y);
   y = std::move(z);
@@ -44,9 +49,18 @@ template <typename T> constexpr void swap1(T &x, T &y) {
 } // namespace
 
 namespace {
-template <typename T> constexpr T ldexp1(const T &x, const int n) {
+template <typename T>
+constexpr ALGO_HOST ALGO_DEVICE T ldexp1(const T &x, const int n) {
   using std::ldexp;
   return ldexp(x, n);
+}
+} // namespace
+
+namespace {
+template <typename T>
+constexpr ALGO_HOST ALGO_DEVICE T clamp1(const T &x, const T &lo, const T &hi) {
+  using std::max, std::min;
+  return min(max(x, lo), hi);
 }
 } // namespace
 
@@ -54,9 +68,12 @@ template <typename T> class eps_tolerance {
   T eps;
 
 public:
-  constexpr eps_tolerance() : eps(10 * std::numeric_limits<T>::epsilon()) {}
-  constexpr eps_tolerance(const int min_bits) : eps(ldexp1(T(1), -min_bits)) {}
-  constexpr bool operator()(const T &x, const T &y) const {
+  constexpr ALGO_HOST ALGO_DEVICE eps_tolerance()
+      : eps(10 * std::numeric_limits<T>::epsilon()) {}
+  constexpr ALGO_HOST ALGO_DEVICE eps_tolerance(const int min_bits)
+      : eps(ldexp1(T(1), -min_bits)) {}
+  constexpr ALGO_HOST ALGO_DEVICE bool operator()(const T &x,
+                                                  const T &y) const {
     using std::abs, std::min;
     return abs(x - y) <= eps * min(abs(x), abs(y));
   }
@@ -79,20 +96,19 @@ std::pair<T, T> bracket_and_solve_root(F &&f, T guess, T factor, bool rising,
                                        int &iters) {
   std::uintmax_t max_iter = max_iters;
   auto res = boost::math::tools::bracket_and_solve_root(
-      std::forward<F>(f), guess, factor, rising,
-      // boost::math::tools::eps_tolerance<T>(min_bits),
-      eps_tolerance<T>(min_bits), max_iter);
+      std::forward<F>(f), guess, factor, rising, eps_tolerance<T>(min_bits),
+      max_iter);
   iters = max_iter;
   return res;
 }
 
 // See <https://en.wikipedia.org/wiki/Brent%27s_method>
+//
 template <typename F, typename T>
 inline CCTK_ATTRIBUTE_ALWAYS_INLINE ALGO_HOST ALGO_DEVICE std::pair<T, T>
 brent(F f, T a, T b, int min_bits, int max_iters, int &iters) {
   using std::abs, std::min, std::max;
 
-  // auto tol = boost::math::tools::eps_tolerance<T>(min_bits);
   const auto tol = eps_tolerance<T>(min_bits);
 
   iters = 0;
@@ -153,10 +169,6 @@ brent(F f, T a, T b, int min_bits, int max_iters, int &iters) {
       a = s;
       fa = fs;
     }
-    // CCTK_VINFO("iters=%d mflag=%d   a=%.17g b=%.17g c=%.17g d=%.17g fa=%.17g"
-    //            "fb=%.17g fc=%.17g",
-    //            iters, int(mflag), double(a), double(b), double(c), double(d),
-    //            double(fa), double(fb), double(fc));
     assert(fa * fb <= 0);
     if (abs(fa) < abs(fb)) {
       swap1(a, b);
@@ -172,7 +184,7 @@ brent(F f, T a, T b, int min_bits, int max_iters, int &iters) {
 
 // Requires function and its derivative
 template <typename F, typename T>
-T newton_raphson(F f, T guess, T min, T max, int min_bits, int max_iters,
+T newton_raphson(F &&f, T guess, T min, T max, int min_bits, int max_iters,
                  int &iters) {
   std::uintmax_t max_iter = max_iters;
   auto res = boost::math::tools::newton_raphson_iterate(
@@ -183,7 +195,8 @@ T newton_raphson(F f, T guess, T min, T max, int min_bits, int max_iters,
 
 // Requires function and first two derivatives
 template <typename F, typename T>
-T halley(F f, T guess, T min, T max, int min_bits, int max_iters, int &iters) {
+T halley(F &&f, T guess, T min, T max, int min_bits, int max_iters,
+         int &iters) {
   std::uintmax_t max_iter = max_iters;
   auto res = boost::math::tools::halley_iterate(std::forward<F>(f), guess, min,
                                                 max, min_bits, max_iter);
@@ -193,15 +206,21 @@ T halley(F f, T guess, T min, T max, int min_bits, int max_iters, int &iters) {
 
 // Requires function and first two derivatives
 template <typename F, typename T>
-T schroder(F f, T guess, T min, T max, int min_bits, int max_iters,
+T schroder(F &&f, T guess, T min, T max, int min_bits, int max_iters,
            int &iters) {
   std::uintmax_t max_iter = max_iters;
-  auto res = boost::math::tools::halley_iterate(std::forward<F>(f), guess, min,
-                                                max, min_bits, max_iter);
+  auto res = boost::math::tools::schroder_iterate(
+      std::forward<F>(f), guess, min, max, min_bits, max_iter);
   iters = max_iter;
   return res;
 }
 
+// Multi-dimensional Newton-Raphson iteration. `f` returns both the residual
+// and its Jacobian. Iterates are confined to the box `[min, max]`.
+//
+// `iters` is the number of Newton steps taken, at most `max_iters`. `failed`
+// is set if no solution was found, i.e. if the Jacobian became singular, if the
+// iteration stalled on a bound, or if `max_iters` was reached.
 template <typename F, typename T, int N>
 inline CCTK_ATTRIBUTE_ALWAYS_INLINE ALGO_HOST ALGO_DEVICE Arith::vec<T, N>
 newton_raphson_nd(F f, const Arith::vec<T, N> &guess,
@@ -209,25 +228,48 @@ newton_raphson_nd(F f, const Arith::vec<T, N> &guess,
                   int min_bits, int max_iters, int &iters, bool &failed) {
   using vec = Arith::vec<T, N>;
   using mat = Arith::mat<T, N>;
-  failed = false;
-  // auto tolfx = boost::math::tools::eps_tolerance<T>(min_bits);
+  using std::isfinite;
+
   const auto tolfx = eps_tolerance<T>(min_bits);
-  vec x = guess;
-  for (iters = 1; iters <= max_iters; ++iters) {
+
+  failed = true;
+  vec x([&](int i) { return clamp1(guess(i), min(i), max(i)); });
+
+  for (iters = 0; iters <= max_iters; ++iters) {
     const auto [fx0, jac0] = f(x);
     const vec fx = fx0;
     const mat jac = jac0;
+
+    // Comparing `1 + errfx` against `1` reduces to `errfx <= eps`, i.e. this is
+    // an absolute criterion on the residual, and hence sensitive to how `f` is
+    // scaled.
     const T errfx = sumabs(fx);
-    if (tolfx(1 + errfx, 1))
+    if (tolfx(1 + errfx, 1)) {
+      failed = false;
       return x;
+    }
+    if (iters == max_iters)
+      break;
+
     const T det_jac = calc_det(jac);
+    if (!isfinite(det_jac) || det_jac == 0)
+      // Singular Jacobian; there is no Newton step to take
+      break;
     const mat inv_jac = calc_inv(jac, det_jac);
     const vec dx([&](int i) {
-      return -Arith::sum<2>([&](int j) { return inv_jac(i, j) * fx(j); });
+      return -Arith::sum<N>([&](int j) { return inv_jac(i, j) * fx(j); });
     });
-    x += dx;
+    const vec xnew([&](int i) { return clamp1(x(i) + dx(i), min(i), max(i)); });
+
+    bool moved = false;
+    for (int i = 0; i < N; ++i)
+      moved |= xnew(i) != x(i);
+    if (!moved)
+      // The iteration is stuck, most likely against a bound
+      break;
+    x = xnew;
   }
-  failed = true;
+
   return x;
 }
 

--- a/Algo/src/roots.hxx
+++ b/Algo/src/roots.hxx
@@ -72,6 +72,17 @@ constexpr ALGO_HOST ALGO_DEVICE T clamp1(const T &x, const T &lo, const T &hi) {
 }
 } // namespace
 
+namespace {
+// Whether `x` and `y` bracket a sign change. Do not test this as `x * y < 0`:
+// that product underflows to `-0` for small operands, and `-0 < 0` is false,
+// so a bracket of e.g. `+1e-200` and `-1e-200` would be misread as having no
+// sign change at all.
+template <typename T>
+constexpr ALGO_HOST ALGO_DEVICE bool opposite_signs1(const T &x, const T &y) {
+  return (x < 0 && y > 0) || (x > 0 && y < 0);
+}
+} // namespace
+
 // A relative convergence criterion, equivalent to
 // `boost::math::tools::eps_tolerance`: two values are considered equal once
 // they agree to `min_bits` binary digits.
@@ -126,14 +137,19 @@ std::pair<T, T> bracket_and_solve_root(F &&f, T guess, T factor, bool rising,
 
 // See <https://en.wikipedia.org/wiki/Brent%27s_method>
 //
+// Returns a bracket containing the root. `iters` is the number of iterations
+// performed. `failed` is set if no root was found, either because `[a, b]` did
+// not bracket one to begin with, or because `max_iters` was reached before the
+// bracket converged.
 template <typename F, typename T>
 inline CCTK_ATTRIBUTE_ALWAYS_INLINE ALGO_HOST ALGO_DEVICE std::pair<T, T>
-brent(F f, T a, T b, int min_bits, int max_iters, int &iters) {
+brent(F f, T a, T b, int min_bits, int max_iters, int &iters, bool &failed) {
   using std::abs, std::min, std::max;
 
   const auto tol = eps_tolerance<T>(min_bits);
 
   iters = 0;
+  failed = false;
   auto fa = f(a);
   auto fb = f(b);
   if (abs(fa) < abs(fb)) {
@@ -142,9 +158,9 @@ brent(F f, T a, T b, int min_bits, int max_iters, int &iters) {
   }
   if (fb == 0)
     return {b, b};
-  if (fa * fb >= 0) {
+  if (!opposite_signs1(fa, fb)) {
     // Root is not bracketed
-    iters = max_iters;
+    failed = true;
     return {min(a, b), max(a, b)};
   }
   T c = a;
@@ -184,14 +200,17 @@ brent(F f, T a, T b, int min_bits, int max_iters, int &iters) {
     d = c;
     c = b;
     fc = fb;
-    if (fa * fs < 0) {
+    if (opposite_signs1(fa, fs)) {
       b = s;
       fb = fs;
     } else {
       a = s;
       fa = fs;
     }
-    assert(fa * fb <= 0);
+    // The bracket is still valid. `fa` can be exactly zero here: if `fs` was
+    // zero we took the `else` branch above, and the swap below has not yet run
+    // to move that root into `b`.
+    assert(fa == 0 || fb == 0 || opposite_signs1(fa, fb));
     if (abs(fa) < abs(fb)) {
       swap1(a, b);
       swap1(fa, fb);
@@ -201,6 +220,7 @@ brent(F f, T a, T b, int min_bits, int max_iters, int &iters) {
 
   if (fb == 0)
     return {b, b};
+  failed = !tol(a, b);
   return {min(a, b), max(a, b)};
 }
 

--- a/Algo/src/roots.hxx
+++ b/Algo/src/roots.hxx
@@ -119,13 +119,23 @@ public:
 // is at a local minimum rather than a root); neither can be suppressed with a
 // policy for the derivative-based iterates, which hardcode `policy<>()`, and
 // an exception escaping into the flesh would terminate the run.
-
+//
+// They also refuse an empty iteration budget rather than passing it on. Boost
+// counts down in a `do ... while (count && ...)` and decrements before it
+// tests, so a budget of zero underflows to an unbounded search; a negative
+// `max_iters` would convert to an enormous unsigned budget in the first place.
+// Neither can be expressed to Boost, so an empty budget is answered here.
 
 template <typename F, typename T>
 std::pair<T, T> bisect(F &&f, T min, T max, int min_bits, int max_iters,
                        int &iters, bool &failed) {
   iters = 0;
   failed = false;
+  assert(max_iters >= 0);
+  if (max_iters <= 0) {
+    failed = true;
+    return {min, max};
+  }
   std::uintmax_t max_iter = max_iters;
   try {
     auto res = boost::math::tools::bisect(
@@ -146,6 +156,11 @@ std::pair<T, T> bracket_and_solve_root(F &&f, T guess, T factor, bool rising,
                                        bool &failed) {
   iters = 0;
   failed = false;
+  assert(max_iters >= 0);
+  if (max_iters <= 0) {
+    failed = true;
+    return {guess, guess};
+  }
   std::uintmax_t max_iter = max_iters;
   try {
     auto res = boost::math::tools::bracket_and_solve_root(
@@ -255,6 +270,11 @@ T newton_raphson(F &&f, T guess, T min, T max, int min_bits, int max_iters,
                  int &iters, bool &failed) {
   iters = 0;
   failed = false;
+  assert(max_iters >= 0);
+  if (max_iters <= 0) {
+    failed = true;
+    return guess;
+  }
   std::uintmax_t max_iter = max_iters;
   try {
     auto res = boost::math::tools::newton_raphson_iterate(
@@ -274,6 +294,11 @@ T halley(F &&f, T guess, T min, T max, int min_bits, int max_iters, int &iters,
          bool &failed) {
   iters = 0;
   failed = false;
+  assert(max_iters >= 0);
+  if (max_iters <= 0) {
+    failed = true;
+    return guess;
+  }
   std::uintmax_t max_iter = max_iters;
   try {
     auto res = boost::math::tools::halley_iterate(std::forward<F>(f), guess,
@@ -293,6 +318,11 @@ T schroder(F &&f, T guess, T min, T max, int min_bits, int max_iters,
            int &iters, bool &failed) {
   iters = 0;
   failed = false;
+  assert(max_iters >= 0);
+  if (max_iters <= 0) {
+    failed = true;
+    return guess;
+  }
   std::uintmax_t max_iter = max_iters;
   try {
     auto res = boost::math::tools::schroder_iterate(

--- a/Algo/src/roots.hxx
+++ b/Algo/src/roots.hxx
@@ -7,6 +7,7 @@
 
 #include <cctk.h>
 
+#include <boost/math/policies/error_handling.hpp>
 #include <boost/math/tools/roots.hpp>
 
 #ifdef __HIPCC__
@@ -40,8 +41,7 @@ namespace Algo {
 // named `min` and `max` that would otherwise shadow `std::min` and `std::max`.
 
 namespace {
-template <typename T>
-constexpr ALGO_HOST ALGO_DEVICE void swap1(T &x, T &y) {
+template <typename T> constexpr ALGO_HOST ALGO_DEVICE void swap1(T &x, T &y) {
   T z = std::move(x);
   x = std::move(y);
   y = std::move(z);
@@ -112,27 +112,52 @@ public:
   }
 };
 
+// The wrappers below run on the host only: Boost's root finders are not
+// device code. Each reports failure through `failed` rather than by throwing.
+// Boost raises `evaluation_error` both for argument errors it can detect (a
+// reversed `[min, max]`) and for a search that genuinely fails (it decides it
+// is at a local minimum rather than a root); neither can be suppressed with a
+// policy for the derivative-based iterates, which hardcode `policy<>()`, and
+// an exception escaping into the flesh would terminate the run.
+
+
 template <typename F, typename T>
 std::pair<T, T> bisect(F &&f, T min, T max, int min_bits, int max_iters,
-                       int &iters) {
+                       int &iters, bool &failed) {
+  iters = 0;
+  failed = false;
   std::uintmax_t max_iter = max_iters;
-  auto res = boost::math::tools::bisect(
-      std::forward<F>(f), min, max,
-      boost::math::tools::eps_tolerance<T>(min_bits), max_iter);
-  iters = max_iter;
-  return res;
+  try {
+    auto res = boost::math::tools::bisect(
+        std::forward<F>(f), min, max,
+        boost::math::tools::eps_tolerance<T>(min_bits), max_iter);
+    iters = max_iter;
+    return res;
+  } catch (const boost::math::evaluation_error &) {
+    iters = max_iter;
+    failed = true;
+    return {min, max};
+  }
 }
 
 template <typename F, typename T>
 std::pair<T, T> bracket_and_solve_root(F &&f, T guess, T factor, bool rising,
-                                       int min_bits, int max_iters,
-                                       int &iters) {
+                                       int min_bits, int max_iters, int &iters,
+                                       bool &failed) {
+  iters = 0;
+  failed = false;
   std::uintmax_t max_iter = max_iters;
-  auto res = boost::math::tools::bracket_and_solve_root(
-      std::forward<F>(f), guess, factor, rising, eps_tolerance<T>(min_bits),
-      max_iter);
-  iters = max_iter;
-  return res;
+  try {
+    auto res = boost::math::tools::bracket_and_solve_root(
+        std::forward<F>(f), guess, factor, rising, eps_tolerance<T>(min_bits),
+        max_iter);
+    iters = max_iter;
+    return res;
+  } catch (const boost::math::evaluation_error &) {
+    iters = max_iter;
+    failed = true;
+    return {guess, guess};
+  }
 }
 
 // See <https://en.wikipedia.org/wiki/Brent%27s_method>
@@ -227,34 +252,58 @@ brent(F f, T a, T b, int min_bits, int max_iters, int &iters, bool &failed) {
 // Requires function and its derivative
 template <typename F, typename T>
 T newton_raphson(F &&f, T guess, T min, T max, int min_bits, int max_iters,
-                 int &iters) {
+                 int &iters, bool &failed) {
+  iters = 0;
+  failed = false;
   std::uintmax_t max_iter = max_iters;
-  auto res = boost::math::tools::newton_raphson_iterate(
-      std::forward<F>(f), guess, min, max, min_bits, max_iter);
-  iters = max_iter;
-  return res;
+  try {
+    auto res = boost::math::tools::newton_raphson_iterate(
+        std::forward<F>(f), guess, min, max, min_bits, max_iter);
+    iters = max_iter;
+    return res;
+  } catch (const boost::math::evaluation_error &) {
+    iters = max_iter;
+    failed = true;
+    return guess;
+  }
 }
 
 // Requires function and first two derivatives
 template <typename F, typename T>
-T halley(F &&f, T guess, T min, T max, int min_bits, int max_iters,
-         int &iters) {
+T halley(F &&f, T guess, T min, T max, int min_bits, int max_iters, int &iters,
+         bool &failed) {
+  iters = 0;
+  failed = false;
   std::uintmax_t max_iter = max_iters;
-  auto res = boost::math::tools::halley_iterate(std::forward<F>(f), guess, min,
-                                                max, min_bits, max_iter);
-  iters = max_iter;
-  return res;
+  try {
+    auto res = boost::math::tools::halley_iterate(std::forward<F>(f), guess,
+                                                  min, max, min_bits, max_iter);
+    iters = max_iter;
+    return res;
+  } catch (const boost::math::evaluation_error &) {
+    iters = max_iter;
+    failed = true;
+    return guess;
+  }
 }
 
 // Requires function and first two derivatives
 template <typename F, typename T>
 T schroder(F &&f, T guess, T min, T max, int min_bits, int max_iters,
-           int &iters) {
+           int &iters, bool &failed) {
+  iters = 0;
+  failed = false;
   std::uintmax_t max_iter = max_iters;
-  auto res = boost::math::tools::schroder_iterate(
-      std::forward<F>(f), guess, min, max, min_bits, max_iter);
-  iters = max_iter;
-  return res;
+  try {
+    auto res = boost::math::tools::schroder_iterate(
+        std::forward<F>(f), guess, min, max, min_bits, max_iter);
+    iters = max_iter;
+    return res;
+  } catch (const boost::math::evaluation_error &) {
+    iters = max_iter;
+    failed = true;
+    return guess;
+  }
 }
 
 // Multi-dimensional Newton-Raphson iteration. `f` returns both the residual

--- a/Algo/src/roots.hxx
+++ b/Algo/src/roots.hxx
@@ -58,20 +58,42 @@ constexpr ALGO_HOST ALGO_DEVICE T ldexp1(const T &x, const int n) {
 
 namespace {
 template <typename T>
+constexpr ALGO_HOST ALGO_DEVICE T max1(const T &x, const T &y) {
+  using std::max;
+  return max(x, y);
+}
+} // namespace
+
+namespace {
+template <typename T>
 constexpr ALGO_HOST ALGO_DEVICE T clamp1(const T &x, const T &lo, const T &hi) {
   using std::max, std::min;
   return min(max(x, lo), hi);
 }
 } // namespace
 
+// A relative convergence criterion, equivalent to
+// `boost::math::tools::eps_tolerance`: two values are considered equal once
+// they agree to `min_bits` binary digits.
+//
+// Note that this is a purely relative criterion, as it is in Boost. A bracket
+// that straddles zero therefore never satisfies it, because `min(|x|, |y|)`
+// tends to zero along with the bracket; such a search terminates on its
+// iteration count instead. Callers looking for a root at zero need an absolute
+// criterion, which this class deliberately does not provide.
 template <typename T> class eps_tolerance {
   T eps;
 
 public:
   constexpr ALGO_HOST ALGO_DEVICE eps_tolerance()
-      : eps(10 * std::numeric_limits<T>::epsilon()) {}
-  constexpr ALGO_HOST ALGO_DEVICE eps_tolerance(const int min_bits)
-      : eps(ldexp1(T(1), -min_bits)) {}
+      : eps(4 * std::numeric_limits<T>::epsilon()) {}
+  // `eps` is clamped from below at `4 * epsilon`, as Boost does. Without the
+  // clamp, any `min_bits >= digits` asks for a precision that no two distinct
+  // floating-point numbers can satisfy, and the search silently runs until it
+  // exhausts its iteration count.
+  explicit constexpr ALGO_HOST ALGO_DEVICE eps_tolerance(const int min_bits)
+      : eps(max1(ldexp1(T(1), 1 - min_bits),
+                 T(4 * std::numeric_limits<T>::epsilon()))) {}
   constexpr ALGO_HOST ALGO_DEVICE bool operator()(const T &x,
                                                   const T &y) const {
     using std::abs, std::min;


### PR DESCRIPTION
A review of `Algo`'s root finders turned up a set of defects, several of which the thorn's own test could not have caught. Each commit is one fix and compiles on its own.

## Bugs

- **`schroder()` was Halley's method.** It called `boost::math::tools::halley_iterate`; the two functions were identical apart from the name. Boost has `schroder_iterate`.
- **`newton_raphson_nd()` was wrong at any dimension but 2.** The Newton step was contracted with a hardcoded `sum<2>` instead of `sum<N>`, so at `N=3` every step silently dropped a term, and at `N=1` it read past the end of the inverse Jacobian and the residual.
- **`newton_raphson_nd()` ignored its `min`/`max` bounds** entirely — they were accepted and never mentioned again. Iterates are now clamped into the box.
- **`brent()` decided every sign question by multiplying two function values.** That product underflows: `1e-200 * -1e-200` is `-0`, and `-0 >= 0` is true, so a genuinely bracketed pair of small values was rejected as unbracketed. The in-loop test is worse — `-0 < 0` is false, so the search took the wrong branch, destroyed its own bracket, and tripped the assertion that follows.
- **The Boost-backed wrappers let `boost::math::evaluation_error` escape,** terminating the run. Boost raises it both for a reversed `[min, max]` and for a search it decides is at a local minimum rather than a root. A non-throwing policy is not available: the three derivative-based iterates take no `Policy` parameter and hardcode `policies::policy<>()`.
- **A negative `max_iters` became an astronomical budget** when converted to `std::uintmax_t`. Clamping to zero would not have helped — Boost's iterates decrement *before* they test (`do { ... --count; ... } while (count && ...)`), so a budget of zero underflows to `SIZE_MAX` and the search becomes unbounded. Verified: given a budget of zero, `newton_raphson_iterate` runs to convergence in 5 iterations. An empty budget is now answered in `Algo` rather than passed on.

## Behaviour and API changes

- **`eps_tolerance` now matches `boost::math::tools::eps_tolerance`**: `max(2^(1-min_bits), 4*epsilon)` rather than an unclamped `2^-min_bits`. The missing clamp was the part that bit — any `min_bits >= digits` asked for closer agreement than two distinct doubles can have, so the criterion was never met and the search silently ran to its iteration cap on a perfectly good bracket.
- **All seven root finders now report failure through a `failed` out-parameter.** `brent()` previously signalled by setting `iters = max_iters`, which conflated "not bracketed", "hit the cap" and "the tolerance was unreachable", and returned a plausible-looking bracket in all three. `iters` is now an honest count.

`brent()`'s signature change affects `AsterX/Con2PrimFactory`, which is the only caller outside this thorn; **companion PR to follow, and the two need to land together.** That change is behaviour-preserving: converting a tolerance to bits needs one more bit to ask for the same `eps`, and for `c2p_tol` anywhere from 1e-6 down to about 1e-15 the resulting `eps` is then bit-identical. Checked directly by running 20,000 brackets through the old and new code at their respective `min_bits`: identical results and identical iteration counts.

The other four wrappers have no callers outside the thorn.

## Testing

The N-dimensional test supplied a **transposed Jacobian**. `Arith::mat` is row-major, so `mat<T,2>{2*x0, x1, 0, x0}` is `[[2x0, x1], [0, x0]]`, while the Jacobian of `(x0^2-2, x0*x1-2)` is `[[2x0, 0], [x1, x0]]`. Newton still converged, but linearly rather than quadratically — 67 iterations instead of 5, comfortably inside the limit of 100 that was asserted, so the test passed throughout. The dead namespace-scope `gnd()` carried the same transposition and was never instantiated, which is how it went unnoticed.

`Test_roots` now asserts the iteration count only a correct Jacobian can achieve, and covers the solver at `N=1` and `N=3`, bounds that exclude the root, a singular Jacobian, a solution found on the last permitted step, brackets whose function values underflow, `min_bits == digits`, non-bracketing intervals, a root exactly on an endpoint, every wrapper failure mode, and an empty iteration budget. Schröder and Halley agree to the last bit on `x^2-2`, so they are separated on `exp(x)-3`, where the two methods genuinely take different paths (4 vs 6 iterations, under both Boost 1.76 and 1.90).

Every new case was checked by reintroducing the bug it covers and confirming it fails — that is how the zero-budget clamp was caught as a non-fix.

Verified with `sim-debug`: `Test_roots` passes with `Test_newton_raphson_nd succeeded in 4 iterations (2D), 4 iterations (3D)`, and AsterX's `Balsara1_shocktube_xdir_ppm_PalenzuelaC2P` reports `Number failed -> 0`.

## Not addressed

- `eps_tolerance` remains purely relative, as it is in Boost, so a bracket straddling zero still cannot converge by tolerance and terminates on its iteration count. Fixing that means deliberately diverging from Boost.
- `newton_raphson_nd()` has no globalization — no damping, no line search. It now reports a singular Jacobian or a stall against a bound instead of grinding to the cap, but it will still diverge from a poor guess.
