### PR TITLE
Loop: correct C++ struct layouts (ODR violation in debug builds)

### DIFF
--- a/Loop/src/loop.hxx
+++ b/Loop/src/loop.hxx
@@ -860,10 +860,8 @@ template <typename T, int CI, int CJ, int CK> struct GF3D {
 template <typename T> struct GF3D1 {
   typedef T value_type;
   T *restrict ptr;
-#ifdef CCTK_DEBUG
   vect<int, dim> imin, imax;
   vect<int, dim> ash;
-#endif
   static constexpr int di = 1;
   int dj, dk, np;
   int off;
@@ -875,9 +873,7 @@ template <typename T> struct GF3D1 {
   GF3D1(T *restrict ptr, const vect<int, dim> &imin, const vect<int, dim> &imax,
         const vect<int, dim> &ash)
       : ptr(ptr),
-#ifdef CCTK_DEBUG
         imin(imin), imax(imax), ash(ash),
-#endif
         dj(di * ash[0]), dk(dj * ash[1]), np(dk * ash[2]),
         off(imin[0] * di + imin[1] * dj + imin[2] * dk) {
   }
@@ -924,10 +920,8 @@ template <typename T> struct GF3D1 {
 ////////////////////////////////////////////////////////////////////////////////
 
 struct GF3D2layout {
-#ifdef CCTK_DEBUG
   vect<int, dim> imin, imax;
   vect<int, dim> ash;
-#endif
   static constexpr int di = 1;
   int dj, dk, np;
   int off;
@@ -940,9 +934,7 @@ struct GF3D2layout {
                                     const vect<int, dim> &imax,
                                     const vect<int, dim> &ash)
       :
-#ifdef CCTK_DEBUG
         imin(imin), imax(imax), ash(ash),
-#endif
         dj(di * ash[0]), dk(dj * ash[1]), np(dk * ash[2]),
         off(imin[0] * di + imin[1] * dj + imin[2] * dk) {
   }
@@ -1019,9 +1011,7 @@ struct GF3D2layout {
 };
 
 struct GF3D2index {
-#ifdef CCTK_DEBUG
   GF3D2layout layout;
-#endif
   int m_linear;
   GF3D2index() = delete;
   GF3D2index(const GF3D2index &) = default;
@@ -1031,9 +1021,7 @@ struct GF3D2index {
   CCTK_DEVICE CCTK_HOST GF3D2index(const GF3D2layout &layout,
                                    const vect<int, dim> &I, int n = 0)
       :
-#ifdef CCTK_DEBUG
         layout(layout),
-#endif
         m_linear(layout.linear(I, n)) {
   }
   CCTK_DEVICE CCTK_HOST int linear() const { return m_linear; }
@@ -1320,10 +1308,8 @@ struct GF3D3ptr : GF3D3layout<NI, NJ, NK, OFF> {
 ////////////////////////////////////////////////////////////////////////////////
 
 struct GF3D5layout {
-#ifdef CCTK_DEBUG
   vect<int, dim> imin, imax;
   vect<int, dim> ash;
-#endif
   static constexpr int di = 1;
   int dj, dk, np;
   int off;
@@ -1336,9 +1322,7 @@ struct GF3D5layout {
                                     const vect<int, dim> &imax,
                                     const vect<int, dim> &ash)
       :
-#ifdef CCTK_DEBUG
         imin(imin), imax(imax), ash(ash),
-#endif
         dj(di * ash[0]), dk(dj * ash[1]), np(dk * ash[2]),
         off(imin[0] * di + imin[1] * dj + imin[2] * dk) {
   }
@@ -1411,9 +1395,7 @@ struct GF3D5layout {
 };
 
 struct GF3D5index {
-#ifdef CCTK_DEBUG
   GF3D5layout layout;
-#endif
   int m_linear;
   GF3D5index() = delete;
   GF3D5index(const GF3D5index &) = default;
@@ -1423,9 +1405,7 @@ struct GF3D5index {
   CCTK_DEVICE CCTK_HOST GF3D5index(const GF3D5layout &layout,
                                    const vect<int, dim> &I)
       :
-#ifdef CCTK_DEBUG
         layout(layout),
-#endif
         m_linear(layout.linear(I)) {
   }
   CCTK_DEVICE CCTK_HOST int linear() const { return m_linear; }
@@ -1433,9 +1413,7 @@ struct GF3D5index {
 
 template <typename T> struct GF3D5 {
   typedef T value_type;
-#ifdef CCTK_DEBUG
   GF3D5layout layout;
-#endif
   T *restrict ptr;
   GF3D5() = delete;
   GF3D5(const GF3D5 &) = default;
@@ -1444,9 +1422,7 @@ template <typename T> struct GF3D5 {
   GF3D5 &operator=(GF3D5 &&) = default;
   CCTK_DEVICE CCTK_HOST GF3D5(const GF3D5layout &layout, T *restrict ptr)
       :
-#ifdef CCTK_DEBUG
         layout(layout),
-#endif
         ptr(ptr) {
 #ifdef CCTK_DEBUG
     assert(&(*this)(layout, layout.imin) == ptr);


### PR DESCRIPTION
`GF3D1`, `GF3D2layout`, `GF3D2index`, `GF3D5layout`, `GF3D5index` and `GF3D5` declared
some of their data members inside `#ifdef CCTK_DEBUG`. That makes the class layout depend
on a macro — and several translation units deliberately undefine that macro before
including `loop.hxx`:

```cpp
#ifdef __CUDACC__
// Disable CCTK_DEBUG since the debug information takes too much
// parameter space to launch the kernels
#ifdef CCTK_DEBUG
#undef CCTK_DEBUG
#endif
#endif
```

`SpacetimeX/Z4c/src/{constraints,rhs,adm2}.cxx` and `SpacetimeX/Weyl/src/weyl.cxx` all do
this. In a `DEBUG=yes` build the result is a One Definition Rule violation: the same class
has two different definitions in one program. Measured with `sizeof` against the real
headers:

| type | `CCTK_DEBUG` defined | undefined |
| --- | --- | --- |
| `GF3D2layout` | 52 | 16 |
| `GF3D5layout` | 52 | 16 |
| `GF3D2<double>` | 64 | 24 |
| `GF3D5<double>` | 64 | 8 |

This is not merely formal. Both variants emit the *same* weak COMDAT symbols — e.g.
`Loop::GF3D2layout::GF3D2layout(_cGH const*, Arith::vect<int, 3> const&)` is defined in
both `constraints.cxx.o` (macro undefined) and `adm.cxx.o` (macro defined) — and because
debug builds are unoptimised these are real calls rather than inlined, with
`R_X86_64_PLT32` relocations against that symbol in both objects. The linker keeps one
definition arbitrarily. In the build where this was found it kept the 52-byte version,
which stores to offset `0x30` of objects that the undefining translation units allocate as
16 bytes.

Symptom: a `sim-debug` CUDA build with Z4c aborts with

```
CUDA error 700 ... an illegal memory access was encountered
```

faulting inside `Z4c::calc_derivs<double>` launched from `Z4c_Constraints` — the first
scheduled routine that comes from one of the undefining translation units. The optimised
build is unaffected, because there `CCTK_DEBUG` is undefined everywhere and the two
definitions coincide.

Fix: make the members unconditional. Only the assertions remain behind `#ifdef
CCTK_DEBUG`, so a translation unit can still switch those off — which is all the `#undef`
sites actually want — without changing any class layout. The cost is a few extra `int`s
per layout object; these are per-kernel-launch, not per grid point.
