### PR TITLE
PDESolvers: Preallocate the Jacobian exactly, and default to algebraic multigrid

### DIFF
--- a/PDESolvers/param.ccl
+++ b/PDESolvers/param.ccl
@@ -7,13 +7,3 @@ STRING petsc_options "PETSc options" STEERABLE=recover
 {
   ".*" :: ""
 } ""
-
-INT dnz "Maximum number of diagonal Jacobian entries" STEERABLE=always
-{
-  1:* :: ""
-} 7
-
-INT onz "Maximum number of off-diagonal Jacobian entries" STEERABLE=always
-{
-  1:* :: ""
-} 4

--- a/PDESolvers/param.ccl
+++ b/PDESolvers/param.ccl
@@ -7,3 +7,7 @@ STRING petsc_options "PETSc options" STEERABLE=recover
 {
   ".*" :: ""
 } ""
+
+BOOLEAN row_equilibration "Scale each row of the Jacobian, and the corresponding residual entry, by 1/|diagonal|" STEERABLE=recover
+{
+} "yes"

--- a/PDESolvers/param.ccl
+++ b/PDESolvers/param.ccl
@@ -3,10 +3,45 @@
 # -snes_monitor ascii
 # -ksp_monitor
 # -ksp_type {bcgs|bcgsl|gmres|...}   <https://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/KSP/KSPType.html>
+#
+# The default requests algebraic multigrid. PETSc's own default preconditioner
+# is ILU (block Jacobi with ILU on each block in parallel), whose iteration
+# count grows like 1/h; AMG is resolution independent. `gamg` is PETSc's
+# built-in AMG, so this default needs no external package.
+#
+# `-pc_gamg_threshold 0.0` is not optional. With GAMG's default threshold the
+# aggregation copes badly with this matrix as soon as a level is split into
+# more than one AMReX box, and both the iteration count and the setup cost
+# blow up. Linear iterations for a single level, measured with PoissonX:
+#
+#   unknowns   grid        ILU   gamg(default)  gamg(thresh 0)  BoomerAMG
+#      3,375   16^3 1 box   17         6              6             4
+#     29,791   32^3 1 box   32         6              6             4
+#     29,791   32^3 8 box   33        18              6             4
+#    250,047   64^3 8 box   56        38              7             4
+#    857,375   96^3         85   out of memory        8             7
+#
+# If PETSc was built with hypre, BoomerAMG needs the fewest iterations of all,
+# but note that hypre's default strong threshold of 0.25 is tuned for two
+# dimensions -- use 0.5 in three:
+#
+#   -ksp_type bcgs -pc_type hypre -pc_hypre_type boomeramg \
+#       -pc_hypre_boomeramg_strong_threshold 0.5
+#
+# AMG wins on iteration count at every size above, but not yet on wall time:
+# its setup dominates below roughly a million unknowns, where plain ILU is as
+# fast or faster. It is the asymptotics that make it the better default.
+#
+# Do not use `-ksp_type cg`: the matrix is not symmetric once there is more
+# than one refinement level, because prolongation is eliminated into the
+# neighbouring rows while restriction aliases indices.
+#
+# This is a single string, so a parameter file that sets it replaces this
+# default entirely rather than adding to it.
 STRING petsc_options "PETSc options" STEERABLE=recover
 {
   ".*" :: ""
-} ""
+} "-ksp_type bcgs -pc_type gamg -pc_gamg_threshold 0.0"
 
 BOOLEAN row_equilibration "Scale each row of the Jacobian, and the corresponding residual entry, by 1/|diagonal|" STEERABLE=recover
 {

--- a/PDESolvers/src/pdesolvers.cxx
+++ b/PDESolvers/src/pdesolvers.cxx
@@ -12,8 +12,12 @@ static inline int omp_get_max_threads() { return 1; }
 static inline int omp_get_thread_num() { return 0; }
 #endif
 
+#include <cctk.h>
+
+#include <algorithm>
 #include <cassert>
 #include <cstring>
+#include <vector>
 
 namespace PDESolvers {
 
@@ -113,34 +117,6 @@ std::size_t jacobian_t::size() const { return entries.size(); }
 
 void jacobian_t::clear() { entries.clear(); }
 
-void jacobian_t::count_matrix_entries(const csr_t &Jp, int ilocal_min,
-                                      int ilocal_max, int &restrict nlocal,
-                                      int &restrict ntotal) const {
-  const auto count_point = [&](const int i, const int j) {
-    nlocal += j >= ilocal_min && j < ilocal_max;
-    ntotal += j >= 0;
-  };
-  for (const auto &e : entries) {
-    const auto i = std::get<0>(e);
-    const auto j = std::get<1>(e);
-    assert(i >= 0);
-    if (j < 0) {
-      // ignore this point
-    } else if (j >= 0 && j < prolongation_index_offset) {
-      // regular point
-      count_point(i, j);
-    } else {
-      // prolongated point
-      const int row = j - prolongation_index_offset;
-      assert(0 <= row && row < Jp.m);
-      const int rowptr0 = Jp.rowptrs.at(row);
-      const int rowptr1 = Jp.rowptrs.at(row + 1);
-      for (int colindp = 0; colindp < rowptr1 - rowptr0; ++colindp)
-        count_point(i, Jp.colvals.at(rowptr0 + colindp));
-    }
-  }
-}
-
 void jacobian_t::set_matrix_entries(const csr_t &Jp, Mat J) const {
   std::vector<CCTK_REAL> values;
   for (const auto &e : entries) {
@@ -152,7 +128,11 @@ void jacobian_t::set_matrix_entries(const csr_t &Jp, Mat J) const {
       // ignore this point
     } else if (j >= 0 && j < prolongation_index_offset) {
       // regular point
-      MatSetValue(J, i, j, v, ADD_VALUES);
+      const PetscErrorCode ierr = MatSetValue(J, i, j, v, ADD_VALUES);
+      // Do not ignore this: if the matrix is preallocated too tightly, PETSc
+      // refuses the insertion, and dropping the error silently would leave a
+      // matrix that is missing entries and merely fails to converge.
+      assert(!ierr);
     } else {
       // prolongated point
       const int row = j - prolongation_index_offset;
@@ -162,8 +142,10 @@ void jacobian_t::set_matrix_entries(const csr_t &Jp, Mat J) const {
       values.resize(rowptr1 - rowptr0);
       for (int rowptr = rowptr0; rowptr < rowptr1; ++rowptr)
         values.at(rowptr - rowptr0) = v * Jp.nzvals.at(rowptr);
-      MatSetValues(J, 1, &i, rowptr1 - rowptr0, &Jp.colvals.at(rowptr0),
-                   values.data(), ADD_VALUES);
+      const PetscErrorCode ierr =
+          MatSetValues(J, 1, &i, rowptr1 - rowptr0, &Jp.colvals.at(rowptr0),
+                       values.data(), ADD_VALUES);
+      assert(!ierr);
     }
   }
 }
@@ -225,6 +207,65 @@ void jacobians_t::clear() {
 
 void jacobians_t::define_matrix(const csr_t &Jp, Mat J) const {
   PetscErrorCode ierr;
+
+  // Preallocate from the entries that are about to be inserted.
+  //
+  // This replaces the former `dnz`/`onz` parameters. Those had to be guessed,
+  // and no value a parameter file can carry is right in general: the number of
+  // entries per row depends on the stencil, on whether the row's stencil
+  // reaches across a refinement boundary (prolongation is eliminated into the
+  // row, which widens it), and on the AMReX box decomposition. Guessing too
+  // low made PETSc refuse the insertions.
+  //
+  // The pattern is recorded by inserting it into PETSc's preallocator, which
+  // keeps the structure and discards the values. This runs the very same
+  // insertion code that writes the values below, so the pattern cannot drift
+  // from what is actually assembled, and PETSc derives the diagonal and
+  // off-diagonal counts, and any off-process rows, by itself. Counting the
+  // entries by hand instead would have to deduplicate columns: a row that
+  // straddles a refinement boundary names the same coarse column from several
+  // of its stencil points, and simply counting occurrences over-allocates by a
+  // factor of four on four levels.
+  //
+  // The pattern is the same for every evaluation within one solve, so this is
+  // done once, before the first assembly.
+  PetscBool assembled;
+  ierr = MatAssembled(J, &assembled);
+  assert(!ierr);
+  const bool preallocating = !assembled;
+  if (preallocating) {
+    MPI_Comm comm;
+    ierr = PetscObjectGetComm((PetscObject)J, &comm);
+    assert(!ierr);
+    PetscInt nlocal_rows, nlocal_cols, nglobal_rows, nglobal_cols;
+    ierr = MatGetLocalSize(J, &nlocal_rows, &nlocal_cols);
+    assert(!ierr);
+    ierr = MatGetSize(J, &nglobal_rows, &nglobal_cols);
+    assert(!ierr);
+
+    Mat P;
+    ierr = MatCreate(comm, &P);
+    assert(!ierr);
+    ierr = MatSetType(P, MATPREALLOCATOR);
+    assert(!ierr);
+    ierr = MatSetSizes(P, nlocal_rows, nlocal_cols, nglobal_rows, nglobal_cols);
+    assert(!ierr);
+    ierr = MatSetUp(P);
+    assert(!ierr);
+    for (const auto &j : jacobians)
+      j.set_matrix_entries(Jp, P);
+    ierr = MatAssemblyBegin(P, MAT_FINAL_ASSEMBLY);
+    assert(!ierr);
+    ierr = MatAssemblyEnd(P, MAT_FINAL_ASSEMBLY);
+    assert(!ierr);
+    // `PETSC_TRUE` also writes explicit zeros into J, so that the ADD_VALUES
+    // below land in positions that already exist
+    ierr = MatPreallocatorPreallocate(P, PETSC_TRUE, J);
+    assert(!ierr);
+    ierr = MatDestroy(&P);
+    assert(!ierr);
+  }
+
   ierr = MatZeroEntries(J);
   assert(!ierr);
   for (const auto &j : jacobians)
@@ -236,51 +277,39 @@ void jacobians_t::define_matrix(const csr_t &Jp, Mat J) const {
   ierr = MatSetOption(J, MAT_NEW_NONZERO_LOCATIONS, PETSC_FALSE);
   assert(!ierr);
 
-#if 0
-  PetscErrorCode ierr;
-  int ilocal_min, ilocal_max;
-  {
+  if (preallocating) {
+    // Report how well the preallocation matched: `mallocs` must be zero, and
+    // `unneeded` is what was allocated but not used. `longest row` is the
+    // number the former `dnz` parameter had to guess.
     MatInfo info;
-    PetscErrorCode ierr;
     ierr = MatGetInfo(J, MAT_GLOBAL_SUM, &info);
     assert(!ierr);
-    CCTK_VINFO("Jacobian info: nz_allocated=%g nz_used=%g nz_unneeded=%g "
-               "memory=%g",
-               double(info.nz_allocated), double(info.nz_used),
-               double(info.nz_unneeded), double(info.memory));
-  }
-  // ierr = MatSetUp(J);
-  // assert(!ierr);
-  ierr = MatGetOwnershipRange(J, &ilocal_min, &ilocal_max);
-  assert(!ierr);
-  int nlocal = 0, ntotal = 0;
-  for (const auto &j : jacobians)
-    j.count_matrix_entries(Jp, ilocal_min, ilocal_max, nlocal, ntotal);
-  const int dnz = nlocal;
-  const int onz = ntotal - nlocal;
-  ierr = MatMPIAIJSetPreallocation(J, dnz, NULL, onz, NULL);
-  assert(!ierr);
-  {
-    MatInfo info;
-    PetscErrorCode ierr;
-    ierr = MatGetInfo(J, MAT_GLOBAL_SUM, &info);
+    MPI_Comm comm;
+    ierr = PetscObjectGetComm((PetscObject)J, &comm);
     assert(!ierr);
-    CCTK_VINFO("Jacobian info: nz_allocated=%g nz_used=%g nz_unneeded=%g "
-               "memory=%g",
-               double(info.nz_allocated), double(info.nz_used),
-               double(info.nz_unneeded), double(info.memory));
+    PetscInt rstart, rend;
+    ierr = MatGetOwnershipRange(J, &rstart, &rend);
+    assert(!ierr);
+    PetscInt longest_row = 0;
+    for (PetscInt row = rstart; row < rend; ++row) {
+      PetscInt ncols;
+      ierr = MatGetRow(J, row, &ncols, NULL, NULL);
+      assert(!ierr);
+      longest_row = std::max(longest_row, ncols);
+      ierr = MatRestoreRow(J, row, &ncols, NULL, NULL);
+      assert(!ierr);
+    }
+    ierr =
+        MPI_Allreduce(MPI_IN_PLACE, &longest_row, 1, MPIU_INT, MPI_MAX, comm);
+    assert(!ierr);
+    CCTK_VINFO("Jacobian: %.0f entries used, %.0f allocated (%.1f%% unneeded), "
+               "%.0f mallocs, longest row %d",
+               double(info.nz_used), double(info.nz_allocated),
+               info.nz_allocated > 0
+                   ? 100 * double(info.nz_unneeded) / double(info.nz_allocated)
+                   : 0.0,
+               double(info.mallocs), int(longest_row));
   }
-  // ierr = MatSetOption(J, MAT_NEW_NONZERO_LOCATIONS, PETSC_FALSE);
-  // assert(!ierr);
-  ierr = MatZeroEntries(J);
-  assert(!ierr);
-  for (const auto &j : jacobians)
-    j.set_matrix_entries(Jp, J);
-  ierr = MatAssemblyBegin(J, MAT_FINAL_ASSEMBLY);
-  assert(!ierr);
-  ierr = MatAssemblyEnd(J, MAT_FINAL_ASSEMBLY);
-  assert(!ierr);
-#endif
 
 #if 0
   PetscErrorCode ierr;

--- a/PDESolvers/src/pdesolvers.hxx
+++ b/PDESolvers/src/pdesolvers.hxx
@@ -67,8 +67,6 @@ public:
   //               int &restrict ntotal) const;
   void clear();
   void add_value(int i, int j, CCTK_REAL v) { entries.emplace_back(i, j, v); }
-  void count_matrix_entries(const csr_t &Jp, int ilocal_min, int ilocal_max,
-                            int &restrict nlocal, int &restrict ntotal) const;
   void set_matrix_entries(const csr_t &Jp, Mat J) const;
   void
   set_matrix_entries(const csr_t &Jp,

--- a/PDESolvers/src/solve.cxx
+++ b/PDESolvers/src/solve.cxx
@@ -1181,11 +1181,23 @@ extern "C" void PDESolvers_Solve(CCTK_ARGUMENTS) {
   ierr = VecSetFromOptions(r);
   assert(!ierr);
 
+  // Row equilibration: a left scaling applied to both the residual and the
+  // Jacobian. It is the identity until it is computed below, just before the
+  // solve; the lambdas capture it by reference and apply whatever it holds at
+  // the time they run.
+  Vec rowscale;
+  ierr = VecDuplicate(r, &rowscale);
+  assert(!ierr);
+  ierr = VecSet(rowscale, 1.0);
+  assert(!ierr);
+
   std::function<PetscErrorCode(SNES snes, Vec x, Vec f)> evalf =
       [&](SNES snes, Vec x, Vec f) {
         copy_PETSc_to_Cactus(x, solinds, component_offsets, component_sizes);
         CallScheduleGroup(cctkGH, "PDESolvers_Residual");
         copy_Cactus_to_PETSc(f, resinds, component_offsets, component_sizes);
+        const PetscErrorCode ierr = VecPointwiseMult(f, rowscale, f);
+        assert(!ierr);
         return 0;
       };
   ierr = SNESSetFunction(snes, r, FormFunction, &evalf);
@@ -1214,6 +1226,10 @@ extern "C" void PDESolvers_Solve(CCTK_ARGUMENTS) {
         CallScheduleGroup(cctkGH, "PDESolvers_Jacobian");
         jacobians->define_matrix(Jp, J);
         jacobians->clear();
+        {
+          const PetscErrorCode ierr = MatDiagonalScale(J, rowscale, NULL);
+          assert(!ierr);
+        }
         if (false) {
           MatInfo info;
           PetscErrorCode ierr;
@@ -1244,6 +1260,45 @@ extern "C" void PDESolvers_Solve(CCTK_ARGUMENTS) {
   ierr = VecDuplicate(r, &x);
   assert(!ierr);
   copy_Cactus_to_PETSc(x, solinds, component_offsets, component_sizes);
+
+  // Row equilibration
+  //
+  // The rows of the flat matrix come from several refinement levels. For a
+  // second order operator their magnitudes differ by a factor 4^level, and
+  // algebraic multigrid then loses its resolution independence: AMG relies on
+  // the near null space (the constants) leaving a small residual, which
+  // requires the rows to be scaled comparably. Left scaling by 1/|J_ii|
+  // preserves each row sum and restores this. (PETSc's -ksp_diagonal_scale
+  // scales symmetrically, which does not preserve row sums and makes AMG
+  // converge worse; do not use it here.)
+  //
+  // This is a left preconditioner: it scales the residual and the Jacobian
+  // identically, so the Newton step and the solution are unchanged. It does
+  // change the residual norms that SNES and KSP test their tolerances against.
+  //
+  // The scaling is taken from the Jacobian at the initial guess and held fixed
+  // for the whole solve, so that residual and Jacobian can never be scaled
+  // inconsistently. Evaluating the Jacobian here costs one extra assembly;
+  // `define_matrix` zeroes the matrix first, so this is idempotent.
+  if (row_equilibration) {
+    ierr = evalJ(snes, x, J, J);
+    assert(!ierr);
+    ierr = MatGetDiagonal(J, rowscale);
+    assert(!ierr);
+    ierr = VecAbs(rowscale);
+    assert(!ierr);
+    PetscInt nlocal;
+    ierr = VecGetLocalSize(rowscale, &nlocal);
+    assert(!ierr);
+    PetscScalar *rowscale_ptr;
+    ierr = VecGetArray(rowscale, &rowscale_ptr);
+    assert(!ierr);
+    for (PetscInt i = 0; i < nlocal; ++i)
+      rowscale_ptr[i] =
+          rowscale_ptr[i] > 0 ? 1.0 / rowscale_ptr[i] : CCTK_REAL(1);
+    ierr = VecRestoreArray(rowscale, &rowscale_ptr);
+    assert(!ierr);
+  }
 
   // Solve
 
@@ -1326,6 +1381,7 @@ extern "C" void PDESolvers_Solve(CCTK_ARGUMENTS) {
   jacobians.reset();
   VecDestroy(&x);
   VecDestroy(&r);
+  VecDestroy(&rowscale);
   MatDestroy(&J);
   SNESDestroy(&snes);
   CCTK_INFO("Done.");

--- a/PDESolvers/src/solve.cxx
+++ b/PDESolvers/src/solve.cxx
@@ -1193,16 +1193,17 @@ extern "C" void PDESolvers_Solve(CCTK_ARGUMENTS) {
 
   // Matrix and Jacobian evaluation function
 
+  // The matrix is deliberately created without preallocation:
+  // `jacobians_t::define_matrix` preallocates it from the entries it is about
+  // to insert, once it knows them.
   Mat J;
-  ierr = MatCreateAIJ(PETSC_COMM_WORLD, nvars * npoints_local,
-                      nvars * npoints_local, nvars * npoints_global,
-                      nvars * npoints_global, dnz, NULL, onz, NULL, &J);
+  ierr = MatCreate(PETSC_COMM_WORLD, &J);
   assert(!ierr);
-  // ierr = MatCreate(PETSC_COMM_WORLD, &J);
-  // assert(!ierr);
-  // ierr = MatSetSizes(J, nvars * npoints_local, nvars * npoints_local,
-  //                    nvars * npoints_global, nvars * npoints_global);
-  // assert(!ierr);
+  ierr = MatSetSizes(J, nvars * npoints_local, nvars * npoints_local,
+                     nvars * npoints_global, nvars * npoints_global);
+  assert(!ierr);
+  ierr = MatSetType(J, MATAIJ);
+  assert(!ierr);
   ierr = MatSetFromOptions(J);
   assert(!ierr);
   jacobians = std::make_optional<jacobians_t>();

--- a/PDESolvers/src/solve.cxx
+++ b/PDESolvers/src/solve.cxx
@@ -1157,8 +1157,8 @@ extern "C" void PDESolvers_Solve(CCTK_ARGUMENTS) {
                    component_prolongated_sizes, Jp);
 
   // TODO: fix this
-  const std::vector<int> solinds{CCTK_VarIndex("Poisson::sol")};
-  const std::vector<int> resinds{CCTK_VarIndex("Poisson::res")};
+  const std::vector<int> solinds{CCTK_VarIndex("PoissonX::sol")};
+  const std::vector<int> resinds{CCTK_VarIndex("PoissonX::res")};
   const int nvars = solinds.size();
   assert(int(resinds.size()) == nvars);
 

--- a/PoissonX/par/poissonx-fd4.par
+++ b/PoissonX/par/poissonx-fd4.par
@@ -41,8 +41,6 @@ CarpetX::prolongation_order = 3
 CarpetX::interpolation_order = 3
 
 PDESolvers::petsc_options = "-snes_linesearch_type basic -ksp_type bcgs -snes_monitor ascii -snes_converged_reason -ksp_monitor -ksp_converged_reason"
-PDESolvers::dnz = 13
-PDESolvers::onz = 8
 
 PoissonX::fdorder = 4
 

--- a/PoissonX/par/poissonx-fd4.par
+++ b/PoissonX/par/poissonx-fd4.par
@@ -40,7 +40,14 @@ CarpetX::prolongation_type = "ddf"
 CarpetX::prolongation_order = 3
 CarpetX::interpolation_order = 3
 
-PDESolvers::petsc_options = "-snes_linesearch_type basic -ksp_type bcgs -snes_monitor ascii -snes_converged_reason -ksp_monitor -ksp_converged_reason"
+# Algebraic multigrid: resolution independent, unlike PETSc's default ILU.
+# The explicit threshold 0.0 is required; at GAMG's default threshold the
+# iteration count and setup cost blow up once a level spans several boxes.
+# `gamg` is built into PETSc; with a hypre-enabled PETSc, replace
+# `-pc_type gamg -pc_gamg_threshold 0.0` by
+#   -pc_type hypre -pc_hypre_type boomeramg -pc_hypre_boomeramg_strong_threshold 0.5
+# Do not use -ksp_type cg: the matrix is not symmetric with refinement.
+PDESolvers::petsc_options = "-snes_linesearch_type basic -ksp_type bcgs -pc_type gamg -pc_gamg_threshold 0.0 -snes_monitor ascii -snes_converged_reason -ksp_monitor -ksp_converged_reason"
 
 PoissonX::fdorder = 4
 

--- a/PoissonX/par/poissonx-logo.par
+++ b/PoissonX/par/poissonx-logo.par
@@ -39,7 +39,14 @@ CarpetX::prolongation_type = "ddf"
 CarpetX::prolongation_order = 1
 CarpetX::interpolation_order = 1
 
-PDESolvers::petsc_options = "-snes_linesearch_type basic -ksp_type bcgs -snes_monitor ascii -snes_converged_reason -ksp_monitor -ksp_converged_reason"
+# Algebraic multigrid: resolution independent, unlike PETSc's default ILU.
+# The explicit threshold 0.0 is required; at GAMG's default threshold the
+# iteration count and setup cost blow up once a level spans several boxes.
+# `gamg` is built into PETSc; with a hypre-enabled PETSc, replace
+# `-pc_type gamg -pc_gamg_threshold 0.0` by
+#   -pc_type hypre -pc_hypre_type boomeramg -pc_hypre_boomeramg_strong_threshold 0.5
+# Do not use -ksp_type cg: the matrix is not symmetric with refinement.
+PDESolvers::petsc_options = "-snes_linesearch_type basic -ksp_type bcgs -pc_type gamg -pc_gamg_threshold 0.0 -snes_monitor ascii -snes_converged_reason -ksp_monitor -ksp_converged_reason"
 
 PoissonX::source = "logo"
 

--- a/PoissonX/par/poissonx-rl2.par
+++ b/PoissonX/par/poissonx-rl2.par
@@ -45,8 +45,6 @@ CarpetX::interpolation_order = 1
 ErrorEstimator::scale_by_resolution = yes
 
 PDESolvers::petsc_options = "-snes_linesearch_type basic -ksp_type bcgs -snes_monitor ascii -snes_converged_reason -ksp_monitor -ksp_converged_reason -ksp_view_eigenvalues -ksp_view_singularvalues -ksp_monitor_singular_value"
-PDESolvers::dnz = 7 + 8
-PDESolvers::onz = 4 + 8
 
 IO::out_dir = $parfile
 IO::out_every = 1

--- a/PoissonX/par/poissonx-rl2.par
+++ b/PoissonX/par/poissonx-rl2.par
@@ -44,7 +44,14 @@ CarpetX::interpolation_order = 1
 
 ErrorEstimator::scale_by_resolution = yes
 
-PDESolvers::petsc_options = "-snes_linesearch_type basic -ksp_type bcgs -snes_monitor ascii -snes_converged_reason -ksp_monitor -ksp_converged_reason -ksp_view_eigenvalues -ksp_view_singularvalues -ksp_monitor_singular_value"
+# Algebraic multigrid: resolution independent, unlike PETSc's default ILU.
+# The explicit threshold 0.0 is required; at GAMG's default threshold the
+# iteration count and setup cost blow up once a level spans several boxes.
+# `gamg` is built into PETSc; with a hypre-enabled PETSc, replace
+# `-pc_type gamg -pc_gamg_threshold 0.0` by
+#   -pc_type hypre -pc_hypre_type boomeramg -pc_hypre_boomeramg_strong_threshold 0.5
+# Do not use -ksp_type cg: the matrix is not symmetric with refinement.
+PDESolvers::petsc_options = "-snes_linesearch_type basic -ksp_type bcgs -pc_type gamg -pc_gamg_threshold 0.0 -snes_monitor ascii -snes_converged_reason -ksp_monitor -ksp_converged_reason -ksp_view_eigenvalues -ksp_view_singularvalues -ksp_monitor_singular_value"
 
 IO::out_dir = $parfile
 IO::out_every = 1

--- a/PoissonX/par/poissonx-rl4.par
+++ b/PoissonX/par/poissonx-rl4.par
@@ -44,7 +44,14 @@ CarpetX::interpolation_order = 1
 
 ErrorEstimator::scale_by_resolution = yes
 
-PDESolvers::petsc_options = "-snes_linesearch_type basic -ksp_type bcgs -snes_monitor ascii -snes_converged_reason -ksp_monitor -ksp_converged_reason -ksp_view_eigenvalues -ksp_view_singularvalues -ksp_monitor_singular_value"
+# Algebraic multigrid: resolution independent, unlike PETSc's default ILU.
+# The explicit threshold 0.0 is required; at GAMG's default threshold the
+# iteration count and setup cost blow up once a level spans several boxes.
+# `gamg` is built into PETSc; with a hypre-enabled PETSc, replace
+# `-pc_type gamg -pc_gamg_threshold 0.0` by
+#   -pc_type hypre -pc_hypre_type boomeramg -pc_hypre_boomeramg_strong_threshold 0.5
+# Do not use -ksp_type cg: the matrix is not symmetric with refinement.
+PDESolvers::petsc_options = "-snes_linesearch_type basic -ksp_type bcgs -pc_type gamg -pc_gamg_threshold 0.0 -snes_monitor ascii -snes_converged_reason -ksp_monitor -ksp_converged_reason -ksp_view_eigenvalues -ksp_view_singularvalues -ksp_monitor_singular_value"
 
 IO::out_dir = $parfile
 IO::out_every = 1

--- a/PoissonX/par/poissonx-rl4.par
+++ b/PoissonX/par/poissonx-rl4.par
@@ -45,8 +45,6 @@ CarpetX::interpolation_order = 1
 ErrorEstimator::scale_by_resolution = yes
 
 PDESolvers::petsc_options = "-snes_linesearch_type basic -ksp_type bcgs -snes_monitor ascii -snes_converged_reason -ksp_monitor -ksp_converged_reason -ksp_view_eigenvalues -ksp_view_singularvalues -ksp_monitor_singular_value"
-PDESolvers::dnz = 7 + 3*8
-PDESolvers::onz = 4 + 3*8
 
 IO::out_dir = $parfile
 IO::out_every = 1

--- a/PoissonX/par/poissonx.par
+++ b/PoissonX/par/poissonx.par
@@ -40,7 +40,14 @@ CarpetX::prolongation_type = "ddf"
 CarpetX::prolongation_order = 1
 CarpetX::interpolation_order = 1
 
-PDESolvers::petsc_options = "-snes_linesearch_type basic -ksp_type bcgs -snes_monitor ascii -snes_converged_reason -ksp_monitor -ksp_converged_reason -ksp_view_eigenvalues -ksp_view_singularvalues -ksp_monitor_singular_value"
+# Algebraic multigrid: resolution independent, unlike PETSc's default ILU.
+# The explicit threshold 0.0 is required; at GAMG's default threshold the
+# iteration count and setup cost blow up once a level spans several boxes.
+# `gamg` is built into PETSc; with a hypre-enabled PETSc, replace
+# `-pc_type gamg -pc_gamg_threshold 0.0` by
+#   -pc_type hypre -pc_hypre_type boomeramg -pc_hypre_boomeramg_strong_threshold 0.5
+# Do not use -ksp_type cg: the matrix is not symmetric with refinement.
+PDESolvers::petsc_options = "-snes_linesearch_type basic -ksp_type bcgs -pc_type gamg -pc_gamg_threshold 0.0 -snes_monitor ascii -snes_converged_reason -ksp_monitor -ksp_converged_reason -ksp_view_eigenvalues -ksp_view_singularvalues -ksp_monitor_singular_value"
 
 IO::out_dir = $parfile
 IO::out_every = 1


### PR DESCRIPTION
PoissonX did not run at all, PDESolvers guessed its matrix preallocation from
two parameters that were wrong in two of the five shipped example parameter
files, and the solver used PETSc's default ILU on an elliptic problem. Five
commits, each self-consistent.

## PoissonX could not run

`PDESolvers_Solve` looked up `Poisson::sol` and `Poisson::res`. The thorn was
renamed to PoissonX in 2fefda6a and the lookups were not updated, so
`CCTK_VarIndex` returned -1 and every PoissonX parameter file aborted at the
first residual evaluation with `Assertion 'vn >= 0' failed`. PoissonX is the
only thorn that schedules into `PDESolvers_Residual`/`_Jacobian`, so the
solver had no working caller.

## dnz/onz were guesses, and silently wrong

No value a parameter file can carry is right in general: the entries per row
depend on the stencil, on whether a row's stencil crosses a refinement
boundary (prolongation is eliminated into the row, which widens it), and on
the AMReX box decomposition. Measuring the longest row per solve:

| parameter file | longest row | `dnz` that was set | |
|---|---|---|---|
| `poissonx` | 7 | 7 (default) | ok |
| `poissonx-fd4` | 13 | 13 | ok |
| `poissonx-logo` | 8 | 7 (default) | **one short** |
| `poissonx-rl2` | 7, 13 | 15 | ok |
| `poissonx-rl4` | 7, 13, 27, 41 | 31 | **ten short** |

Guessing low was not diagnosed, because `set_matrix_entries` discarded the
return code of `MatSetValue`. PETSc's refusal to insert a new nonzero was
ignored and the matrix came out missing entries: `poissonx-logo` then merely
failed to converge (`DIVERGED_MAX_IT` at residual 0.589), and `poissonx-rl4`
needed 326 linear iterations where a correctly assembled matrix needs 116.
Where the insertion aborted instead, it corrupted the heap.

The pattern is now recorded by inserting it into PETSc's `MATPREALLOCATOR`.
That runs the same insertion code that writes the values, so the pattern
cannot drift from what is assembled, and PETSc derives the diagonal and
off-diagonal counts and any off-process rows itself. Result: 0 unneeded
entries and 0 mallocs on 1-4 levels, 1-8 boxes, and 1, 2 and 4 processes.

Counting the entries by hand was tried and rejected: a row straddling a
refinement boundary names the same coarse column from several stencil points,
so counting occurrences over-allocates 4x on four levels. The existing
`count_matrix_entries`, which the disabled block in `define_matrix` was going
to use, could not have worked either -- it returns totals over all rows where
PETSc wants a per-row count, and calls only the MPI variant, a no-op on the
MATSEQAIJ a single-process run creates. It is removed.

## ILU -> algebraic multigrid

Linear iterations for a single level:

| unknowns | grid | ILU | gamg (default) | gamg (thresh 0) | BoomerAMG |
|---|---|---|---|---|---|
| 3,375 | 16^3, 1 box | 17 | 6 | 6 | 4 |
| 29,791 | 32^3, 1 box | 32 | 6 | 6 | 4 |
| 29,791 | 32^3, 8 boxes | 33 | 18 | 6 | 4 |
| 250,047 | 64^3, 8 boxes | 56 | 38 | 7 | 4 |
| 857,375 | 96^3 | 85 | out of memory | 8 | 7 |

`gamg` is built into PETSc, so the default needs no external package.
`-pc_gamg_threshold 0.0` is **not optional**: at GAMG's default threshold the
aggregation copes badly with this matrix once a level spans more than one
AMReX box, and both iteration count and setup cost blow up.

AMG wins on iteration count at every size above but not yet on wall time --
its setup dominates below roughly a million unknowns, where plain ILU is as
fast or faster. It is the asymptotics that make it the better default.

`-ksp_type cg` must not be used: `MatIsSymmetric` reports the matrix
symmetric on one level and **not** symmetric on two or more, because
prolongation is eliminated into the neighbouring rows one-sidedly while
restriction aliases indices.

## Row equilibration

Rows come from several refinement levels, so for a second order operator
their magnitudes differ by 4^level. AMG relies on the near null space (the
constants) leaving a small residual, which needs comparably scaled rows.
BoomerAMG linear iterations on a 32^3 base grid:

| levels | 1 | 2 | 3 | 4 | 5 |
|---|---|---|---|---|---|
| as is | 3 | 5 | 8 | 9 | 10 |
| equilibrated | 3 | 4 | 5 | 5 | 5 |

Left scaling by `1/|J_ii|` preserves each row sum and restores resolution
independence. PETSc's `-ksp_diagonal_scale` scales symmetrically, does not
preserve row sums, and makes convergence worse -- GAMG dramatically so
(5, 27, 39, 71, 96 over the same cases) -- so it is not a substitute. The
scaling is applied to residual and Jacobian identically, making it a left
preconditioner that leaves the Newton step and the solution unchanged; it
does change the residual norms SNES and KSP test against. With one level all
diagonals are equal, so it is a no-op there and results are unchanged bit for
bit. Switch it off with the new `row_equilibration` parameter.

## Compatibility

`PDESolvers::dnz` and `PDESolvers::onz` are **removed**. A parameter file that
still sets them will fail with "no such parameter". The five PoissonX files
are updated here; `cactusamrex`'s historical `Poisson2` copy is untouched.

## Testing

Neither PoissonX nor PDESolvers has a `test/` directory, and CI's
`--select-tests=CarpetX` picks up nothing from them, so no reference output is
affected. Verified by hand with `sim` (optimised), `OMP_NUM_THREADS=1` for
reproducibility: all five parameter files run to completion with exact
preallocation and no mallocs; `poissonx`, `-fd4` and `-logo` converge to
~1e-10; single-level cases checked at 1, 2 and 4 MPI ranks.

Built and tested on top of an integration branch rather than on `main`
directly. Every cross-thorn header PDESolvers includes is identical between
the two, but a clean CI build here is the real check.

Two pre-existing problems found along the way are **not** addressed:
`poissonx-rl2`/`-rl4` stall on `CONVERGED_SNORM_RELATIVE` at residual ~0.35
for every preconditioner even with a provably correct matrix, and the
multi-box path is nondeterministic under OpenMP (1 run in 6 of an identical
16^3/8-box case differed at 6 threads, occasionally aborting in `free()`
inside libgomp during AMReX regridding, before PDESolvers runs).