### PR TITLE
docker: Move the images onto the MPI ABI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,15 @@ jobs:
 
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container: einsteintoolkit/carpetx:${{matrix.accelerator}}-${{matrix.real-precision}}
+    # TEMPORARY: the `-testing` tags. These are the MPI-ABI images -- MPI, HDF5
+    # and PETSc come from the ABI in /usr/local rather than from distribution
+    # packages -- built from the dockerfiles in `docker/` in this same branch.
+    # They are not yet published under the plain tags, so CI has to name the
+    # testing ones to exercise them at all.
+    # Revert this line to
+    #     container: einsteintoolkit/carpetx:${{matrix.accelerator}}-${{matrix.real-precision}}
+    # before merging, once the plain tags have been pushed.
+    container: einsteintoolkit/carpetx:${{matrix.accelerator}}-${{matrix.real-precision}}-testing
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
   # This workflow contains a single job
   download-build-test:
     strategy:
+      # TEMPORARY, alongside the `-testing` tags below: with the default
+      # fail-fast the first failing job cancels the other seven, so a single
+      # error hides whatever the other images would have said. Remove this
+      # together with the `-testing` suffix before merging.
+      fail-fast: false
       matrix:
         accelerator: [cpu, cuda, rocm, oneapi]
         real-precision: [real32, real64]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,22 @@ on:
   # Allow running this workflow manually from the Actions tab
   workflow_dispatch:
 
-# concurrency:
-#   group: carpetx
-#   cancel-in-progress: false
+# Supersede an in-flight run when a newer commit arrives for the same branch.
+# Note this is *not* the repository-wide serialisation the previous, commented
+# out version of this block described (`group: carpetx`, cancel-in-progress
+# false): the group is per branch, so unrelated branches still build in
+# parallel, and a superseded run is cancelled rather than queued behind others.
+#
+# `head_ref` is the source branch on a `pull_request` and empty otherwise, so a
+# pull request groups by its own branch name and a push groups by its ref.
+# Cancelling is restricted to pull requests: a push to `main` or to an `ET_*`
+# branch should always finish, because that result is the record of whether the
+# commit built, and there is nothing to supersede it with.
+#
+# Unlike `fail-fast` and the `-testing` tags, this is meant to stay.
+concurrency:
+  group: ${{github.workflow}}-${{github.head_ref || github.ref}}
+  cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ on:
 # Cancelling is restricted to pull requests: a push to `main` or to an `ET_*`
 # branch should always finish, because that result is the record of whether the
 # commit built, and there is nothing to supersede it with.
-#
-# Unlike `fail-fast` and the `-testing` tags, this is meant to stay.
 concurrency:
   group: ${{github.workflow}}-${{github.head_ref || github.ref}}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
@@ -39,11 +37,6 @@ jobs:
   # This workflow contains a single job
   download-build-test:
     strategy:
-      # TEMPORARY, alongside the `-testing` tags below: with the default
-      # fail-fast the first failing job cancels the other seven, so a single
-      # error hides whatever the other images would have said. Remove this
-      # together with the `-testing` suffix before merging.
-      fail-fast: false
       matrix:
         accelerator: [cpu, cuda, rocm, oneapi]
         real-precision: [real32, real64]
@@ -61,15 +54,7 @@ jobs:
 
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    # TEMPORARY: the `-testing` tags. These are the MPI-ABI images -- MPI, HDF5
-    # and PETSc come from the ABI in /usr/local rather than from distribution
-    # packages -- built from the dockerfiles in `docker/` in this same branch.
-    # They are not yet published under the plain tags, so CI has to name the
-    # testing ones to exercise them at all.
-    # Revert this line to
-    #     container: einsteintoolkit/carpetx:${{matrix.accelerator}}-${{matrix.real-precision}}
-    # before merging, once the plain tags have been pushed.
-    container: einsteintoolkit/carpetx:${{matrix.accelerator}}-${{matrix.real-precision}}-testing
+    container: einsteintoolkit/carpetx:${{matrix.accelerator}}-${{matrix.real-precision}}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/docker/carpetx-arm64v8-cpu.dockerfile
+++ b/docker/carpetx-arm64v8-cpu.dockerfile
@@ -6,10 +6,86 @@
 #     docker build --build-arg real_precision=real32 --file carpetx-arm64v8-cpu.dockerfile --tag einsteintoolkit/carpetx:arm64v8-cpu-real32 .
 #     docker push einsteintoolkit/carpetx:arm64v8-cpu-real32
 
+# This is `carpetx-native-arm64v8-cpu.dockerfile` with every MPI-using library moved
+# onto the **MPI ABI** (MPI-5.0 §20.2) instead of the system Open MPI. Two
+# packages provide that ABI over the distribution's MPI:
+#
+#   mpi_abi_wrapper  the C bindings: `mpi.h`, `libmpi_abi`, `mpicc`, `mpicxx`
+#   mpif             the Fortran bindings: `mpif.h`, `mpi.mod`, `mpi_f08.mod`,
+#                    `libmpif`, `mpifort` -- needed because §20.4 leaves
+#                    `MPI_Fint` and the Fortran modules out of the ABI entirely
+#
+# Both install into `/usr/local`, so `/usr/local/bin/{mpicc,mpicxx,mpifort}` is
+# the toolchain every stanza below is pointed at, and `libmpi.so.40` must not
+# appear in the `ldd` output of anything this file installs. Which MPI actually
+# runs a binary is then a *run-time* choice: `libmpi_abi` dlopens the wrapper,
+# and another ABI-providing implementation can be put in front of it without
+# recompiling. `/usr/local/bin/mpiexec` is a **forwarder**, not a launcher:
+# starting a job stays the wrapped MPI's business, so it resolves that MPI's own
+# `mpiexec` -- `$MPI_ABI_WRAPPER_MPIEXEC`, else the path found beside
+# `MPI_C_COMPILER` at configure time -- and passes every argument through. That
+# is the same run-time indirection `libmpi_abi` uses to find `libmpiwrapper`, so
+# the launcher follows the library when a binary is re-pointed.
+#
+# Consequences for the apt list below:
+# - `libhdf5-dev` and `libpetsc-real-dev` are **gone**. Both are built here
+#   instead, over the ABI. PETSc drags in a whole parallel stack when installed
+#   from apt -- parallel HDF5, hypre, MUMPS, ScaLAPACK, PtScotch, SuperLU-DIST,
+#   CombBLAS, FFTW3-MPI -- every one of which links `libmpi.so.40`; dropping it
+#   removes all of them at once, and the PETSc built here has none of them.
+# - `libaec-dev` is **added**: it provides the szip encoder that Debian's HDF5
+#   was built with, which the HDF5 built here would otherwise lose.
+# - `libcurl4-openssl-dev` and `libjpeg-dev` are **added** because they were
+#   only ever present as transitive dependencies of `libpetsc-real-dev`, and
+#   dropping it took them with it. The Cactus option list points LIBCURL_DIR
+#   and LIBJPEG_DIR at /usr, so their absence stops the CST outright:
+#   "LIBJPEG not found at /usr". Naming them explicitly is right regardless --
+#   depending on PETSc to supply an image's libjpeg was always an accident.
+# - `python3-dev` is **added** for the same kind of reason. Conduit is built
+#   with `-DENABLE_PYTHON=ON`, so its `find_package(Python3 ... Development
+#   NumPy)` needs `Python.h` and the numpy headers; those arrived only as a
+#   transitive dependency of `libboost-all-dev`, by way of
+#   `libboost-python1.83-dev`. Naming it explicitly is right regardless, and is
+#   required outright in the images below that narrow Boost.
+# - `libopenmpi-dev` stays. It is the MPI being *wrapped*; nothing else in this
+#   image compiles against it.
+# - `libboost-all-dev` becomes **`libboost-filesystem-dev`**. The wide package
+#   drags in Boost.MPI, which links `libmpi.so.40` directly -- the one thing
+#   every other line here exists to avoid. Nothing links Boost.MPI today, so it
+#   was previously left alone with a note saying it must not start being used;
+#   the narrow package retires that caveat instead of restating it, and matches
+#   the accelerator variants, where the wide package is not merely untidy but
+#   reinstalls a second MPI outright.
+#   **Not plain `libboost-dev`**, which is the obvious narrowing and does not
+#   work: RePrimAnd's `meson.build` asks for `dependency('boost')`, and Meson's
+#   Boost detection wants to see boost *libraries* even when the dependency is
+#   header-only -- with headers alone it reports "Run-time dependency Boost
+#   found: NO (tried system)" and RePrimAnd stops. Measured on Ubuntu 26.04:
+#   `libboost-dev` installs 0 boost libraries and fails; `libboost-filesystem-dev`
+#   installs 6 and gives "Boost found: YES 1.90.0 (/usr)".
+#   `filesystem` is the right component to keep rather than an arbitrary one:
+#   `desert-arm64v8.cfg` sets `BOOST_LIBS="boost_filesystem"`, so Cactus does
+#   link it. Nothing else does -- CarpetX's own Boost use is header-only
+#   (`boost::math` in `repos/CarpetX/Algo/src/roots.hxx`) and RePrimAnd's
+#   `dependency('boost')` names no modules -- so for those it only has to be
+#   present to be found.
+#
+# The matching Cactus option list needs `MPI_DIR = /usr/local`,
+# `HDF5_DIR = /usr/local` (with `hdf5_hl_fortran`/`hdf5_fortran`, the CMake
+# spelling, rather than Debian's `hdf5hl_fortran`), and `PETSC_DIR = /usr/local`.
+
 # noble is ubuntu:24.04
 # FROM arm64v8/ubuntu:noble-20250714
 # FROM arm64v8/ubuntu:noble-20250805
-FROM arm64v8/ubuntu:noble-20251001
+# FROM arm64v8/ubuntu:noble-20251001
+# FROM arm64v8/ubuntu:noble-20251013
+# FROM arm64v8/ubuntu:noble-20260113
+# FROM arm64v8/ubuntu:noble-20260210.1
+# FROM arm64v8/ubuntu:noble-20260324
+# FROM arm64v8/ubuntu:noble-20260410
+# FROM arm64v8/ubuntu:noble-20260509.1
+# FROM arm64v8/ubuntu:resolute-20260610
+FROM arm64v8/ubuntu:resolute-20260811.1
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LANGUAGE=en_US.en \
@@ -25,6 +101,7 @@ WORKDIR /cactus
 #        python2
 RUN apt-get update && \
     apt-get --yes --no-install-recommends install \
+        bison \
         bzip2 \
         ca-certificates \
         clang-format \
@@ -33,6 +110,7 @@ RUN apt-get update && \
         cvs \
         diffutils \
         elfutils \
+        flex \
         g++ \
         gcc \
         gdb \
@@ -46,22 +124,23 @@ RUN apt-get update && \
         hwloc-nox \
         language-pack-en \
         less \
+        libaec-dev \
         libblosc-dev \
         libblosc2-dev \
-        libboost-all-dev \
+        libboost-filesystem-dev \
         libbz2-dev \
+        libcurl4-openssl-dev \
         libfftw3-dev \
         libgit2-dev \
         libgsl-dev \
-        libhdf5-dev \
         libhwloc-dev \
         libiberty-dev \
+        libjpeg-dev \
         liblz4-dev \
         liblzma-dev \
         libopenblas-dev \
         libopenmpi-dev \
         libpapi-dev \
-        libpetsc-real-dev \
         libprotobuf-dev \
         libreadline-dev \
         libtool \
@@ -82,12 +161,15 @@ RUN apt-get update && \
         pkgconf \
         protobuf-compiler \
         python3 \
+        python3-dev \
         python3-numpy \
         python3-pip \
         python3-requests \
+        python3-venv \
         rsync \
         subversion \
         tar \
+        unzip \
         vim \
         wget \
         xz-utils \
@@ -101,15 +183,15 @@ RUN apt-get update && \
 # Try to reuse build tools from Ubuntu, but do not use any libraries because HPC Toolkit is a bit iffy to install.
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/spack/spack/archive/refs/tags/v1.0.2.tar.gz && \
-    tar xzf v1.0.2.tar.gz && \
-    export SPACK_ROOT="$(pwd)/spack-1.0.2" && \
+    wget https://github.com/spack/spack/archive/refs/tags/v1.2.2.tar.gz && \
+    tar xzf v1.2.2.tar.gz && \
+    export SPACK_ROOT="$(pwd)/spack-1.2.2" && \
     mkdir -p "${HOME}/.spack" && \
     echo 'config: {install_tree: {root: /spack}}' >"${HOME}/.spack/config.yaml" && \
     . ${SPACK_ROOT}/share/spack/setup-env.sh && \
-    : wget https://github.com/spack/spack-packages/archive/refs/tags/v2025.07.0.tar.gz && \
-    : tar xzf v2025.07.0.tar.gz && \
-    : spack repo add $(pwd)/spack-packages-2025.07.0 && \
+    wget https://github.com/spack/spack-packages/archive/refs/tags/v2026.06.0.tar.gz && \
+    tar xzf v2026.06.0.tar.gz && \
+    spack repo add --scope site spack-packages-2026.06.0/repos/spack_repo/builtin && \
     spack external find \
         autoconf \
         automake \
@@ -132,37 +214,215 @@ RUN mkdir src && \
     true) && \
     rm -rf src "${HOME}/.spack"
 
-# # Install blosc2
-# # blosc2 is a compression library, comparable to zlib
-# RUN mkdir src && \
-#     (cd src && \
-#     wget https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.18.0.tar.gz && \
-#     tar xzf v2.18.0.tar.gz && \
-#     cd c-blosc2-2.18.0 && \
-#     cmake -B build -G Ninja \
-#         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-#         -DCMAKE_INSTALL_PREFIX=/usr/local \
-#         -DBUILD_BENCHMARKS=OFF \
-#         -DBUILD_EXAMPLES=OFF \
-#         -DBUILD_FUZZERS=OFF \
-#         -DBUILD_STATIC=OFF \
-#         -DBUILD_TESTS=OFF \
-#         -DPREFER_EXTERNAL_LZ4=ON  \
-#         -DPREFER_EXTERNAL_ZLIB=ON \
-#         -DPREFER_EXTERNAL_ZSTD=ON \
-#         && \
-#     cmake --build build && \
-#     cmake --install build && \
-#     true) && \
-#     rm -rf src
+# Install mpi_abi_wrapper
+# mpi_abi_wrapper wraps an MPI library and provides the MPI ABI
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/mpi_abi_wrapper/archive/refs/tags/v1.2.0.tar.gz && \
+    tar xzf v1.2.0.tar.gz && \
+    cd mpi_abi_wrapper-1.2.0 && \
+    cmake -B build -G Ninja \
+        -DBUILD_TESTING=OFF \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install mpif
+# mpif provides the Fortran bindings for the MPI ABI
+# - depends on mpi_abi_wrapper
+# The ABI is specified for C only: MPI-5.0 §20.4 leaves `MPI_Fint` and the
+# Fortran modules out of it deliberately, so `mpi.h` and `libmpi_abi` give a
+# Fortran caller nothing. mpif supplies `mpif.h`, `use mpi` and `use mpi_f08`
+# on top of them, and is what makes HDF5's Fortran interface, PETSc's Fortran
+# stubs and Cactus's own Fortran thorns possible over the ABI.
+# MPI_C_COMPILER is named explicitly rather than left to find_package(MPI):
+# CMake's FindMPI searches PATH, finds the system Open MPI's `mpicc` at
+# /usr/bin/mpicc, and mpif then stops with "MPI_C_LIBRARIES ... names no
+# libmpi_abi". MPI_HOME is what mpifort records as its default MPI prefix
+# (`mpifort -showme:mpiprefix`).
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/mpif/archive/refs/tags/v1.0.1.tar.gz && \
+    tar xzf v1.0.1.tar.gz && \
+    cd mpif-1.0.1 && \
+    cmake -B build -G Ninja \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_HOME=/usr/local \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# From here on, every find_package(MPI) must resolve to the ABI rather than to
+# the system Open MPI on PATH. The stanzas below say so explicitly with
+# -DMPI_C_COMPILER, but that does not reach a find_package(MPI) issued from
+# *inside* another package's config file -- and HDF5's `hdf5-config.cmake` does
+# exactly that, to rebuild the MPI::MPI_C target its exported targets depend
+# on. A consumer that merely links HDF5 therefore acquires an -lmpi against the
+# system MPI, silently: measured on SZ3's H5Z filter and on Silo, both of which
+# came out with a direct NEEDED on libmpi.so.40. MPI_HOME is a documented
+# FindMPI hint (`MPI_HINT_DIRS`, FindMPI.cmake) read from the environment, so
+# it reaches those nested calls where -D cannot.
+ENV MPI_HOME=/usr/local
+
+# Install HDF5
+# HDF5 is the I/O library nearly everything below reads and writes through
+# - depends on mpi_abi_wrapper (parallel I/O) and mpif (the Fortran interface)
+# Built here rather than taken from apt because Debian's parallel flavour
+# (`libhdf5-openmpi-dev`) links libmpi.so.40, and its serial flavour has no
+# MPI-IO at all. Cactus wants one HDF5 with all three language interfaces:
+# - HDF5_ALLOW_UNSUPPORTED is required because HDF5 refuses to combine the C++
+#   interface with parallel I/O. Debian's `libhdf5-openmpi-cpp` is built the
+#   same way; the C++ interface simply has no parallel entry points of its own.
+# - HDF5 2.x renamed two of these options from their 1.14 spellings, and both
+#   renames fail quietly rather than loudly: `ALLOW_UNSUPPORTED` became
+#   `HDF5_ALLOW_UNSUPPORTED` (that one does at least stop the configure), and
+#   `HDF5_ENABLE_Z_LIB_SUPPORT` became `HDF5_ENABLE_ZLIB_SUPPORT` -- the old
+#   name is merely reported as an unused variable, and the build then finishes
+#   with no zlib and hence no `deflate` filter at all.
+# - the CMake build spells the Fortran libraries `hdf5_fortran` /
+#   `hdf5_hl_fortran`, where Debian spells the latter `hdf5hl_fortran`. The
+#   Cactus option list has to follow this spelling.
+# - the `hdf5-filter-plugin*` and `hdf5-plugin-lzf` apt packages install their
+#   dynamically-loaded filters under /usr/lib/*/hdf5/{serial,openmpi}/plugins,
+#   built against Debian's `libhdf5_serial`. This build looks in
+#   /usr/local/hdf5/lib/plugin instead, so it does not load them -- which is
+#   the right outcome, since loading them would pull a second HDF5 with a
+#   different soname into the process. Those packages remain useful to apt's
+#   own /usr/bin/h5dump; a file needing one of those filters has to be read
+#   with that, not with /usr/local/bin/h5dump.
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/HDFGroup/hdf5/releases/download/2.2.0/hdf5-2.2.0.tar.gz && \
+    tar xzf hdf5-2.2.0.tar.gz && \
+    cd hdf5-2.2.0 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_STATIC_LIBS=OFF \
+        -DBUILD_TESTING=OFF \
+        -DHDF5_ALLOW_UNSUPPORTED=ON \
+        -DHDF5_BUILD_CPP_LIB=ON \
+        -DHDF5_BUILD_EXAMPLES=OFF \
+        -DHDF5_BUILD_FORTRAN=ON \
+        -DHDF5_BUILD_HL_LIB=ON \
+        -DHDF5_BUILD_TOOLS=ON \
+        -DHDF5_ENABLE_PARALLEL=ON \
+        -DHDF5_ENABLE_SZIP_ENCODING=ON \
+        -DHDF5_ENABLE_SZIP_SUPPORT=ON \
+        -DHDF5_ENABLE_ZLIB_SUPPORT=ON \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
+        -DMPI_Fortran_COMPILER=/usr/local/bin/mpifort \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install PETSc
+# PETSc provides the linear and nonlinear solvers CarpetX/PDESolvers uses
+# - depends on mpi_abi_wrapper, mpif, HDF5, and a BLAS/LAPACK
+#
+# The external packages below are the set an HPC site would normally enable,
+# and the reason they are here is CarpetX/PDESolvers: it assembles the whole
+# refinement hierarchy into one flat `MatCreateAIJ` and then chooses no
+# preconditioner in the source at all, so whatever PETSc defaults to (ILU
+# serially, block-Jacobi/ILU in parallel) is what ends up solving an elliptic
+# problem that wants multigrid. Every package here is reachable from
+# `PDESolvers::petsc_options` alone, with no code change:
+#
+#   hypre         BoomerAMG, the standard algebraic multigrid for exactly this
+#                 (`-pc_type hypre -pc_hypre_type boomeramg`). This is the one
+#                 that matters; the rest are supporting cast.
+#   MUMPS         parallel sparse direct (`-pc_type lu
+#                 -pc_factor_mat_solver_type mumps`) -- the fallback when AMG
+#                 stalls, and the usual coarse-grid solver
+#   SuperLU_DIST  the other parallel direct solver, same role
+#   SuperLU       serial direct
+#   SuiteSparse   UMFPACK / CHOLMOD / KLU, serial direct
+#   ScaLAPACK     required by MUMPS
+#   METIS         graph partitioning
+#   PT-Scotch     parallel partitioning and ordering, for MUMPS and SuperLU_DIST
+#
+# - **PT-Scotch rather than ParMETIS**, the other obvious choice for that last
+#   slot: ParMETIS is licensed for non-commercial research use only, so it must
+#   not go into an image that gets pushed to a registry. PT-Scotch is CeCILL-C,
+#   and its `libptscotchparmetisv3` answers the ParMETIS v3 API that MUMPS and
+#   SuperLU_DIST actually ask for. Debian's PETSc makes the same substitution
+#   for the same reason.
+# - **--download-* rather than a stanza each.** PETSc builds these with the
+#   compilers it was given, so they come out over the ABI automatically, and
+#   their versions stay matched to the PETSc release, which is the combination
+#   PETSc tests. Wiring eight packages up by hand and then persuading PETSc to
+#   accept them is the part that goes wrong.
+# - PT-Scotch generates its parsers at build time, which is why `flex` and
+#   `bison` are in the apt list above. Without them configure dies deep in the
+#   download stage with "PTScotch needs flex installed".
+# - --with-hdf5-dir draws a warning -- "Using version 2.2.0 of package HDF5,
+#   PETSc is tested with 1.14". Configure accepts it; nothing in Cactus uses
+#   PetscViewerHDF5, so this is availability rather than something relied on.
+#   Drop --with-hdf5-dir if it ever turns into a hard error.
+# - PETSc's configure compiles and runs small MPI programs; Open MPI refuses to
+#   initialise as root without OMPI_ALLOW_RUN_AS_ROOT, and this container is
+#   root. The variables are scoped to this RUN rather than set image-wide.
+# - --with-mpiexec names the ABI prefix's own `mpiexec`, which forwards to the
+#   wrapped MPI's launcher rather than being one. Naming the forwarder rather
+#   than /usr/bin/mpiexec keeps the recorded launcher correct if this image is
+#   later re-pointed at another MPI; PETSc would otherwise bake in whatever it
+#   found on PATH.
+# - the stock build installs `libpetsc.so` and `include/petsc.h` under one
+#   prefix, which is exactly the layout `ExternalLibraries-PETSc/src/detect.sh`
+#   looks for -- unlike Debian's `libpetsc_real.so` under /usr/lib/petsc.
+RUN mkdir src && \
+    (cd src && \
+    export OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 && \
+    wget https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.25.5.tar.gz && \
+    tar xzf petsc-3.25.5.tar.gz && \
+    cd petsc-3.25.5 && \
+    ./configure \
+        --prefix=/usr/local \
+        --download-hypre \
+        --download-metis \
+        --download-mumps \
+        --download-ptscotch \
+        --download-scalapack \
+        --download-suitesparse \
+        --download-superlu \
+        --download-superlu_dist \
+        --with-blaslapack-lib=-lopenblas \
+        --with-cc=/usr/local/bin/mpicc \
+        --with-cxx=/usr/local/bin/mpicxx \
+        --with-debugging=0 \
+        --with-fc=/usr/local/bin/mpifort \
+        --with-hdf5-dir=/usr/local \
+        --with-mpiexec=/usr/local/bin/mpiexec \
+        --with-shared-libraries=1 \
+        --with-x=0 \
+        COPTFLAGS=-O2 CXXOPTFLAGS=-O2 FOPTFLAGS=-O2 \
+        && \
+    make && \
+    make install && \
+    true) && \
+    rm -rf src
 
 # Install MGARD
 # MGARD is a lossy compression library
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/CODARcode/MGARD/archive/refs/tags/1.5.2.tar.gz && \
-    tar xzf 1.5.2.tar.gz && \
-    cd MGARD-1.5.2 && \
+    wget https://github.com/CODARcode/MGARD/archive/refs/tags/1.6.0.tar.gz && \
+    tar xzf 1.6.0.tar.gz && \
+    cd MGARD-1.6.0 && \
     cmake -B build -G Ninja \
         -DBUILD_TESTING=OFF \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -176,15 +436,58 @@ RUN mkdir src && \
     true) && \
     rm -rf src
 
+# Install SZ3
+# SZ3 is a lossy compression library
+# - BUILD_H5Z_FILTER links HDF5, which drags MPI in behind it; hence the
+#   compilers, even though SZ3 itself knows nothing about MPI
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/szcompressor/SZ3/releases/download/v3.3.2/SZ3-v3.3.2.zip && \
+    unzip SZ3-v3.3.2.zip && \
+    cd SZ3-master && \
+    cmake -B build -G Ninja \
+        -DBUILD_H5Z_FILTER=ON \
+        -DBUILD_MDZ=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
 # Install ADIOS2
 # ADIOS2 is a parallel I/O library, comparable to HDF5
 # - depends on blosc2
 # - depends on MGARD
+# - depends on mpi_abi_wrapper: ADIOS2 is built against the MPI ABI, not against
+#   the system MPI directly. ADIOS2 inserts its own `cmake/` at the front of
+#   CMAKE_MODULE_PATH and its `cmake/FindMPI.cmake` defers to CMake's bundled
+#   module, so pointing CMAKE_MODULE_PATH at mpi_abi_wrapper's FindMPI shim
+#   would be shadowed. Instead we name the wrappers, which CMake's own FindMPI
+#   interrogates with `-showme:compile` / `-showme:link` -- flags that
+#   mpi_abi_wrapper's `bin/mpicc` answers the way a real mpicc would.
+# - ADIOS2_USE_MPI=ON rather than the AUTO default, so that a failure to find
+#   the MPI ABI is an error here instead of a silently serial ADIOS2.
+#
+#     wget https://github.com/GTkorvo/dill/commit/94b4c437182318a0d446fb6f82511fac0e4f2516.patch && \
+#     (cd thirdparty/dill/dill && patch -p1 <../94b4c437182318a0d446fb6f82511fac0e4f2516.patch) && \
+#
+#     wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.12.0.tar.gz && \
+#     tar xzf v2.12.0.tar.gz && \
+#     cd ADIOS2-2.12.0 && \
+#
+#    wget https://github.com/ornladios/ADIOS2/archive/45035d24b4505b241037e2a1b35a4bbf1af782a8.tar.gz && \
+#    tar xzf 45035d24b4505b241037e2a1b35a4bbf1af782a8.tar.gz && \
+#    cd ADIOS2-45035d24b4505b241037e2a1b35a4bbf1af782a8 && \
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.10.2.tar.gz && \
-    tar xzf v2.10.2.tar.gz && \
-    cd ADIOS2-2.10.2 && \
+    wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.12.1.tar.gz && \
+    tar xzf v2.12.1.tar.gz && \
+    cd ADIOS2-2.12.1 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -197,7 +500,11 @@ RUN mkdir src && \
         -DADIOS2_USE_Fortran=OFF \
         -DADIOS2_USE_HDF5=ON \
         -DADIOS2_USE_MGARD=ON \
+        -DADIOS2_USE_MPI=ON \
+        -DADIOS2_USE_SZ3=ON \
         -DADIOS2_USE_ZFP=ON \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
     cmake --build build && \
     cmake --install build && \
@@ -209,9 +516,9 @@ RUN mkdir src && \
 # - depends on yaml-cpp
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/eschnett/asdf-cxx/archive/refs/tags/version/7.3.2.tar.gz && \
-    tar xzf 7.3.2.tar.gz && \
-    cd asdf-cxx-version-7.3.2 && \
+    wget https://github.com/eschnett/asdf-cxx/archive/refs/tags/version/8.0.0.tar.gz && \
+    tar xzf 8.0.0.tar.gz && \
+    cd asdf-cxx-version-8.0.0 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -224,7 +531,7 @@ RUN mkdir src && \
 
 # Install NSIMD
 # NSIMD allows writing explicitly SIMD-vectorized code
-# Note: This assumes that the system has x86_64 CPUs
+# Note: This assumes that the system has aarch64 (ARM) CPUs
 RUN mkdir src && \
     (cd src && \
     wget https://github.com/agenium-scale/nsimd/archive/refs/tags/v3.0.1.tar.gz && \
@@ -233,6 +540,7 @@ RUN mkdir src && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
         -Dsimd=aarch64 \
         && \
     cmake --build build && \
@@ -245,11 +553,20 @@ RUN mkdir src && \
 # Install openPMD-api
 # openPMD-api defines a standard for laying out AMR data in a file
 # - depends on ADIOS2
+# - depends on mpi_abi_wrapper, and this is not optional: openPMD calls
+#   find_package(MPI) itself, and left alone it finds the system Open MPI and
+#   then fails to link ADIOS2 -- "undefined reference to
+#   adios2::ADIOS::ADIOS(ompi_communicator_t*)", because ADIOS2's MPI_Comm is
+#   the ABI's. The subtler half is HDF5: it is *also* mandatory that
+#   find_package(HDF5) resolve to the ABI-built HDF5 in /usr/local, since
+#   openPMD hands an MPI_Comm to H5Pset_fapl_mpio. Mixing there does not fail
+#   to link -- C linkage hides the type mismatch -- it silently passes an ABI
+#   handle to a library expecting an ompi_communicator_t*.
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/openPMD/openPMD-api/archive/refs/tags/0.16.1.tar.gz && \
-    tar xzf 0.16.1.tar.gz && \
-    cd openPMD-api-0.16.1 && \
+    wget https://github.com/openPMD/openPMD-api/archive/refs/tags/0.17.1.tar.gz && \
+    tar xzf 0.17.1.tar.gz && \
+    cd openPMD-api-0.17.1 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -257,6 +574,8 @@ RUN mkdir src && \
         -DBUILD_TESTING=OFF \
         -DopenPMD_BUILD_SHARED_LIBS=ON \
         -DopenPMD_USE_MPI=ON \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
     cmake --build build && \
     cmake --install build && \
@@ -270,7 +589,7 @@ RUN mkdir src && \
     wget https://github.com/wokast/RePrimAnd/archive/refs/tags/v1.7.tar.gz && \
     tar xzf v1.7.tar.gz && \
     cd RePrimAnd-1.7 && \
-    meson build --buildtype=release --prefix=/usr/local && \
+    meson setup build --buildtype=release --prefix=/usr/local -Dcpp_std=c++14 && \
     ninja -C build && \
     ninja -C build install && \
     true) && \
@@ -278,38 +597,51 @@ RUN mkdir src && \
 
 # Install Silo
 # Silo defines a standard for laying out AMR data in a file
+# - Silo has no MPI of its own, but it links HDF5 and so inherits HDF5's MPI;
+#   the compilers are named for the same reason as in the SZ3 stanza
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/LLNL/Silo/releases/download/4.11.1/silo-4.11.1.tar.xz && \
-    tar xJf silo-4.11.1.tar.xz && \
-    cd silo-4.11.1 && \
-    mkdir build && \
-    cd build && \
-    ../configure \
-        --disable-fortran \
-        --disable-static \
-        --enable-optimization \
-        --enable-shared \
-        --with-hdf5=/usr/lib/aarch64-linux-gnu/hdf5/serial/include,/usr/lib/aarch64-linux-gnu/hdf5/serial/lib \
-        --prefix=/usr/local \
+    wget https://github.com/LLNL/Silo/releases/download/4.12.1/Silo-4.12.1.tar.xz && \
+    tar xJf Silo-4.12.1.tar.xz && \
+    cd Silo-4.12.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DSILO_BUILD_FOR_BSD_LICENSE=ON \
+        -DSILO_ENABLE_BROWSER=OFF \
+        -DSILO_ENABLE_FORTRAN=OFF \
+        -DSILO_ENABLE_HDF5=ON \
+        -DSILO_ENABLE_JSON=OFF \
+        -DSILO_ENABLE_PYTHON_MODULE=OFF \
+        -DSILO_ENABLE_SHARED=ON \
+        -DSILO_ENABLE_SILEX=OFF \
+        -DSILO_ENABLE_SILOCK=ON \
+        -DSILO_ENABLE_TESTS=OFF \
+        -DSILO_HDF5_SZIP_DIR=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
-    make -j$(nproc) && \
-    make -j$(nproc) install && \
+    cmake --build build && \
+    cmake --install build && \
     true) && \
     rm -rf src
 
 # Install Conduit
 # Conduit defines a standard for laying out AMR data in a file.
 # - depends on Silo
+# - depends on mpi_abi_wrapper: `libconduit_relay_mpi*` and
+#   `libconduit_blueprint_mpi` take an MPI_Comm across their public interface.
+#   HDF5_DIR moves from /usr to /usr/local for the same reason -- Conduit's
+#   relay writes HDF5, and the two must agree on what an MPI_Comm is.
 # TODO:
 # - enable CUDA? HIP?
 # -DADIOS_DIR=/usr/local   # conduit doesn't find ADIOS because there is no FindADIOS.cmake
 # -DZFP_DIR=/usr           # conduit doesn't find zfp because the library directory is wrong
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/LLNL/conduit/releases/download/v0.9.5/conduit-v0.9.5-src-with-blt.tar.gz && \
-    tar xzf conduit-v0.9.5-src-with-blt.tar.gz && \
-    cd conduit-v0.9.5 && \
+    wget https://github.com/LLNL/conduit/releases/download/v0.9.8/conduit-v0.9.8-src-with-blt.tar.gz && \
+    tar xzf conduit-v0.9.8-src-with-blt.tar.gz && \
+    cd conduit-v0.9.8 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -325,7 +657,9 @@ RUN mkdir src && \
         -DENABLE_RELAY_WEBSERVER=OFF \
         -DENABLE_TESTS=OFF \
         -DENABLE_UTILS=ON \
-        -DHDF5_DIR=/usr \
+        -DHDF5_DIR=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         -DSILO_DIR=/usr/local \
         -DZLIB_DIR=/usr \
         src \
@@ -348,7 +682,8 @@ RUN mkdir src && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
-        -DENABLE_ASDF_CXX=OFF \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        -DENABLE_ASDF_CXX=ON \
         && \
     cmake --build build && \
     cmake --install build && \
@@ -372,18 +707,47 @@ RUN mkdir src && \
     true) && \
     rm -rf src
 
+# # Install Fuka
+# RUN mkdir src
+# WORKDIR src
+# RUN git clone --branch ET_2025_05 https://bitbucket.org/fukaws/fuka
+# WORKDIR fuka
+# # Ensure this macro is defined at build time to enable multi-threaded importers
+# RUN sed -i -E 's%// #define DEFAULT_KAD_MEM%#define DEFAULT_KAD_MEM%' include/memory.hpp
+# WORKDIR build_release
+# RUN env HOME_KADATH=/cactus/src/fuka \
+#     cmake -B build -G Ninja \
+#         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+#         -DCMAKE_INSTALL_PREFIX=/usr/local \
+#         -DGRHAYL_EOS=OFF \
+#         -DPAR_VERSION=ON
+# RUN cmake --build build
+# WORKDIR ..
+# RUN cp lib/libkadath.a /usr/local/lib
+# RUN ls -l /cactus/src/fuka/include
+# RUN false
+# WORKDIR ../..
+# RUN rm -rf src
+# RUN echo
+# RUN ls -l /usr/local/include
+# RUN ls -l /usr/local/lib
+# RUN false
+
 ARG real_precision=real64
 
 # Install AMReX
 # AMReX provides adaptive mesh refinement
+# - depends on mpi_abi_wrapper: AMReX is where CarpetX's own communication
+#   happens, so its MPI_Comm has to be the same one Cactus calls MPI_Init on.
+#   AMReX_MPI defaults to ON and is left that way; only the compilers change.
 # - Enable Fortran for `docker/Dockerfile`
 # - Install this last because it changes most often
 # Should we keep the AMReX source tree around for debugging?
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/AMReX-Codes/amrex/archive/25.11.tar.gz && \
-    tar xzf 25.11.tar.gz && \
-    cd amrex-25.11 && \
+    wget https://github.com/AMReX-Codes/amrex/archive/26.01.tar.gz && \
+    tar xzf 26.01.tar.gz && \
+    cd amrex-26.01 && \
     case $real_precision in \
         real32) precision=SINGLE;; \
         real64) precision=DOUBLE;; \
@@ -398,6 +762,8 @@ RUN mkdir src && \
         -DAMReX_OMP=ON \
         -DAMReX_PARTICLES=ON \
         -DAMReX_PRECISION="$precision" \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
     cmake --build build && \
     cmake --install build && \

--- a/docker/carpetx-cpu.dockerfile
+++ b/docker/carpetx-cpu.dockerfile
@@ -6,12 +6,84 @@
 #     docker build --build-arg real_precision=real32 --file carpetx-cpu.dockerfile --tag einsteintoolkit/carpetx:cpu-real32 .
 #     docker push einsteintoolkit/carpetx:cpu-real32
 
+# This is `carpetx-native-cpu.dockerfile` with every MPI-using library moved
+# onto the **MPI ABI** (MPI-5.0 §20.2) instead of the system Open MPI. Two
+# packages provide that ABI over the distribution's MPI:
+#
+#   mpi_abi_wrapper  the C bindings: `mpi.h`, `libmpi_abi`, `mpicc`, `mpicxx`
+#   mpif             the Fortran bindings: `mpif.h`, `mpi.mod`, `mpi_f08.mod`,
+#                    `libmpif`, `mpifort` -- needed because §20.4 leaves
+#                    `MPI_Fint` and the Fortran modules out of the ABI entirely
+#
+# Both install into `/usr/local`, so `/usr/local/bin/{mpicc,mpicxx,mpifort}` is
+# the toolchain every stanza below is pointed at, and `libmpi.so.40` must not
+# appear in the `ldd` output of anything this file installs. Which MPI actually
+# runs a binary is then a *run-time* choice: `libmpi_abi` dlopens the wrapper,
+# and another ABI-providing implementation can be put in front of it without
+# recompiling. `/usr/local/bin/mpiexec` is a **forwarder**, not a launcher:
+# starting a job stays the wrapped MPI's business, so it resolves that MPI's own
+# `mpiexec` -- `$MPI_ABI_WRAPPER_MPIEXEC`, else the path found beside
+# `MPI_C_COMPILER` at configure time -- and passes every argument through. That
+# is the same run-time indirection `libmpi_abi` uses to find `libmpiwrapper`, so
+# the launcher follows the library when a binary is re-pointed.
+#
+# Consequences for the apt list below:
+# - `libhdf5-dev` and `libpetsc-real-dev` are **gone**. Both are built here
+#   instead, over the ABI. PETSc drags in a whole parallel stack when installed
+#   from apt -- parallel HDF5, hypre, MUMPS, ScaLAPACK, PtScotch, SuperLU-DIST,
+#   CombBLAS, FFTW3-MPI -- every one of which links `libmpi.so.40`; dropping it
+#   removes all of them at once, and the PETSc built here has none of them.
+# - `libaec-dev` is **added**: it provides the szip encoder that Debian's HDF5
+#   was built with, which the HDF5 built here would otherwise lose.
+# - `libcurl4-openssl-dev` and `libjpeg-dev` are **added** because they were
+#   only ever present as transitive dependencies of `libpetsc-real-dev`, and
+#   dropping it took them with it. The Cactus option list points LIBCURL_DIR
+#   and LIBJPEG_DIR at /usr, so their absence stops the CST outright:
+#   "LIBJPEG not found at /usr". Naming them explicitly is right regardless --
+#   depending on PETSc to supply an image's libjpeg was always an accident.
+# - `python3-dev` is **added** for the same kind of reason. Conduit is built
+#   with `-DENABLE_PYTHON=ON`, so its `find_package(Python3 ... Development
+#   NumPy)` needs `Python.h` and the numpy headers; those arrived only as a
+#   transitive dependency of `libboost-all-dev`, by way of
+#   `libboost-python1.83-dev`. Naming it explicitly is right regardless, and is
+#   required outright in the images below that narrow Boost.
+# - `libopenmpi-dev` stays. It is the MPI being *wrapped*; nothing else in this
+#   image compiles against it.
+# - `libboost-all-dev` becomes **`libboost-filesystem-dev`**. The wide package
+#   drags in Boost.MPI, which links `libmpi.so.40` directly -- the one thing
+#   every other line here exists to avoid. Nothing links Boost.MPI today, so it
+#   was previously left alone with a note saying it must not start being used;
+#   the narrow package retires that caveat instead of restating it, and matches
+#   the accelerator variants, where the wide package is not merely untidy but
+#   reinstalls a second MPI outright.
+#   **Not plain `libboost-dev`**, which is the obvious narrowing and does not
+#   work: RePrimAnd's `meson.build` asks for `dependency('boost')`, and Meson's
+#   Boost detection wants to see boost *libraries* even when the dependency is
+#   header-only -- with headers alone it reports "Run-time dependency Boost
+#   found: NO (tried system)" and RePrimAnd stops. Measured on Ubuntu 26.04:
+#   `libboost-dev` installs 0 boost libraries and fails; `libboost-filesystem-dev`
+#   installs 6 and gives "Boost found: YES 1.90.0 (/usr)".
+#   `filesystem` is the right component to keep rather than an arbitrary one:
+#   `desert-arm64v8.cfg` sets `BOOST_LIBS="boost_filesystem"`, so Cactus does
+#   link it. Nothing else does -- CarpetX's own Boost use is header-only
+#   (`boost::math` in `repos/CarpetX/Algo/src/roots.hxx`) and RePrimAnd's
+#   `dependency('boost')` names no modules -- so for those it only has to be
+#   present to be found.
+#
+# The matching Cactus option list needs `MPI_DIR = /usr/local`,
+# `HDF5_DIR = /usr/local` (with `hdf5_hl_fortran`/`hdf5_fortran`, the CMake
+# spelling, rather than Debian's `hdf5hl_fortran`), and `PETSC_DIR = /usr/local`.
+
 # noble is ubuntu:24.04
 # FROM amd64/ubuntu:noble-20250714
 # FROM amd64/ubuntu:noble-20250805
-FROM amd64/ubuntu:noble-20251001
-
-#TODO: try this?   FROM amd64/spack/ubuntu-noble:0.23.1
+# FROM amd64/ubuntu:noble-20251001
+# FROM amd64/ubuntu:noble-20251013
+# FROM amd64/ubuntu:noble-20260113
+# FROM amd64/ubuntu:noble-20260210.1
+# FROM amd64/ubuntu:noble-20260410
+# FROM amd64/ubuntu:noble-20260509.1
+FROM amd64/ubuntu:resolute-20260811.1
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LANGUAGE=en_US.en \
@@ -27,6 +99,7 @@ WORKDIR /cactus
 #        python2
 RUN apt-get update && \
     apt-get --yes --no-install-recommends install \
+        bison \
         bzip2 \
         ca-certificates \
         clang-format \
@@ -35,6 +108,7 @@ RUN apt-get update && \
         cvs \
         diffutils \
         elfutils \
+        flex \
         g++ \
         gcc \
         gdb \
@@ -48,22 +122,23 @@ RUN apt-get update && \
         hwloc-nox \
         language-pack-en \
         less \
+        libaec-dev \
         libblosc-dev \
         libblosc2-dev \
-        libboost-all-dev \
+        libboost-filesystem-dev \
         libbz2-dev \
+        libcurl4-openssl-dev \
         libfftw3-dev \
         libgit2-dev \
         libgsl-dev \
-        libhdf5-dev \
         libhwloc-dev \
         libiberty-dev \
+        libjpeg-dev \
         liblz4-dev \
         liblzma-dev \
         libopenblas-dev \
         libopenmpi-dev \
         libpapi-dev \
-        libpetsc-real-dev \
         libprotobuf-dev \
         libreadline-dev \
         libtool \
@@ -84,12 +159,15 @@ RUN apt-get update && \
         pkgconf \
         protobuf-compiler \
         python3 \
+        python3-dev \
         python3-numpy \
         python3-pip \
         python3-requests \
+        python3-venv \
         rsync \
         subversion \
         tar \
+        unzip \
         vim \
         wget \
         xz-utils \
@@ -103,12 +181,15 @@ RUN apt-get update && \
 # Try to reuse build tools from Ubuntu, but do not use any libraries because HPC Toolkit is a bit iffy to install.
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/spack/spack/archive/refs/tags/v1.0.2.tar.gz && \
-    tar xzf v1.0.2.tar.gz && \
-    export SPACK_ROOT="$(pwd)/spack-1.0.2" && \
+    wget https://github.com/spack/spack/archive/refs/tags/v1.2.2.tar.gz && \
+    tar xzf v1.2.2.tar.gz && \
+    export SPACK_ROOT="$(pwd)/spack-1.2.2" && \
     mkdir -p "${HOME}/.spack" && \
     echo 'config: {install_tree: {root: /spack}}' >"${HOME}/.spack/config.yaml" && \
     . ${SPACK_ROOT}/share/spack/setup-env.sh && \
+    wget https://github.com/spack/spack-packages/archive/refs/tags/v2026.06.0.tar.gz && \
+    tar xzf v2026.06.0.tar.gz && \
+    spack repo add --scope site spack-packages-2026.06.0/repos/spack_repo/builtin && \
     spack external find \
         autoconf \
         automake \
@@ -131,37 +212,215 @@ RUN mkdir src && \
     true) && \
     rm -rf src "${HOME}/.spack"
 
-# # Install blosc2
-# # blosc2 is a compression library, comparable to zlib
-# RUN mkdir src && \
-#     (cd src && \
-#     wget https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.18.0.tar.gz && \
-#     tar xzf v2.18.0.tar.gz && \
-#     cd c-blosc2-2.18.0 && \
-#     cmake -B build -G Ninja \
-#         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-#         -DCMAKE_INSTALL_PREFIX=/usr/local \
-#         -DBUILD_BENCHMARKS=OFF \
-#         -DBUILD_EXAMPLES=OFF \
-#         -DBUILD_FUZZERS=OFF \
-#         -DBUILD_STATIC=OFF \
-#         -DBUILD_TESTS=OFF \
-#         -DPREFER_EXTERNAL_LZ4=ON  \
-#         -DPREFER_EXTERNAL_ZLIB=ON \
-#         -DPREFER_EXTERNAL_ZSTD=ON \
-#         && \
-#     cmake --build build && \
-#     cmake --install build && \
-#     true) && \
-#     rm -rf src
+# Install mpi_abi_wrapper
+# mpi_abi_wrapper wraps an MPI library and provides the MPI ABI
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/mpi_abi_wrapper/archive/refs/tags/v1.2.0.tar.gz && \
+    tar xzf v1.2.0.tar.gz && \
+    cd mpi_abi_wrapper-1.2.0 && \
+    cmake -B build -G Ninja \
+        -DBUILD_TESTING=OFF \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install mpif
+# mpif provides the Fortran bindings for the MPI ABI
+# - depends on mpi_abi_wrapper
+# The ABI is specified for C only: MPI-5.0 §20.4 leaves `MPI_Fint` and the
+# Fortran modules out of it deliberately, so `mpi.h` and `libmpi_abi` give a
+# Fortran caller nothing. mpif supplies `mpif.h`, `use mpi` and `use mpi_f08`
+# on top of them, and is what makes HDF5's Fortran interface, PETSc's Fortran
+# stubs and Cactus's own Fortran thorns possible over the ABI.
+# MPI_C_COMPILER is named explicitly rather than left to find_package(MPI):
+# CMake's FindMPI searches PATH, finds the system Open MPI's `mpicc` at
+# /usr/bin/mpicc, and mpif then stops with "MPI_C_LIBRARIES ... names no
+# libmpi_abi". MPI_HOME is what mpifort records as its default MPI prefix
+# (`mpifort -showme:mpiprefix`).
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/mpif/archive/refs/tags/v1.0.1.tar.gz && \
+    tar xzf v1.0.1.tar.gz && \
+    cd mpif-1.0.1 && \
+    cmake -B build -G Ninja \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_HOME=/usr/local \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# From here on, every find_package(MPI) must resolve to the ABI rather than to
+# the system Open MPI on PATH. The stanzas below say so explicitly with
+# -DMPI_C_COMPILER, but that does not reach a find_package(MPI) issued from
+# *inside* another package's config file -- and HDF5's `hdf5-config.cmake` does
+# exactly that, to rebuild the MPI::MPI_C target its exported targets depend
+# on. A consumer that merely links HDF5 therefore acquires an -lmpi against the
+# system MPI, silently: measured on SZ3's H5Z filter and on Silo, both of which
+# came out with a direct NEEDED on libmpi.so.40. MPI_HOME is a documented
+# FindMPI hint (`MPI_HINT_DIRS`, FindMPI.cmake) read from the environment, so
+# it reaches those nested calls where -D cannot.
+ENV MPI_HOME=/usr/local
+
+# Install HDF5
+# HDF5 is the I/O library nearly everything below reads and writes through
+# - depends on mpi_abi_wrapper (parallel I/O) and mpif (the Fortran interface)
+# Built here rather than taken from apt because Debian's parallel flavour
+# (`libhdf5-openmpi-dev`) links libmpi.so.40, and its serial flavour has no
+# MPI-IO at all. Cactus wants one HDF5 with all three language interfaces:
+# - HDF5_ALLOW_UNSUPPORTED is required because HDF5 refuses to combine the C++
+#   interface with parallel I/O. Debian's `libhdf5-openmpi-cpp` is built the
+#   same way; the C++ interface simply has no parallel entry points of its own.
+# - HDF5 2.x renamed two of these options from their 1.14 spellings, and both
+#   renames fail quietly rather than loudly: `ALLOW_UNSUPPORTED` became
+#   `HDF5_ALLOW_UNSUPPORTED` (that one does at least stop the configure), and
+#   `HDF5_ENABLE_Z_LIB_SUPPORT` became `HDF5_ENABLE_ZLIB_SUPPORT` -- the old
+#   name is merely reported as an unused variable, and the build then finishes
+#   with no zlib and hence no `deflate` filter at all.
+# - the CMake build spells the Fortran libraries `hdf5_fortran` /
+#   `hdf5_hl_fortran`, where Debian spells the latter `hdf5hl_fortran`. The
+#   Cactus option list has to follow this spelling.
+# - the `hdf5-filter-plugin*` and `hdf5-plugin-lzf` apt packages install their
+#   dynamically-loaded filters under /usr/lib/*/hdf5/{serial,openmpi}/plugins,
+#   built against Debian's `libhdf5_serial`. This build looks in
+#   /usr/local/hdf5/lib/plugin instead, so it does not load them -- which is
+#   the right outcome, since loading them would pull a second HDF5 with a
+#   different soname into the process. Those packages remain useful to apt's
+#   own /usr/bin/h5dump; a file needing one of those filters has to be read
+#   with that, not with /usr/local/bin/h5dump.
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/HDFGroup/hdf5/releases/download/2.2.0/hdf5-2.2.0.tar.gz && \
+    tar xzf hdf5-2.2.0.tar.gz && \
+    cd hdf5-2.2.0 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_STATIC_LIBS=OFF \
+        -DBUILD_TESTING=OFF \
+        -DHDF5_ALLOW_UNSUPPORTED=ON \
+        -DHDF5_BUILD_CPP_LIB=ON \
+        -DHDF5_BUILD_EXAMPLES=OFF \
+        -DHDF5_BUILD_FORTRAN=ON \
+        -DHDF5_BUILD_HL_LIB=ON \
+        -DHDF5_BUILD_TOOLS=ON \
+        -DHDF5_ENABLE_PARALLEL=ON \
+        -DHDF5_ENABLE_SZIP_ENCODING=ON \
+        -DHDF5_ENABLE_SZIP_SUPPORT=ON \
+        -DHDF5_ENABLE_ZLIB_SUPPORT=ON \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
+        -DMPI_Fortran_COMPILER=/usr/local/bin/mpifort \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install PETSc
+# PETSc provides the linear and nonlinear solvers CarpetX/PDESolvers uses
+# - depends on mpi_abi_wrapper, mpif, HDF5, and a BLAS/LAPACK
+#
+# The external packages below are the set an HPC site would normally enable,
+# and the reason they are here is CarpetX/PDESolvers: it assembles the whole
+# refinement hierarchy into one flat `MatCreateAIJ` and then chooses no
+# preconditioner in the source at all, so whatever PETSc defaults to (ILU
+# serially, block-Jacobi/ILU in parallel) is what ends up solving an elliptic
+# problem that wants multigrid. Every package here is reachable from
+# `PDESolvers::petsc_options` alone, with no code change:
+#
+#   hypre         BoomerAMG, the standard algebraic multigrid for exactly this
+#                 (`-pc_type hypre -pc_hypre_type boomeramg`). This is the one
+#                 that matters; the rest are supporting cast.
+#   MUMPS         parallel sparse direct (`-pc_type lu
+#                 -pc_factor_mat_solver_type mumps`) -- the fallback when AMG
+#                 stalls, and the usual coarse-grid solver
+#   SuperLU_DIST  the other parallel direct solver, same role
+#   SuperLU       serial direct
+#   SuiteSparse   UMFPACK / CHOLMOD / KLU, serial direct
+#   ScaLAPACK     required by MUMPS
+#   METIS         graph partitioning
+#   PT-Scotch     parallel partitioning and ordering, for MUMPS and SuperLU_DIST
+#
+# - **PT-Scotch rather than ParMETIS**, the other obvious choice for that last
+#   slot: ParMETIS is licensed for non-commercial research use only, so it must
+#   not go into an image that gets pushed to a registry. PT-Scotch is CeCILL-C,
+#   and its `libptscotchparmetisv3` answers the ParMETIS v3 API that MUMPS and
+#   SuperLU_DIST actually ask for. Debian's PETSc makes the same substitution
+#   for the same reason.
+# - **--download-* rather than a stanza each.** PETSc builds these with the
+#   compilers it was given, so they come out over the ABI automatically, and
+#   their versions stay matched to the PETSc release, which is the combination
+#   PETSc tests. Wiring eight packages up by hand and then persuading PETSc to
+#   accept them is the part that goes wrong.
+# - PT-Scotch generates its parsers at build time, which is why `flex` and
+#   `bison` are in the apt list above. Without them configure dies deep in the
+#   download stage with "PTScotch needs flex installed".
+# - --with-hdf5-dir draws a warning -- "Using version 2.2.0 of package HDF5,
+#   PETSc is tested with 1.14". Configure accepts it; nothing in Cactus uses
+#   PetscViewerHDF5, so this is availability rather than something relied on.
+#   Drop --with-hdf5-dir if it ever turns into a hard error.
+# - PETSc's configure compiles and runs small MPI programs; Open MPI refuses to
+#   initialise as root without OMPI_ALLOW_RUN_AS_ROOT, and this container is
+#   root. The variables are scoped to this RUN rather than set image-wide.
+# - --with-mpiexec names the ABI prefix's own `mpiexec`, which forwards to the
+#   wrapped MPI's launcher rather than being one. Naming the forwarder rather
+#   than /usr/bin/mpiexec keeps the recorded launcher correct if this image is
+#   later re-pointed at another MPI; PETSc would otherwise bake in whatever it
+#   found on PATH.
+# - the stock build installs `libpetsc.so` and `include/petsc.h` under one
+#   prefix, which is exactly the layout `ExternalLibraries-PETSc/src/detect.sh`
+#   looks for -- unlike Debian's `libpetsc_real.so` under /usr/lib/petsc.
+RUN mkdir src && \
+    (cd src && \
+    export OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 && \
+    wget https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.25.5.tar.gz && \
+    tar xzf petsc-3.25.5.tar.gz && \
+    cd petsc-3.25.5 && \
+    ./configure \
+        --prefix=/usr/local \
+        --download-hypre \
+        --download-metis \
+        --download-mumps \
+        --download-ptscotch \
+        --download-scalapack \
+        --download-suitesparse \
+        --download-superlu \
+        --download-superlu_dist \
+        --with-blaslapack-lib=-lopenblas \
+        --with-cc=/usr/local/bin/mpicc \
+        --with-cxx=/usr/local/bin/mpicxx \
+        --with-debugging=0 \
+        --with-fc=/usr/local/bin/mpifort \
+        --with-hdf5-dir=/usr/local \
+        --with-mpiexec=/usr/local/bin/mpiexec \
+        --with-shared-libraries=1 \
+        --with-x=0 \
+        COPTFLAGS=-O2 CXXOPTFLAGS=-O2 FOPTFLAGS=-O2 \
+        && \
+    make && \
+    make install && \
+    true) && \
+    rm -rf src
 
 # Install MGARD
 # MGARD is a lossy compression library
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/CODARcode/MGARD/archive/refs/tags/1.5.2.tar.gz && \
-    tar xzf 1.5.2.tar.gz && \
-    cd MGARD-1.5.2 && \
+    wget https://github.com/CODARcode/MGARD/archive/refs/tags/1.6.0.tar.gz && \
+    tar xzf 1.6.0.tar.gz && \
+    cd MGARD-1.6.0 && \
     cmake -B build -G Ninja \
         -DBUILD_TESTING=OFF \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -175,15 +434,58 @@ RUN mkdir src && \
     true) && \
     rm -rf src
 
+# Install SZ3
+# SZ3 is a lossy compression library
+# - BUILD_H5Z_FILTER links HDF5, which drags MPI in behind it; hence the
+#   compilers, even though SZ3 itself knows nothing about MPI
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/szcompressor/SZ3/releases/download/v3.3.2/SZ3-v3.3.2.zip && \
+    unzip SZ3-v3.3.2.zip && \
+    cd SZ3-master && \
+    cmake -B build -G Ninja \
+        -DBUILD_H5Z_FILTER=ON \
+        -DBUILD_MDZ=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
 # Install ADIOS2
 # ADIOS2 is a parallel I/O library, comparable to HDF5
 # - depends on blosc2
 # - depends on MGARD
+# - depends on mpi_abi_wrapper: ADIOS2 is built against the MPI ABI, not against
+#   the system MPI directly. ADIOS2 inserts its own `cmake/` at the front of
+#   CMAKE_MODULE_PATH and its `cmake/FindMPI.cmake` defers to CMake's bundled
+#   module, so pointing CMAKE_MODULE_PATH at mpi_abi_wrapper's FindMPI shim
+#   would be shadowed. Instead we name the wrappers, which CMake's own FindMPI
+#   interrogates with `-showme:compile` / `-showme:link` -- flags that
+#   mpi_abi_wrapper's `bin/mpicc` answers the way a real mpicc would.
+# - ADIOS2_USE_MPI=ON rather than the AUTO default, so that a failure to find
+#   the MPI ABI is an error here instead of a silently serial ADIOS2.
+#
+#     wget https://github.com/GTkorvo/dill/commit/94b4c437182318a0d446fb6f82511fac0e4f2516.patch && \
+#     (cd thirdparty/dill/dill && patch -p1 <../94b4c437182318a0d446fb6f82511fac0e4f2516.patch) && \
+#
+#     wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.12.0.tar.gz && \
+#     tar xzf v2.12.0.tar.gz && \
+#     cd ADIOS2-2.12.0 && \
+#
+#    wget https://github.com/ornladios/ADIOS2/archive/45035d24b4505b241037e2a1b35a4bbf1af782a8.tar.gz && \
+#    tar xzf 45035d24b4505b241037e2a1b35a4bbf1af782a8.tar.gz && \
+#    cd ADIOS2-45035d24b4505b241037e2a1b35a4bbf1af782a8 && \
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.10.2.tar.gz && \
-    tar xzf v2.10.2.tar.gz && \
-    cd ADIOS2-2.10.2 && \
+    wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.12.1.tar.gz && \
+    tar xzf v2.12.1.tar.gz && \
+    cd ADIOS2-2.12.1 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -196,7 +498,11 @@ RUN mkdir src && \
         -DADIOS2_USE_Fortran=OFF \
         -DADIOS2_USE_HDF5=ON \
         -DADIOS2_USE_MGARD=ON \
+        -DADIOS2_USE_MPI=ON \
+        -DADIOS2_USE_SZ3=ON \
         -DADIOS2_USE_ZFP=ON \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
     cmake --build build && \
     cmake --install build && \
@@ -208,9 +514,9 @@ RUN mkdir src && \
 # - depends on yaml-cpp
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/eschnett/asdf-cxx/archive/refs/tags/version/7.3.2.tar.gz && \
-    tar xzf 7.3.2.tar.gz && \
-    cd asdf-cxx-version-7.3.2 && \
+    wget https://github.com/eschnett/asdf-cxx/archive/refs/tags/version/8.0.0.tar.gz && \
+    tar xzf 8.0.0.tar.gz && \
+    cd asdf-cxx-version-8.0.0 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -232,6 +538,7 @@ RUN mkdir src && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
         -Dsimd=AVX2 \
         && \
     cmake --build build && \
@@ -244,11 +551,20 @@ RUN mkdir src && \
 # Install openPMD-api
 # openPMD-api defines a standard for laying out AMR data in a file
 # - depends on ADIOS2
+# - depends on mpi_abi_wrapper, and this is not optional: openPMD calls
+#   find_package(MPI) itself, and left alone it finds the system Open MPI and
+#   then fails to link ADIOS2 -- "undefined reference to
+#   adios2::ADIOS::ADIOS(ompi_communicator_t*)", because ADIOS2's MPI_Comm is
+#   the ABI's. The subtler half is HDF5: it is *also* mandatory that
+#   find_package(HDF5) resolve to the ABI-built HDF5 in /usr/local, since
+#   openPMD hands an MPI_Comm to H5Pset_fapl_mpio. Mixing there does not fail
+#   to link -- C linkage hides the type mismatch -- it silently passes an ABI
+#   handle to a library expecting an ompi_communicator_t*.
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/openPMD/openPMD-api/archive/refs/tags/0.16.1.tar.gz && \
-    tar xzf 0.16.1.tar.gz && \
-    cd openPMD-api-0.16.1 && \
+    wget https://github.com/openPMD/openPMD-api/archive/refs/tags/0.17.1.tar.gz && \
+    tar xzf 0.17.1.tar.gz && \
+    cd openPMD-api-0.17.1 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -256,6 +572,8 @@ RUN mkdir src && \
         -DBUILD_TESTING=OFF \
         -DopenPMD_BUILD_SHARED_LIBS=ON \
         -DopenPMD_USE_MPI=ON \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
     cmake --build build && \
     cmake --install build && \
@@ -269,7 +587,7 @@ RUN mkdir src && \
     wget https://github.com/wokast/RePrimAnd/archive/refs/tags/v1.7.tar.gz && \
     tar xzf v1.7.tar.gz && \
     cd RePrimAnd-1.7 && \
-    meson build --buildtype=release --prefix=/usr/local && \
+    meson setup build --buildtype=release --prefix=/usr/local -Dcpp_std=c++14 && \
     ninja -C build && \
     ninja -C build install && \
     true) && \
@@ -277,38 +595,51 @@ RUN mkdir src && \
 
 # Install Silo
 # Silo defines a standard for laying out AMR data in a file
+# - Silo has no MPI of its own, but it links HDF5 and so inherits HDF5's MPI;
+#   the compilers are named for the same reason as in the SZ3 stanza
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/LLNL/Silo/releases/download/4.11.1/silo-4.11.1.tar.xz && \
-    tar xJf silo-4.11.1.tar.xz && \
-    cd silo-4.11.1 && \
-    mkdir build && \
-    cd build && \
-    ../configure \
-        --disable-fortran \
-        --disable-static \
-        --enable-optimization \
-        --enable-shared \
-        --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial/include,/usr/lib/x86_64-linux-gnu/hdf5/serial/lib \
-        --prefix=/usr/local \
+    wget https://github.com/LLNL/Silo/releases/download/4.12.1/Silo-4.12.1.tar.xz && \
+    tar xJf Silo-4.12.1.tar.xz && \
+    cd Silo-4.12.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DSILO_BUILD_FOR_BSD_LICENSE=ON \
+        -DSILO_ENABLE_BROWSER=OFF \
+        -DSILO_ENABLE_FORTRAN=OFF \
+        -DSILO_ENABLE_HDF5=ON \
+        -DSILO_ENABLE_JSON=OFF \
+        -DSILO_ENABLE_PYTHON_MODULE=OFF \
+        -DSILO_ENABLE_SHARED=ON \
+        -DSILO_ENABLE_SILEX=OFF \
+        -DSILO_ENABLE_SILOCK=ON \
+        -DSILO_ENABLE_TESTS=OFF \
+        -DSILO_HDF5_SZIP_DIR=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
-    make -j$(nproc) && \
-    make -j$(nproc) install && \
+    cmake --build build && \
+    cmake --install build && \
     true) && \
     rm -rf src
 
 # Install Conduit
 # Conduit defines a standard for laying out AMR data in a file.
 # - depends on Silo
+# - depends on mpi_abi_wrapper: `libconduit_relay_mpi*` and
+#   `libconduit_blueprint_mpi` take an MPI_Comm across their public interface.
+#   HDF5_DIR moves from /usr to /usr/local for the same reason -- Conduit's
+#   relay writes HDF5, and the two must agree on what an MPI_Comm is.
 # TODO:
 # - enable CUDA? HIP?
 # -DADIOS_DIR=/usr/local   # conduit doesn't find ADIOS because there is no FindADIOS.cmake
 # -DZFP_DIR=/usr           # conduit doesn't find zfp because the library directory is wrong
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/LLNL/conduit/releases/download/v0.9.5/conduit-v0.9.5-src-with-blt.tar.gz && \
-    tar xzf conduit-v0.9.5-src-with-blt.tar.gz && \
-    cd conduit-v0.9.5 && \
+    wget https://github.com/LLNL/conduit/releases/download/v0.9.8/conduit-v0.9.8-src-with-blt.tar.gz && \
+    tar xzf conduit-v0.9.8-src-with-blt.tar.gz && \
+    cd conduit-v0.9.8 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -324,7 +655,9 @@ RUN mkdir src && \
         -DENABLE_RELAY_WEBSERVER=OFF \
         -DENABLE_TESTS=OFF \
         -DENABLE_UTILS=ON \
-        -DHDF5_DIR=/usr \
+        -DHDF5_DIR=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         -DSILO_DIR=/usr/local \
         -DZLIB_DIR=/usr \
         src \
@@ -347,7 +680,8 @@ RUN mkdir src && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
-        -DENABLE_ASDF_CXX=OFF \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        -DENABLE_ASDF_CXX=ON \
         && \
     cmake --build build && \
     cmake --install build && \
@@ -371,18 +705,47 @@ RUN mkdir src && \
     true) && \
     rm -rf src
 
+# # Install Fuka
+# RUN mkdir src
+# WORKDIR src
+# RUN git clone --branch ET_2025_05 https://bitbucket.org/fukaws/fuka
+# WORKDIR fuka
+# # Ensure this macro is defined at build time to enable multi-threaded importers
+# RUN sed -i -E 's%// #define DEFAULT_KAD_MEM%#define DEFAULT_KAD_MEM%' include/memory.hpp
+# WORKDIR build_release
+# RUN env HOME_KADATH=/cactus/src/fuka \
+#     cmake -B build -G Ninja \
+#         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+#         -DCMAKE_INSTALL_PREFIX=/usr/local \
+#         -DGRHAYL_EOS=OFF \
+#         -DPAR_VERSION=ON
+# RUN cmake --build build
+# WORKDIR ..
+# RUN cp lib/libkadath.a /usr/local/lib
+# RUN ls -l /cactus/src/fuka/include
+# RUN false
+# WORKDIR ../..
+# RUN rm -rf src
+# RUN echo
+# RUN ls -l /usr/local/include
+# RUN ls -l /usr/local/lib
+# RUN false
+
 ARG real_precision=real64
 
 # Install AMReX
 # AMReX provides adaptive mesh refinement
+# - depends on mpi_abi_wrapper: AMReX is where CarpetX's own communication
+#   happens, so its MPI_Comm has to be the same one Cactus calls MPI_Init on.
+#   AMReX_MPI defaults to ON and is left that way; only the compilers change.
 # - Enable Fortran for `docker/Dockerfile`
 # - Install this last because it changes most often
 # Should we keep the AMReX source tree around for debugging?
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/AMReX-Codes/amrex/archive/25.11.tar.gz && \
-    tar xzf 25.11.tar.gz && \
-    cd amrex-25.11 && \
+    wget https://github.com/AMReX-Codes/amrex/archive/26.01.tar.gz && \
+    tar xzf 26.01.tar.gz && \
+    cd amrex-26.01 && \
     case $real_precision in \
         real32) precision=SINGLE;; \
         real64) precision=DOUBLE;; \
@@ -397,6 +760,8 @@ RUN mkdir src && \
         -DAMReX_OMP=ON \
         -DAMReX_PARTICLES=ON \
         -DAMReX_PRECISION="$precision" \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
     cmake --build build && \
     cmake --install build && \

--- a/docker/carpetx-cuda.dockerfile
+++ b/docker/carpetx-cuda.dockerfile
@@ -6,9 +6,118 @@
 #     docker build --build-arg real_precision=real32 --file carpetx-cuda.dockerfile --tag einsteintoolkit/carpetx:cuda-real32 .
 #     docker push einsteintoolkit/carpetx:cuda-real32
 
+# This is `carpetx-native-cuda.dockerfile` with every MPI-using library moved
+# onto the **MPI ABI** (MPI-5.0 §20.2) instead of a directly-linked MPI. Two
+# packages provide that ABI over the distribution's MPI:
+#
+#   mpi_abi_wrapper  the C bindings: `mpi.h`, `libmpi_abi`, `mpicc`, `mpicxx`
+#   mpif             the Fortran bindings: `mpif.h`, `mpi.mod`, `mpi_f08.mod`,
+#                    `libmpif`, `mpifort` -- needed because §20.4 leaves
+#                    `MPI_Fint` and the Fortran modules out of the ABI entirely
+#
+# Both install into `/usr/local`, so `/usr/local/bin/{mpicc,mpicxx,mpifort}` is
+# the toolchain every stanza below is pointed at, and `libmpi.so.40` must not
+# appear in the `ldd` output of anything this file installs. Which MPI actually
+# runs a binary is then a *run-time* choice: `libmpi_abi` dlopens the wrapper,
+# and another ABI-providing implementation can be put in front of it without
+# recompiling. `/usr/local/bin/mpiexec` is a **forwarder**, not a launcher:
+# starting a job stays the wrapped MPI's business, so it resolves that MPI's own
+# `mpiexec` -- `$MPI_ABI_WRAPPER_MPIEXEC`, else the path found beside
+# `MPI_C_COMPILER` at configure time -- and passes every argument through. That
+# is the same run-time indirection `libmpi_abi` uses to find `libmpiwrapper`, so
+# the launcher follows the library when a binary is re-pointed.
+#
+# Consequences for the apt list below:
+# - `libhdf5-dev` and `libpetsc-real-dev` are **gone**. Both are built here
+#   instead, over the ABI. PETSc drags in a whole parallel stack when installed
+#   from apt -- parallel HDF5, hypre, MUMPS, ScaLAPACK, PtScotch, SuperLU-DIST,
+#   CombBLAS, FFTW3-MPI -- every one of which links `libmpi.so.40`; dropping it
+#   removes all of them at once, and the PETSc built here has none of them.
+# - `libaec-dev` is **added**: it provides the szip encoder that Debian's HDF5
+#   was built with, which the HDF5 built here would otherwise lose.
+# - `libcurl4-openssl-dev` and `libjpeg-dev` are **added** because they were
+#   only ever present as transitive dependencies of `libpetsc-real-dev`, and
+#   dropping it took them with it. The Cactus option list points LIBCURL_DIR
+#   and LIBJPEG_DIR at /usr, so their absence stops the CST outright:
+#   "LIBJPEG not found at /usr". Naming them explicitly is right regardless --
+#   depending on PETSc to supply an image's libjpeg was always an accident.
+# - `python3-dev` is **added** for the same kind of reason. Conduit is built
+#   with `-DENABLE_PYTHON=ON`, so its `find_package(Python3 ... Development
+#   NumPy)` needs `Python.h` and the numpy headers; those arrived only as a
+#   transitive dependency of `libboost-all-dev`, by way of
+#   `libboost-python1.83-dev`. Naming it explicitly is right regardless, and is
+#   required outright in the images below that narrow Boost.
+# - `libopenmpi-dev` is **gone**. The MPI being wrapped here is the HPC SDK's
+#   CUDA-aware Open MPI, and there is to be exactly one MPI in the image.
+# - `libboost-all-dev` becomes **`libboost-filesystem-dev`**, and this is not
+#   cosmetic: `libboost-all-dev` depends on `libboost-mpi-dev`, which depends on
+#   `libopenmpi-dev`, so leaving it in would reinstall Ubuntu's Open MPI through
+#   the back door and defeat the line above. `libboost-filesystem-dev` reaches
+#   no MPI package at all (checked with `apt-cache depends --recurse`).
+#   **Not plain `libboost-dev`**, which is the obvious narrowing and does not
+#   work: RePrimAnd's `meson.build` asks for `dependency('boost')`, and Meson's
+#   Boost detection wants to see boost *libraries* even when the dependency is
+#   header-only -- with headers alone it reports "Run-time dependency Boost
+#   found: NO (tried system)" and RePrimAnd stops. Measured on Ubuntu 26.04:
+#   `libboost-dev` installs 0 boost libraries and fails; `libboost-filesystem-dev`
+#   installs 6 and gives "Boost found: YES 1.90.0 (/usr)".
+#   `filesystem` is the right component to keep rather than an arbitrary one:
+#   `desert-arm64v8.cfg` sets `BOOST_LIBS="boost_filesystem"`, so Cactus does
+#   link it. Nothing else does -- CarpetX's own Boost use is header-only
+#   (`boost::math` in `repos/CarpetX/Algo/src/roots.hxx`) and RePrimAnd's
+#   `dependency('boost')` names no modules -- so for those it only has to be
+#   present to be found.
+#
+# The matching Cactus option list needs `MPI_DIR = /usr/local`,
+# `HDF5_DIR = /usr/local` (with `hdf5_hl_fortran`/`hdf5_fortran`, the CMake
+# spelling, rather than Debian's `hdf5hl_fortran`), and `PETSC_DIR = /usr/local`.
+#
+# CUDA-specific notes:
+# - **the base image is the NVIDIA HPC SDK, not `nvidia/cuda`**, and the MPI
+#   being wrapped is the CUDA-aware Open MPI the SDK bundles, at
+#   `/opt/nvidia/hpc_sdk/Linux_x86_64/26.5/comm_libs/mpi`. That is the whole
+#   reason for the change of base: `nvidia/cuda` ships no MPI at all, so
+#   `carpetx-native-cuda.dockerfile` falls back on Ubuntu's Open MPI, which is built
+#   without CUDA support -- every GPU buffer it sends is staged through host
+#   memory. The SDK's build is CUDA-aware, and brings NCCL, NVSHMEM and gdrcopy
+#   with it.
+# - **the price is Ubuntu 24.04 and CUDA 13.2.** NVIDIA publishes no Ubuntu
+#   26.04 tag for the HPC SDK (checked: none of the 573 images in the
+#   repository), so this is the one file here that does not move to Ubuntu 26,
+#   and it steps back from CUDA 13.3.1 to the 13.2 the SDK carries. The
+#   `cuda13.2` variant is used rather than `cuda_multi`: 7.5 GB against 16.9 GB,
+#   and CarpetX needs exactly one CUDA.
+# - **PATH is reordered.** The SDK puts `comm_libs/mpi/bin` on PATH, so a bare
+#   `mpicc` would resolve to the *wrapped* MPI rather than to the ABI wrapper --
+#   the reverse of every other image here, where /usr/local/bin comes first.
+#   `/usr/local/bin` is prepended below to restore the usual meaning.
+# - the apt list is `carpetx-cpu.dockerfile`'s (minus `libopenmpi-dev`,
+#   with Boost narrowed), not `carpetx-native-cuda.dockerfile`'s. That file drops a
+#   dozen packages -- `make`, `patch`, `tar`, `xz-utils`, `bzip2`, ... -- because
+#   it builds neither HPCToolkit nor PETSc from source. The PETSc stanza below
+#   does, and `--download-*` needs those tools.
+# - nothing needs the nine hard-wired `-DMPI_*` variables that the ROCm and
+#   oneAPI files carry in their AMReX stanzas; `carpetx-native-cuda.dockerfile` never
+#   had them, and `-DMPI_C_COMPILER`/`-DMPI_CXX_COMPILER` are enough.
+
+# The nvidia/cuda images are `carpetx-native-cuda.dockerfile`'s history. They ship no
+# MPI; the HPC SDK does, and a CUDA-aware one. See the CUDA notes above.
+# FROM nvidia/cuda:12.6.3-devel-ubuntu24.04
 # FROM nvidia/cuda:12.9.1-devel-ubuntu24.04
 # FROM nvidia/cuda:13.0.0-devel-ubuntu24.04
-FROM nvidia/cuda:12.6.3-devel-ubuntu24.04
+# FROM nvidia/cuda:13.1.1-devel-ubuntu24.04
+# FROM nvidia/cuda:13.1.2-devel-ubuntu24.04
+# FROM nvidia/cuda:13.3.0-devel-ubuntu24.04
+# FROM nvidia/cuda:13.3.1-devel-ubuntu24.04
+# FROM nvidia/cuda:13.3.1-devel-ubuntu26.04
+# FROM nvcr.io/nvidia/nvhpc:26.5-devel-cuda_multi-ubuntu24.04
+FROM nvcr.io/nvidia/nvhpc:26.5-devel-cuda13.2-ubuntu24.04
+
+# The HPC SDK puts its own `comm_libs/mpi/bin` on PATH ahead of /usr/local/bin.
+# Everything below names the ABI wrappers by absolute path, so this is belt and
+# braces -- but it makes a bare `mpicc`, `mpicxx` or `mpiexec` mean the ABI
+# prefix's, as it does in every other image here.
+ENV PATH=/usr/local/bin:${PATH}
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LANGUAGE=en_US.en \
@@ -24,11 +133,16 @@ WORKDIR /cactus
 #        python2
 RUN apt-get update && \
     apt-get --yes --no-install-recommends install \
+        bison \
+        bzip2 \
         ca-certificates \
         clang-format \
         cmake \
+        curl \
         cvs \
         diffutils \
+        elfutils \
+        flex \
         g++ \
         gcc \
         gdb \
@@ -42,19 +156,22 @@ RUN apt-get update && \
         hwloc-nox \
         language-pack-en \
         less \
+        libaec-dev \
         libblosc-dev \
         libblosc2-dev \
-        libboost-all-dev \
+        libboost-filesystem-dev \
         libbz2-dev \
+        libcurl4-openssl-dev \
         libfftw3-dev \
         libgit2-dev \
         libgsl-dev \
-        libhdf5-dev \
         libhwloc-dev \
+        libiberty-dev \
+        libjpeg-dev \
         liblz4-dev \
+        liblzma-dev \
         libopenblas-dev \
-        libopenmpi-dev \
-        libpetsc-real-dev \
+        libpapi-dev \
         libprotobuf-dev \
         libreadline-dev \
         libtool \
@@ -64,40 +181,53 @@ RUN apt-get update && \
         libzstd-dev \
         locales \
         m4 \
+        make \
         meson \
         ninja-build \
         nlohmann-json3-dev \
         numactl \
+        papi-tools \
+        patch \
         perl \
         pkgconf \
         protobuf-compiler \
         python3 \
+        python3-dev \
         python3-numpy \
         python3-pip \
         python3-requests \
+        python3-venv \
         rsync \
         subversion \
+        tar \
+        unzip \
         vim \
         wget \
+        xz-utils \
         zlib1g-dev \
+        zstd \
         && \
     rm -rf /var/lib/apt/lists/*
 
 # # Install HPCToolkit
 # # Install this first because it is expensive to build
+# # HPCToolkit is not built here, matching `carpetx-native-cuda.dockerfile`.
 # RUN mkdir src && \
 #     (cd src && \
-#     wget https://github.com/spack/spack/archive/refs/tags/v1.0.2.tar.gz && \
-#     tar xzf v1.0.2.tar.gz && \
-#     export SPACK_ROOT="$(pwd)/spack-1.0.2" && \
+#     wget https://github.com/spack/spack/archive/refs/tags/v1.2.2.tar.gz && \
+#     tar xzf v1.2.2.tar.gz && \
+#     export SPACK_ROOT="$(pwd)/spack-1.2.2" && \
 #     mkdir -p "${HOME}/.spack" && \
 #     echo 'config: {install_tree: {root: /spack}}' >"${HOME}/.spack/config.yaml" && \
 #     . ${SPACK_ROOT}/share/spack/setup-env.sh && \
+#     wget https://github.com/spack/spack-packages/archive/refs/tags/v2026.06.0.tar.gz && \
+#     tar xzf v2026.06.0.tar.gz && \
+#     spack repo add --scope site spack-packages-2026.06.0/repos/spack_repo/builtin && \
 #     spack external find \
 #         autoconf \
 #         automake \
 #         cmake \
-#         cuda \
+#         curl \
 #         diffutils \
 #         elfutils \
 #         gmake \
@@ -110,43 +240,228 @@ RUN apt-get update && \
 #         pkgconf \
 #         python \
 #     && \
-#     spack install --fail-fast hpctoolkit +cuda ~viewer && \
+#     spack install --fail-fast hpctoolkit ~viewer && \
 #     spack view --dependencies no hardlink /hpctoolkit hpctoolkit && \
 #     true) && \
 #     rm -rf src "${HOME}/.spack"
 
-# # Install blosc2
-# # blosc2 is a compression library, comparable to zlib
-# RUN mkdir src && \
-#     (cd src && \
-#     wget https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.18.0.tar.gz && \
-#     tar xzf v2.18.0.tar.gz && \
-#     cd c-blosc2-2.18.0 && \
-#     cmake -B build -G Ninja \
-#         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-#         -DCMAKE_INSTALL_PREFIX=/usr/local \
-#         -DBUILD_BENCHMARKS=OFF \
-#         -DBUILD_EXAMPLES=OFF \
-#         -DBUILD_FUZZERS=OFF \
-#         -DBUILD_STATIC=OFF \
-#         -DBUILD_TESTS=OFF \
-#         -DPREFER_EXTERNAL_LZ4=ON  \
-#         -DPREFER_EXTERNAL_ZLIB=ON \
-#         -DPREFER_EXTERNAL_ZSTD=ON \
-#         && \
-#     cmake --build build && \
-#     cmake --install build && \
-#     true) && \
-#     rm -rf src
+# Install mpi_abi_wrapper
+# mpi_abi_wrapper wraps an MPI library and provides the MPI ABI
+# The MPI being wrapped is the HPC SDK's CUDA-aware Open MPI, named explicitly
+# because there is no reason to leave it to a PATH search. Wrapping it is what
+# makes the CUDA-awareness reach Cactus: `libmpi_abi` dlopens this build, so a
+# GPU pointer handed to MPI_Send stays a GPU pointer, and a different
+# implementation can still be put in front of it at run time without recompiling.
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/mpi_abi_wrapper/archive/refs/tags/v1.2.0.tar.gz && \
+    tar xzf v1.2.0.tar.gz && \
+    cd mpi_abi_wrapper-1.2.0 && \
+    cmake -B build -G Ninja \
+        -DBUILD_TESTING=OFF \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        -DMPI_C_COMPILER=/opt/nvidia/hpc_sdk/Linux_x86_64/26.5/comm_libs/mpi/bin/mpicc \
+        -DMPI_HOME=/opt/nvidia/hpc_sdk/Linux_x86_64/26.5/comm_libs/mpi \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install mpif
+# mpif provides the Fortran bindings for the MPI ABI
+# - depends on mpi_abi_wrapper
+# The ABI is specified for C only: MPI-5.0 §20.4 leaves `MPI_Fint` and the
+# Fortran modules out of it deliberately, so `mpi.h` and `libmpi_abi` give a
+# Fortran caller nothing. mpif supplies `mpif.h`, `use mpi` and `use mpi_f08`
+# on top of them, and is what makes HDF5's Fortran interface, PETSc's Fortran
+# stubs and Cactus's own Fortran thorns possible over the ABI.
+# MPI_C_COMPILER is named explicitly rather than left to find_package(MPI):
+# CMake's FindMPI searches PATH, finds the wrapped MPI's own `mpicc` -- the HPC
+# SDK's, in this image -- and mpif then stops with "MPI_C_LIBRARIES ... names no
+# libmpi_abi". MPI_HOME is what mpifort records as its default MPI prefix
+# (`mpifort -showme:mpiprefix`).
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/mpif/archive/refs/tags/v1.0.1.tar.gz && \
+    tar xzf v1.0.1.tar.gz && \
+    cd mpif-1.0.1 && \
+    cmake -B build -G Ninja \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_HOME=/usr/local \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# From here on, every find_package(MPI) must resolve to the ABI rather than to
+# the system Open MPI on PATH. The stanzas below say so explicitly with
+# -DMPI_C_COMPILER, but that does not reach a find_package(MPI) issued from
+# *inside* another package's config file -- and HDF5's `hdf5-config.cmake` does
+# exactly that, to rebuild the MPI::MPI_C target its exported targets depend
+# on. A consumer that merely links HDF5 therefore acquires an -lmpi against the
+# system MPI, silently: measured on SZ3's H5Z filter and on Silo, both of which
+# came out with a direct NEEDED on libmpi.so.40. MPI_HOME is a documented
+# FindMPI hint (`MPI_HINT_DIRS`, FindMPI.cmake) read from the environment, so
+# it reaches those nested calls where -D cannot.
+ENV MPI_HOME=/usr/local
+
+# Install HDF5
+# HDF5 is the I/O library nearly everything below reads and writes through
+# - depends on mpi_abi_wrapper (parallel I/O) and mpif (the Fortran interface)
+# Built here rather than taken from apt because Debian's parallel flavour
+# (`libhdf5-openmpi-dev`) links libmpi.so.40, and its serial flavour has no
+# MPI-IO at all. Cactus wants one HDF5 with all three language interfaces:
+# - HDF5_ALLOW_UNSUPPORTED is required because HDF5 refuses to combine the C++
+#   interface with parallel I/O. Debian's `libhdf5-openmpi-cpp` is built the
+#   same way; the C++ interface simply has no parallel entry points of its own.
+# - HDF5 2.x renamed two of these options from their 1.14 spellings, and both
+#   renames fail quietly rather than loudly: `ALLOW_UNSUPPORTED` became
+#   `HDF5_ALLOW_UNSUPPORTED` (that one does at least stop the configure), and
+#   `HDF5_ENABLE_Z_LIB_SUPPORT` became `HDF5_ENABLE_ZLIB_SUPPORT` -- the old
+#   name is merely reported as an unused variable, and the build then finishes
+#   with no zlib and hence no `deflate` filter at all.
+# - the CMake build spells the Fortran libraries `hdf5_fortran` /
+#   `hdf5_hl_fortran`, where Debian spells the latter `hdf5hl_fortran`. The
+#   Cactus option list has to follow this spelling.
+# - the `hdf5-filter-plugin*` and `hdf5-plugin-lzf` apt packages install their
+#   dynamically-loaded filters under /usr/lib/*/hdf5/{serial,openmpi}/plugins,
+#   built against Debian's `libhdf5_serial`. This build looks in
+#   /usr/local/hdf5/lib/plugin instead, so it does not load them -- which is
+#   the right outcome, since loading them would pull a second HDF5 with a
+#   different soname into the process. Those packages remain useful to apt's
+#   own /usr/bin/h5dump; a file needing one of those filters has to be read
+#   with that, not with /usr/local/bin/h5dump.
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/HDFGroup/hdf5/releases/download/2.2.0/hdf5-2.2.0.tar.gz && \
+    tar xzf hdf5-2.2.0.tar.gz && \
+    cd hdf5-2.2.0 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_STATIC_LIBS=OFF \
+        -DBUILD_TESTING=OFF \
+        -DHDF5_ALLOW_UNSUPPORTED=ON \
+        -DHDF5_BUILD_CPP_LIB=ON \
+        -DHDF5_BUILD_EXAMPLES=OFF \
+        -DHDF5_BUILD_FORTRAN=ON \
+        -DHDF5_BUILD_HL_LIB=ON \
+        -DHDF5_BUILD_TOOLS=ON \
+        -DHDF5_ENABLE_PARALLEL=ON \
+        -DHDF5_ENABLE_SZIP_ENCODING=ON \
+        -DHDF5_ENABLE_SZIP_SUPPORT=ON \
+        -DHDF5_ENABLE_ZLIB_SUPPORT=ON \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
+        -DMPI_Fortran_COMPILER=/usr/local/bin/mpifort \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install PETSc
+# PETSc provides the linear and nonlinear solvers CarpetX/PDESolvers uses
+# - depends on mpi_abi_wrapper, mpif, HDF5, and a BLAS/LAPACK
+#
+# The external packages below are the set an HPC site would normally enable,
+# and the reason they are here is CarpetX/PDESolvers: it assembles the whole
+# refinement hierarchy into one flat `MatCreateAIJ` and then chooses no
+# preconditioner in the source at all, so whatever PETSc defaults to (ILU
+# serially, block-Jacobi/ILU in parallel) is what ends up solving an elliptic
+# problem that wants multigrid. Every package here is reachable from
+# `PDESolvers::petsc_options` alone, with no code change:
+#
+#   hypre         BoomerAMG, the standard algebraic multigrid for exactly this
+#                 (`-pc_type hypre -pc_hypre_type boomeramg`). This is the one
+#                 that matters; the rest are supporting cast.
+#   MUMPS         parallel sparse direct (`-pc_type lu
+#                 -pc_factor_mat_solver_type mumps`) -- the fallback when AMG
+#                 stalls, and the usual coarse-grid solver
+#   SuperLU_DIST  the other parallel direct solver, same role
+#   SuperLU       serial direct
+#   SuiteSparse   UMFPACK / CHOLMOD / KLU, serial direct
+#   ScaLAPACK     required by MUMPS
+#   METIS         graph partitioning
+#   PT-Scotch     parallel partitioning and ordering, for MUMPS and SuperLU_DIST
+#
+# - **PT-Scotch rather than ParMETIS**, the other obvious choice for that last
+#   slot: ParMETIS is licensed for non-commercial research use only, so it must
+#   not go into an image that gets pushed to a registry. PT-Scotch is CeCILL-C,
+#   and its `libptscotchparmetisv3` answers the ParMETIS v3 API that MUMPS and
+#   SuperLU_DIST actually ask for. Debian's PETSc makes the same substitution
+#   for the same reason.
+# - **--download-* rather than a stanza each.** PETSc builds these with the
+#   compilers it was given, so they come out over the ABI automatically, and
+#   their versions stay matched to the PETSc release, which is the combination
+#   PETSc tests. Wiring eight packages up by hand and then persuading PETSc to
+#   accept them is the part that goes wrong.
+# - PT-Scotch generates its parsers at build time, which is why `flex` and
+#   `bison` are in the apt list above. Without them configure dies deep in the
+#   download stage with "PTScotch needs flex installed".
+# - --with-hdf5-dir draws a warning -- "Using version 2.2.0 of package HDF5,
+#   PETSc is tested with 1.14". Configure accepts it; nothing in Cactus uses
+#   PetscViewerHDF5, so this is availability rather than something relied on.
+#   Drop --with-hdf5-dir if it ever turns into a hard error.
+# - PETSc's configure compiles and runs small MPI programs; Open MPI refuses to
+#   initialise as root without OMPI_ALLOW_RUN_AS_ROOT, and this container is
+#   root. The variables are scoped to this RUN rather than set image-wide.
+# - --with-mpiexec names the ABI prefix's own `mpiexec`, which forwards to the
+#   wrapped MPI's launcher rather than being one. Naming the forwarder rather
+#   than /usr/bin/mpiexec keeps the recorded launcher correct if this image is
+#   later re-pointed at another MPI; PETSc would otherwise bake in whatever it
+#   found on PATH.
+# - the stock build installs `libpetsc.so` and `include/petsc.h` under one
+#   prefix, which is exactly the layout `ExternalLibraries-PETSc/src/detect.sh`
+#   looks for -- unlike Debian's `libpetsc_real.so` under /usr/lib/petsc.
+RUN mkdir src && \
+    (cd src && \
+    export OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 && \
+    wget https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.25.5.tar.gz && \
+    tar xzf petsc-3.25.5.tar.gz && \
+    cd petsc-3.25.5 && \
+    ./configure \
+        --prefix=/usr/local \
+        --download-hypre \
+        --download-metis \
+        --download-mumps \
+        --download-ptscotch \
+        --download-scalapack \
+        --download-suitesparse \
+        --download-superlu \
+        --download-superlu_dist \
+        --with-blaslapack-lib=-lopenblas \
+        --with-cc=/usr/local/bin/mpicc \
+        --with-cxx=/usr/local/bin/mpicxx \
+        --with-debugging=0 \
+        --with-fc=/usr/local/bin/mpifort \
+        --with-hdf5-dir=/usr/local \
+        --with-mpiexec=/usr/local/bin/mpiexec \
+        --with-shared-libraries=1 \
+        --with-x=0 \
+        COPTFLAGS=-O2 CXXOPTFLAGS=-O2 FOPTFLAGS=-O2 \
+        && \
+    make && \
+    make install && \
+    true) && \
+    rm -rf src
 
 # Install MGARD
 # MGARD is a lossy compression library
 # Note: -DMGARD_ENABLE_CUDA=ON requires nvcomp with a restrictive licence
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/CODARcode/MGARD/archive/refs/tags/1.5.2.tar.gz && \
-    tar xzf 1.5.2.tar.gz && \
-    cd MGARD-1.5.2 && \
+    wget https://github.com/CODARcode/MGARD/archive/refs/tags/1.6.0.tar.gz && \
+    tar xzf 1.6.0.tar.gz && \
+    cd MGARD-1.6.0 && \
     cmake -B build -G Ninja \
         -DBUILD_TESTING=OFF \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -160,15 +475,58 @@ RUN mkdir src && \
     true) && \
     rm -rf src
 
+# Install SZ3
+# SZ3 is a lossy compression library
+# - BUILD_H5Z_FILTER links HDF5, which drags MPI in behind it; hence the
+#   compilers, even though SZ3 itself knows nothing about MPI
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/szcompressor/SZ3/releases/download/v3.3.2/SZ3-v3.3.2.zip && \
+    unzip SZ3-v3.3.2.zip && \
+    cd SZ3-master && \
+    cmake -B build -G Ninja \
+        -DBUILD_H5Z_FILTER=ON \
+        -DBUILD_MDZ=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
 # Install ADIOS2
 # ADIOS2 is a parallel I/O library, comparable to HDF5
 # - depends on blosc2
 # - depends on MGARD
+# - depends on mpi_abi_wrapper: ADIOS2 is built against the MPI ABI, not against
+#   the system MPI directly. ADIOS2 inserts its own `cmake/` at the front of
+#   CMAKE_MODULE_PATH and its `cmake/FindMPI.cmake` defers to CMake's bundled
+#   module, so pointing CMAKE_MODULE_PATH at mpi_abi_wrapper's FindMPI shim
+#   would be shadowed. Instead we name the wrappers, which CMake's own FindMPI
+#   interrogates with `-showme:compile` / `-showme:link` -- flags that
+#   mpi_abi_wrapper's `bin/mpicc` answers the way a real mpicc would.
+# - ADIOS2_USE_MPI=ON rather than the AUTO default, so that a failure to find
+#   the MPI ABI is an error here instead of a silently serial ADIOS2.
+#
+#     wget https://github.com/GTkorvo/dill/commit/94b4c437182318a0d446fb6f82511fac0e4f2516.patch && \
+#     (cd thirdparty/dill/dill && patch -p1 <../94b4c437182318a0d446fb6f82511fac0e4f2516.patch) && \
+#
+#     wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.12.0.tar.gz && \
+#     tar xzf v2.12.0.tar.gz && \
+#     cd ADIOS2-2.12.0 && \
+#
+#    wget https://github.com/ornladios/ADIOS2/archive/45035d24b4505b241037e2a1b35a4bbf1af782a8.tar.gz && \
+#    tar xzf 45035d24b4505b241037e2a1b35a4bbf1af782a8.tar.gz && \
+#    cd ADIOS2-45035d24b4505b241037e2a1b35a4bbf1af782a8 && \
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.10.2.tar.gz && \
-    tar xzf v2.10.2.tar.gz && \
-    cd ADIOS2-2.10.2 && \
+    wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.12.1.tar.gz && \
+    tar xzf v2.12.1.tar.gz && \
+    cd ADIOS2-2.12.1 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -181,7 +539,11 @@ RUN mkdir src && \
         -DADIOS2_USE_Fortran=OFF \
         -DADIOS2_USE_HDF5=ON \
         -DADIOS2_USE_MGARD=ON \
+        -DADIOS2_USE_MPI=ON \
+        -DADIOS2_USE_SZ3=ON \
         -DADIOS2_USE_ZFP=ON \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
     cmake --build build && \
     cmake --install build && \
@@ -193,9 +555,9 @@ RUN mkdir src && \
 # - depends on yaml-cpp
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/eschnett/asdf-cxx/archive/refs/tags/version/7.3.2.tar.gz && \
-    tar xzf 7.3.2.tar.gz && \
-    cd asdf-cxx-version-7.3.2 && \
+    wget https://github.com/eschnett/asdf-cxx/archive/refs/tags/version/8.0.0.tar.gz && \
+    tar xzf 8.0.0.tar.gz && \
+    cd asdf-cxx-version-8.0.0 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -217,6 +579,7 @@ RUN mkdir src && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
         -Dsimd=AVX2 \
         && \
     cmake --build build && \
@@ -229,11 +592,20 @@ RUN mkdir src && \
 # Install openPMD-api
 # openPMD-api defines a standard for laying out AMR data in a file
 # - depends on ADIOS2
+# - depends on mpi_abi_wrapper, and this is not optional: openPMD calls
+#   find_package(MPI) itself, and left alone it finds the system Open MPI and
+#   then fails to link ADIOS2 -- "undefined reference to
+#   adios2::ADIOS::ADIOS(ompi_communicator_t*)", because ADIOS2's MPI_Comm is
+#   the ABI's. The subtler half is HDF5: it is *also* mandatory that
+#   find_package(HDF5) resolve to the ABI-built HDF5 in /usr/local, since
+#   openPMD hands an MPI_Comm to H5Pset_fapl_mpio. Mixing there does not fail
+#   to link -- C linkage hides the type mismatch -- it silently passes an ABI
+#   handle to a library expecting an ompi_communicator_t*.
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/openPMD/openPMD-api/archive/refs/tags/0.16.1.tar.gz && \
-    tar xzf 0.16.1.tar.gz && \
-    cd openPMD-api-0.16.1 && \
+    wget https://github.com/openPMD/openPMD-api/archive/refs/tags/0.17.1.tar.gz && \
+    tar xzf 0.17.1.tar.gz && \
+    cd openPMD-api-0.17.1 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -241,6 +613,8 @@ RUN mkdir src && \
         -DBUILD_TESTING=OFF \
         -DopenPMD_BUILD_SHARED_LIBS=ON \
         -DopenPMD_USE_MPI=ON \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
     cmake --build build && \
     cmake --install build && \
@@ -254,7 +628,7 @@ RUN mkdir src && \
     wget https://github.com/wokast/RePrimAnd/archive/refs/tags/v1.7.tar.gz && \
     tar xzf v1.7.tar.gz && \
     cd RePrimAnd-1.7 && \
-    meson build --buildtype=release --prefix=/usr/local && \
+    meson setup build --buildtype=release --prefix=/usr/local -Dcpp_std=c++14 && \
     ninja -C build && \
     ninja -C build install && \
     true) && \
@@ -262,38 +636,51 @@ RUN mkdir src && \
 
 # Install Silo
 # Silo defines a standard for laying out AMR data in a file
+# - Silo has no MPI of its own, but it links HDF5 and so inherits HDF5's MPI;
+#   the compilers are named for the same reason as in the SZ3 stanza
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/LLNL/Silo/releases/download/4.11.1/silo-4.11.1.tar.xz && \
-    tar xJf silo-4.11.1.tar.xz && \
-    cd silo-4.11.1 && \
-    mkdir build && \
-    cd build && \
-    ../configure \
-        --disable-fortran \
-        --disable-static \
-        --enable-optimization \
-        --enable-shared \
-        --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial/include,/usr/lib/x86_64-linux-gnu/hdf5/serial/lib \
-        --prefix=/usr/local \
+    wget https://github.com/LLNL/Silo/releases/download/4.12.1/Silo-4.12.1.tar.xz && \
+    tar xJf Silo-4.12.1.tar.xz && \
+    cd Silo-4.12.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DSILO_BUILD_FOR_BSD_LICENSE=ON \
+        -DSILO_ENABLE_BROWSER=OFF \
+        -DSILO_ENABLE_FORTRAN=OFF \
+        -DSILO_ENABLE_HDF5=ON \
+        -DSILO_ENABLE_JSON=OFF \
+        -DSILO_ENABLE_PYTHON_MODULE=OFF \
+        -DSILO_ENABLE_SHARED=ON \
+        -DSILO_ENABLE_SILEX=OFF \
+        -DSILO_ENABLE_SILOCK=ON \
+        -DSILO_ENABLE_TESTS=OFF \
+        -DSILO_HDF5_SZIP_DIR=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
-    make -j$(nproc) && \
-    make -j$(nproc) install && \
+    cmake --build build && \
+    cmake --install build && \
     true) && \
     rm -rf src
 
 # Install Conduit
 # Conduit defines a standard for laying out AMR data in a file.
 # - depends on Silo
+# - depends on mpi_abi_wrapper: `libconduit_relay_mpi*` and
+#   `libconduit_blueprint_mpi` take an MPI_Comm across their public interface.
+#   HDF5_DIR moves from /usr to /usr/local for the same reason -- Conduit's
+#   relay writes HDF5, and the two must agree on what an MPI_Comm is.
 # TODO:
 # - enable CUDA? HIP?
 # -DADIOS_DIR=/usr/local   # conduit doesn't find ADIOS because there is no FindADIOS.cmake
 # -DZFP_DIR=/usr           # conduit doesn't find zfp because the library directory is wrong
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/LLNL/conduit/releases/download/v0.9.5/conduit-v0.9.5-src-with-blt.tar.gz && \
-    tar xzf conduit-v0.9.5-src-with-blt.tar.gz && \
-    cd conduit-v0.9.5 && \
+    wget https://github.com/LLNL/conduit/releases/download/v0.9.8/conduit-v0.9.8-src-with-blt.tar.gz && \
+    tar xzf conduit-v0.9.8-src-with-blt.tar.gz && \
+    cd conduit-v0.9.8 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -309,7 +696,9 @@ RUN mkdir src && \
         -DENABLE_RELAY_WEBSERVER=OFF \
         -DENABLE_TESTS=OFF \
         -DENABLE_UTILS=ON \
-        -DHDF5_DIR=/usr \
+        -DHDF5_DIR=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         -DSILO_DIR=/usr/local \
         -DZLIB_DIR=/usr \
         src \
@@ -332,7 +721,8 @@ RUN mkdir src && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
-        -DENABLE_ASDF_CXX=OFF \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        -DENABLE_ASDF_CXX=ON \
         && \
     cmake --build build && \
     cmake --install build && \
@@ -356,18 +746,47 @@ RUN mkdir src && \
     true) && \
     rm -rf src
 
+# # Install Fuka
+# RUN mkdir src
+# WORKDIR src
+# RUN git clone --branch ET_2025_05 https://bitbucket.org/fukaws/fuka
+# WORKDIR fuka
+# # Ensure this macro is defined at build time to enable multi-threaded importers
+# RUN sed -i -E 's%// #define DEFAULT_KAD_MEM%#define DEFAULT_KAD_MEM%' include/memory.hpp
+# WORKDIR build_release
+# RUN env HOME_KADATH=/cactus/src/fuka \
+#     cmake -B build -G Ninja \
+#         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+#         -DCMAKE_INSTALL_PREFIX=/usr/local \
+#         -DGRHAYL_EOS=OFF \
+#         -DPAR_VERSION=ON
+# RUN cmake --build build
+# WORKDIR ..
+# RUN cp lib/libkadath.a /usr/local/lib
+# RUN ls -l /cactus/src/fuka/include
+# RUN false
+# WORKDIR ../..
+# RUN rm -rf src
+# RUN echo
+# RUN ls -l /usr/local/include
+# RUN ls -l /usr/local/lib
+# RUN false
+
 ARG real_precision=real64
 
 # Install AMReX
 # AMReX provides adaptive mesh refinement
+# - depends on mpi_abi_wrapper: AMReX is where CarpetX's own communication
+#   happens, so its MPI_Comm has to be the same one Cactus calls MPI_Init on.
+#   AMReX_MPI defaults to ON and is left that way; only the compilers change.
 # - Enable Fortran for `docker/Dockerfile`
 # - Install this last because it changes most often
 # Should we keep the AMReX source tree around for debugging?
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/AMReX-Codes/amrex/archive/25.11.tar.gz && \
-    tar xzf 25.11.tar.gz && \
-    cd amrex-25.11 && \
+    wget https://github.com/AMReX-Codes/amrex/archive/26.01.tar.gz && \
+    tar xzf 26.01.tar.gz && \
+    cd amrex-26.01 && \
     case $real_precision in \
         real32) precision=SINGLE;; \
         real64) precision=DOUBLE;; \
@@ -384,6 +803,8 @@ RUN mkdir src && \
         -DAMReX_OMP=ON \
         -DAMReX_PARTICLES=ON \
         -DAMReX_PRECISION="$precision" \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
     cmake --build build && \
     cmake --install build && \

--- a/docker/carpetx-native-arm64v8-cpu.dockerfile
+++ b/docker/carpetx-native-arm64v8-cpu.dockerfile
@@ -1,0 +1,458 @@
+# How to build this Docker image:
+
+#     docker build --file carpetx-native-arm64v8-cpu.dockerfile --tag einsteintoolkit/carpetx:native-arm64v8-cpu-real64 .
+#     docker push einsteintoolkit/carpetx:native-arm64v8-cpu-real64
+
+#     docker build --build-arg real_precision=real32 --file carpetx-native-arm64v8-cpu.dockerfile --tag einsteintoolkit/carpetx:native-arm64v8-cpu-real32 .
+#     docker push einsteintoolkit/carpetx:native-arm64v8-cpu-real32
+
+# noble is ubuntu:24.04
+# FROM arm64v8/ubuntu:noble-20250714
+# FROM arm64v8/ubuntu:noble-20250805
+# FROM arm64v8/ubuntu:noble-20251001
+# FROM arm64v8/ubuntu:noble-20251013
+# FROM arm64v8/ubuntu:noble-20260113
+# FROM arm64v8/ubuntu:noble-20260210.1
+# FROM arm64v8/ubuntu:noble-20260324
+# FROM arm64v8/ubuntu:noble-20260410
+# FROM arm64v8/ubuntu:noble-20260509.1
+# FROM arm64v8/ubuntu:resolute-20260610
+FROM arm64v8/ubuntu:resolute-20260811.1
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANGUAGE=en_US.en \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
+
+RUN mkdir /cactus
+WORKDIR /cactus
+
+# Install system packages
+# - Boost on Ubuntu requires OpenMPI
+#        elfutils
+#        python2
+RUN apt-get update && \
+    apt-get --yes --no-install-recommends install \
+        bzip2 \
+        ca-certificates \
+        clang-format \
+        cmake \
+        curl \
+        cvs \
+        diffutils \
+        elfutils \
+        g++ \
+        gcc \
+        gdb \
+        gfortran \
+        git \
+        hdf5-filter-plugin \
+        hdf5-filter-plugin-blosc-serial \
+        hdf5-filter-plugin-zfp-serial \
+        hdf5-plugin-lzf \
+        hdf5-tools \
+        hwloc-nox \
+        language-pack-en \
+        less \
+        libblosc-dev \
+        libblosc2-dev \
+        libboost-all-dev \
+        libbz2-dev \
+        libfftw3-dev \
+        libgit2-dev \
+        libgsl-dev \
+        libhdf5-dev \
+        libhwloc-dev \
+        libiberty-dev \
+        liblz4-dev \
+        liblzma-dev \
+        libopenblas-dev \
+        libopenmpi-dev \
+        libpapi-dev \
+        libpetsc-real-dev \
+        libprotobuf-dev \
+        libreadline-dev \
+        libtool \
+        libudev-dev \
+        libyaml-cpp-dev \
+        libzfp-dev \
+        libzstd-dev \
+        locales \
+        m4 \
+        make \
+        meson \
+        ninja-build \
+        nlohmann-json3-dev \
+        numactl \
+        papi-tools \
+        patch \
+        perl \
+        pkgconf \
+        protobuf-compiler \
+        python3 \
+        python3-numpy \
+        python3-pip \
+        python3-requests \
+        python3-venv \
+        rsync \
+        subversion \
+        tar \
+        unzip \
+        vim \
+        wget \
+        xz-utils \
+        zlib1g-dev \
+        zstd \
+        && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install HPCToolkit
+# Install this first because it is expensive to build
+# Try to reuse build tools from Ubuntu, but do not use any libraries because HPC Toolkit is a bit iffy to install.
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/spack/spack/archive/refs/tags/v1.2.2.tar.gz && \
+    tar xzf v1.2.2.tar.gz && \
+    export SPACK_ROOT="$(pwd)/spack-1.2.2" && \
+    mkdir -p "${HOME}/.spack" && \
+    echo 'config: {install_tree: {root: /spack}}' >"${HOME}/.spack/config.yaml" && \
+    . ${SPACK_ROOT}/share/spack/setup-env.sh && \
+    wget https://github.com/spack/spack-packages/archive/refs/tags/v2026.06.0.tar.gz && \
+    tar xzf v2026.06.0.tar.gz && \
+    spack repo add --scope site spack-packages-2026.06.0/repos/spack_repo/builtin && \
+    spack external find \
+        autoconf \
+        automake \
+        cmake \
+        curl \
+        diffutils \
+        elfutils \
+        gmake \
+        libtool \
+        m4 \
+        meson \
+        ninja \
+        numactl \
+        perl \
+        pkgconf \
+        python \
+    && \
+    spack install --fail-fast hpctoolkit ~viewer && \
+    spack view --dependencies no hardlink /hpctoolkit hpctoolkit && \
+    true) && \
+    rm -rf src "${HOME}/.spack"
+
+# Install MGARD
+# MGARD is a lossy compression library
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/CODARcode/MGARD/archive/refs/tags/1.6.0.tar.gz && \
+    tar xzf 1.6.0.tar.gz && \
+    cd MGARD-1.6.0 && \
+    cmake -B build -G Ninja \
+        -DBUILD_TESTING=OFF \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        -DMGARD_ENABLE_OPENMP=ON \
+        -DMGARD_ENABLE_SERIAL=ON \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install SZ3
+# SZ3 is a lossy compression library
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/szcompressor/SZ3/releases/download/v3.3.2/SZ3-v3.3.2.zip && \
+    unzip SZ3-v3.3.2.zip && \
+    cd SZ3-master && \
+    cmake -B build -G Ninja \
+        -DBUILD_H5Z_FILTER=ON \
+        -DBUILD_MDZ=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install ADIOS2
+# ADIOS2 is a parallel I/O library, comparable to HDF5
+# - depends on blosc2
+# - depends on MGARD
+#
+#     wget https://github.com/GTkorvo/dill/commit/94b4c437182318a0d446fb6f82511fac0e4f2516.patch && \
+#     (cd thirdparty/dill/dill && patch -p1 <../94b4c437182318a0d446fb6f82511fac0e4f2516.patch) && \
+#
+#     wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.12.0.tar.gz && \
+#     tar xzf v2.12.0.tar.gz && \
+#     cd ADIOS2-2.12.0 && \
+#
+#    wget https://github.com/ornladios/ADIOS2/archive/45035d24b4505b241037e2a1b35a4bbf1af782a8.tar.gz && \
+#    tar xzf 45035d24b4505b241037e2a1b35a4bbf1af782a8.tar.gz && \
+#    cd ADIOS2-45035d24b4505b241037e2a1b35a4bbf1af782a8 && \
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.12.1.tar.gz && \
+    tar xzf v2.12.1.tar.gz && \
+    cd ADIOS2-2.12.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_TESTING=OFF \
+        -DADIOS2_BUILD_EXAMPLES=OFF \
+        -DADIOS2_Blosc2_PREFER_SHARED=ON \
+        -DADIOS2_USE_BZip2=ON \
+        -DADIOS2_USE_Blosc2=ON \
+        -DADIOS2_USE_Fortran=OFF \
+        -DADIOS2_USE_HDF5=ON \
+        -DADIOS2_USE_MGARD=ON \
+        -DADIOS2_USE_SZ3=ON \
+        -DADIOS2_USE_ZFP=ON && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install ASDF
+# ASDF is an I/O library like HDF5
+# - depends on yaml-cpp
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/asdf-cxx/archive/refs/tags/version/8.0.0.tar.gz && \
+    tar xzf 8.0.0.tar.gz && \
+    cd asdf-cxx-version-8.0.0 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install NSIMD
+# NSIMD allows writing explicitly SIMD-vectorized code
+# Note: This assumes that the system has aarch64 (ARM) CPUs
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/agenium-scale/nsimd/archive/refs/tags/v3.0.1.tar.gz && \
+    tar xzf v3.0.1.tar.gz && \
+    cd nsimd-3.0.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        -Dsimd=aarch64 \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# COPY patches/openPMD-api.patch /cactus/patches/
+
+# Install openPMD-api
+# openPMD-api defines a standard for laying out AMR data in a file
+# - depends on ADIOS2
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/openPMD/openPMD-api/archive/refs/tags/0.17.1.tar.gz && \
+    tar xzf 0.17.1.tar.gz && \
+    cd openPMD-api-0.17.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_EXAMPLES=OFF \
+        -DBUILD_TESTING=OFF \
+        -DopenPMD_BUILD_SHARED_LIBS=ON \
+        -DopenPMD_USE_MPI=ON \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install RePrimAnd
+# RePrimAnd is a physics package for nuclear equations of state
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/wokast/RePrimAnd/archive/refs/tags/v1.7.tar.gz && \
+    tar xzf v1.7.tar.gz && \
+    cd RePrimAnd-1.7 && \
+    meson setup build --buildtype=release --prefix=/usr/local -Dcpp_std=c++14 && \
+    ninja -C build && \
+    ninja -C build install && \
+    true) && \
+    rm -rf src
+
+# Install Silo
+# Silo defines a standard for laying out AMR data in a file
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/LLNL/Silo/releases/download/4.12.1/Silo-4.12.1.tar.xz && \
+    tar xJf Silo-4.12.1.tar.xz && \
+    cd Silo-4.12.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DSILO_BUILD_FOR_BSD_LICENSE=ON \
+        -DSILO_ENABLE_BROWSER=OFF \
+        -DSILO_ENABLE_FORTRAN=OFF \
+        -DSILO_ENABLE_HDF5=ON \
+        -DSILO_ENABLE_JSON=OFF \
+        -DSILO_ENABLE_PYTHON_MODULE=OFF \
+        -DSILO_ENABLE_SHARED=ON \
+        -DSILO_ENABLE_SILEX=OFF \
+        -DSILO_ENABLE_SILOCK=ON \
+        -DSILO_ENABLE_TESTS=OFF \
+        -DSILO_HDF5_SZIP_DIR=/usr/local \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install Conduit
+# Conduit defines a standard for laying out AMR data in a file.
+# - depends on Silo
+# TODO:
+# - enable CUDA? HIP?
+# -DADIOS_DIR=/usr/local   # conduit doesn't find ADIOS because there is no FindADIOS.cmake
+# -DZFP_DIR=/usr           # conduit doesn't find zfp because the library directory is wrong
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/LLNL/conduit/releases/download/v0.9.8/conduit-v0.9.8-src-with-blt.tar.gz && \
+    tar xzf conduit-v0.9.8-src-with-blt.tar.gz && \
+    cd conduit-v0.9.8 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCONDUIT_ENABLE_TESTS=OFF \
+        -DENABLE_COVERAGE=OFF \
+        -DENABLE_DOCS=OFF \
+        -DENABLE_EXAMPLES=OFF \
+        -DENABLE_FORTRAN=OFF \
+        -DENABLE_MPI=ON \
+        -DENABLE_OPENMP=ON \
+        -DENABLE_PYTHON=ON \
+        -DENABLE_RELAY_WEBSERVER=OFF \
+        -DENABLE_TESTS=OFF \
+        -DENABLE_UTILS=ON \
+        -DHDF5_DIR=/usr \
+        -DSILO_DIR=/usr/local \
+        -DZLIB_DIR=/usr \
+        src \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install SimulationIO
+# SimulationIO is an I/O library like HDF5
+# - depends on asdf-cxx
+# - depends on yaml-cpp
+# Currently disabling ASDF because there is a confusion with C++11/17 standards
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/SimulationIO/archive/refs/tags/version/9.0.3.tar.gz && \
+    tar xzf 9.0.3.tar.gz && \
+    cd SimulationIO-version-9.0.3 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        -DENABLE_ASDF_CXX=ON \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install ssht
+# ssht provides spin-weighted spherical harmonics
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/astro-informatics/ssht/archive/v1.5.2.tar.gz && \
+    tar xzf v1.5.2.tar.gz && \
+    cd ssht-1.5.2 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_TESTING=OFF \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# # Install Fuka
+# RUN mkdir src
+# WORKDIR src
+# RUN git clone --branch ET_2025_05 https://bitbucket.org/fukaws/fuka
+# WORKDIR fuka
+# # Ensure this macro is defined at build time to enable multi-threaded importers
+# RUN sed -i -E 's%// #define DEFAULT_KAD_MEM%#define DEFAULT_KAD_MEM%' include/memory.hpp
+# WORKDIR build_release
+# RUN env HOME_KADATH=/cactus/src/fuka \
+#     cmake -B build -G Ninja \
+#         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+#         -DCMAKE_INSTALL_PREFIX=/usr/local \
+#         -DGRHAYL_EOS=OFF \
+#         -DPAR_VERSION=ON
+# RUN cmake --build build
+# WORKDIR ..
+# RUN cp lib/libkadath.a /usr/local/lib
+# RUN ls -l /cactus/src/fuka/include
+# RUN false
+# WORKDIR ../..
+# RUN rm -rf src
+# RUN echo
+# RUN ls -l /usr/local/include
+# RUN ls -l /usr/local/lib
+# RUN false
+
+ARG real_precision=real64
+
+# Install AMReX
+# AMReX provides adaptive mesh refinement
+# - Enable Fortran for `docker/Dockerfile`
+# - Install this last because it changes most often
+# Should we keep the AMReX source tree around for debugging?
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/AMReX-Codes/amrex/archive/26.01.tar.gz && \
+    tar xzf 26.01.tar.gz && \
+    cd amrex-26.01 && \
+    case $real_precision in \
+        real32) precision=SINGLE;; \
+        real64) precision=DOUBLE;; \
+        *) exit 1;; \
+    esac && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DAMReX_FORTRAN=OFF \
+        -DAMReX_FORTRAN_INTERFACES=OFF \
+        -DAMReX_OMP=ON \
+        -DAMReX_PARTICLES=ON \
+        -DAMReX_PRECISION="$precision" \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Find libraries in /usr/local/lib64
+RUN echo /usr/local/lib64 >/etc/ld.so.conf.d/usr-local-lib64.conf && \
+    ldconfig

--- a/docker/carpetx-native-cpu.dockerfile
+++ b/docker/carpetx-native-cpu.dockerfile
@@ -1,0 +1,445 @@
+# How to build this Docker image:
+
+#     docker build --file carpetx-native-cpu.dockerfile --tag einsteintoolkit/carpetx:native-cpu-real64 .
+#     docker push einsteintoolkit/carpetx:native-cpu-real64
+
+#     docker build --build-arg real_precision=real32 --file carpetx-native-cpu.dockerfile --tag einsteintoolkit/carpetx:native-cpu-real32 .
+#     docker push einsteintoolkit/carpetx:native-cpu-real32
+
+# noble is ubuntu:24.04
+# FROM amd64/ubuntu:noble-20250714
+# FROM amd64/ubuntu:noble-20250805
+# FROM amd64/ubuntu:noble-20251001
+# FROM amd64/ubuntu:noble-20251013
+# FROM amd64/ubuntu:noble-20260113
+# FROM amd64/ubuntu:noble-20260210.1
+# FROM amd64/ubuntu:noble-20260410
+# FROM amd64/ubuntu:noble-20260509.1
+FROM amd64/ubuntu:resolute-20260811.1
+
+#TODO: try this?   FROM amd64/spack/ubuntu-noble:0.23.1
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANGUAGE=en_US.en \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
+
+RUN mkdir /cactus
+WORKDIR /cactus
+
+# Install system packages
+# - Boost on Ubuntu requires OpenMPI
+#        elfutils
+#        python2
+RUN apt-get update && \
+    apt-get --yes --no-install-recommends install \
+        bzip2 \
+        ca-certificates \
+        clang-format \
+        cmake \
+        curl \
+        cvs \
+        diffutils \
+        elfutils \
+        g++ \
+        gcc \
+        gdb \
+        gfortran \
+        git \
+        hdf5-filter-plugin \
+        hdf5-filter-plugin-blosc-serial \
+        hdf5-filter-plugin-zfp-serial \
+        hdf5-plugin-lzf \
+        hdf5-tools \
+        hwloc-nox \
+        language-pack-en \
+        less \
+        libblosc-dev \
+        libblosc2-dev \
+        libboost-all-dev \
+        libbz2-dev \
+        libfftw3-dev \
+        libgit2-dev \
+        libgsl-dev \
+        libhdf5-dev \
+        libhwloc-dev \
+        libiberty-dev \
+        liblz4-dev \
+        liblzma-dev \
+        libopenblas-dev \
+        libopenmpi-dev \
+        libpapi-dev \
+        libpetsc-real-dev \
+        libprotobuf-dev \
+        libreadline-dev \
+        libtool \
+        libudev-dev \
+        libyaml-cpp-dev \
+        libzfp-dev \
+        libzstd-dev \
+        locales \
+        m4 \
+        make \
+        meson \
+        ninja-build \
+        nlohmann-json3-dev \
+        numactl \
+        papi-tools \
+        patch \
+        perl \
+        pkgconf \
+        protobuf-compiler \
+        python3 \
+        python3-numpy \
+        python3-pip \
+        python3-requests \
+        python3-venv \
+        rsync \
+        subversion \
+        tar \
+        unzip \
+        vim \
+        wget \
+        xz-utils \
+        zlib1g-dev \
+        zstd \
+        && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install HPCToolkit
+# Install this first because it is expensive to build
+# Try to reuse build tools from Ubuntu, but do not use any libraries because HPC Toolkit is a bit iffy to install.
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/spack/spack/archive/refs/tags/v1.2.2.tar.gz && \
+    tar xzf v1.2.2.tar.gz && \
+    export SPACK_ROOT="$(pwd)/spack-1.2.2" && \
+    mkdir -p "${HOME}/.spack" && \
+    echo 'config: {install_tree: {root: /spack}}' >"${HOME}/.spack/config.yaml" && \
+    . ${SPACK_ROOT}/share/spack/setup-env.sh && \
+    wget https://github.com/spack/spack-packages/archive/refs/tags/v2026.06.0.tar.gz && \
+    tar xzf v2026.06.0.tar.gz && \
+    spack repo add --scope site spack-packages-2026.06.0/repos/spack_repo/builtin && \
+    spack external find \
+        autoconf \
+        automake \
+        cmake \
+        curl \
+        diffutils \
+        elfutils \
+        gmake \
+        libtool \
+        m4 \
+        meson \
+        ninja \
+        numactl \
+        perl \
+        pkgconf \
+        python \
+    && \
+    spack install --fail-fast hpctoolkit ~viewer && \
+    spack view --dependencies no hardlink /hpctoolkit hpctoolkit && \
+    true) && \
+    rm -rf src "${HOME}/.spack"
+
+# # Install blosc2
+# # blosc2 is a compression library, comparable to zlib
+# RUN mkdir src && \
+#     (cd src && \
+#     wget https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.18.0.tar.gz && \
+#     tar xzf v2.18.0.tar.gz && \
+#     cd c-blosc2-2.18.0 && \
+#     cmake -B build -G Ninja \
+#         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+#         -DCMAKE_INSTALL_PREFIX=/usr/local \
+#         -DBUILD_BENCHMARKS=OFF \
+#         -DBUILD_EXAMPLES=OFF \
+#         -DBUILD_FUZZERS=OFF \
+#         -DBUILD_STATIC=OFF \
+#         -DBUILD_TESTS=OFF \
+#         -DPREFER_EXTERNAL_LZ4=ON  \
+#         -DPREFER_EXTERNAL_ZLIB=ON \
+#         -DPREFER_EXTERNAL_ZSTD=ON \
+#         && \
+#     cmake --build build && \
+#     cmake --install build && \
+#     true) && \
+#     rm -rf src
+
+# Install MGARD
+# MGARD is a lossy compression library
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/CODARcode/MGARD/archive/refs/tags/1.6.0.tar.gz && \
+    tar xzf 1.6.0.tar.gz && \
+    cd MGARD-1.6.0 && \
+    cmake -B build -G Ninja \
+        -DBUILD_TESTING=OFF \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        -DMGARD_ENABLE_OPENMP=ON \
+        -DMGARD_ENABLE_SERIAL=ON \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install SZ3
+# SZ3 is a lossy compression library
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/szcompressor/SZ3/releases/download/v3.3.2/SZ3-v3.3.2.zip && \
+    unzip SZ3-v3.3.2.zip && \
+    cd SZ3-master && \
+    cmake -B build -G Ninja \
+        -DBUILD_H5Z_FILTER=ON \
+        -DBUILD_MDZ=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install ADIOS2
+# ADIOS2 is a parallel I/O library, comparable to HDF5
+# - depends on blosc2
+# - depends on MGARD
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.12.1.tar.gz && \
+    tar xzf v2.12.1.tar.gz && \
+    cd ADIOS2-2.12.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_TESTING=OFF \
+        -DADIOS2_BUILD_EXAMPLES=OFF \
+        -DADIOS2_Blosc2_PREFER_SHARED=ON \
+        -DADIOS2_USE_BZip2=ON \
+        -DADIOS2_USE_Blosc2=ON \
+        -DADIOS2_USE_Fortran=OFF \
+        -DADIOS2_USE_HDF5=ON \
+        -DADIOS2_USE_MGARD=ON \
+        -DADIOS2_USE_SZ3=ON \
+        -DADIOS2_USE_ZFP=ON && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install ASDF
+# ASDF is an I/O library like HDF5
+# - depends on yaml-cpp
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/asdf-cxx/archive/refs/tags/version/7.3.2.tar.gz && \
+    tar xzf 7.3.2.tar.gz && \
+    cd asdf-cxx-version-7.3.2 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install NSIMD
+# NSIMD allows writing explicitly SIMD-vectorized code
+# Note: This assumes that the system has x86_64 CPUs
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/agenium-scale/nsimd/archive/refs/tags/v3.0.1.tar.gz && \
+    tar xzf v3.0.1.tar.gz && \
+    cd nsimd-3.0.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        -Dsimd=AVX2 \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# COPY patches/openPMD-api.patch /cactus/patches/
+
+# Install openPMD-api
+# openPMD-api defines a standard for laying out AMR data in a file
+# - depends on ADIOS2
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/openPMD/openPMD-api/archive/refs/tags/0.17.1.tar.gz && \
+    tar xzf 0.17.1.tar.gz && \
+    cd openPMD-api-0.17.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_EXAMPLES=OFF \
+        -DBUILD_TESTING=OFF \
+        -DopenPMD_BUILD_SHARED_LIBS=ON \
+        -DopenPMD_USE_MPI=ON \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install RePrimAnd
+# RePrimAnd is a physics package for nuclear equations of state
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/wokast/RePrimAnd/archive/refs/tags/v1.7.tar.gz && \
+    tar xzf v1.7.tar.gz && \
+    cd RePrimAnd-1.7 && \
+    meson setup build --buildtype=release --prefix=/usr/local -Dcpp_std=c++14 && \
+    ninja -C build && \
+    ninja -C build install && \
+    true) && \
+    rm -rf src
+
+# Install Silo
+# Silo defines a standard for laying out AMR data in a file
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/LLNL/Silo/releases/download/4.12.1/Silo-4.12.1.tar.xz && \
+    tar xJf Silo-4.12.1.tar.xz && \
+    cd Silo-4.12.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DSILO_BUILD_FOR_BSD_LICENSE=ON \
+        -DSILO_ENABLE_BROWSER=OFF \
+        -DSILO_ENABLE_FORTRAN=OFF \
+        -DSILO_ENABLE_HDF5=ON \
+        -DSILO_ENABLE_JSON=OFF \
+        -DSILO_ENABLE_PYTHON_MODULE=OFF \
+        -DSILO_ENABLE_SHARED=ON \
+        -DSILO_ENABLE_SILEX=OFF \
+        -DSILO_ENABLE_SILOCK=ON \
+        -DSILO_ENABLE_TESTS=OFF \
+        -DSILO_HDF5_SZIP_DIR=/usr/local \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install Conduit
+# Conduit defines a standard for laying out AMR data in a file.
+# - depends on Silo
+# TODO:
+# - enable CUDA? HIP?
+# -DADIOS_DIR=/usr/local   # conduit doesn't find ADIOS because there is no FindADIOS.cmake
+# -DZFP_DIR=/usr           # conduit doesn't find zfp because the library directory is wrong
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/LLNL/conduit/releases/download/v0.9.7/conduit-v0.9.7-src-with-blt.tar.gz && \
+    tar xzf conduit-v0.9.7-src-with-blt.tar.gz && \
+    cd conduit-v0.9.7 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCONDUIT_ENABLE_TESTS=OFF \
+        -DENABLE_COVERAGE=OFF \
+        -DENABLE_DOCS=OFF \
+        -DENABLE_EXAMPLES=OFF \
+        -DENABLE_FORTRAN=OFF \
+        -DENABLE_MPI=ON \
+        -DENABLE_OPENMP=ON \
+        -DENABLE_PYTHON=ON \
+        -DENABLE_RELAY_WEBSERVER=OFF \
+        -DENABLE_TESTS=OFF \
+        -DENABLE_UTILS=ON \
+        -DHDF5_DIR=/usr \
+        -DSILO_DIR=/usr/local \
+        -DZLIB_DIR=/usr \
+        src \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install SimulationIO
+# SimulationIO is an I/O library like HDF5
+# - depends on asdf-cxx
+# - depends on yaml-cpp
+# Currently disabling ASDF because there is a confusion with C++11/17 standards
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/SimulationIO/archive/refs/tags/version/9.0.3.tar.gz && \
+    tar xzf 9.0.3.tar.gz && \
+    cd SimulationIO-version-9.0.3 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        -DENABLE_ASDF_CXX=OFF \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install ssht
+# ssht provides spin-weighted spherical harmonics
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/astro-informatics/ssht/archive/v1.5.2.tar.gz && \
+    tar xzf v1.5.2.tar.gz && \
+    cd ssht-1.5.2 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_TESTING=OFF \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+ARG real_precision=real64
+
+# Install AMReX
+# AMReX provides adaptive mesh refinement
+# - Enable Fortran for `docker/Dockerfile`
+# - Install this last because it changes most often
+# Should we keep the AMReX source tree around for debugging?
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/AMReX-Codes/amrex/archive/26.01.tar.gz && \
+    tar xzf 26.01.tar.gz && \
+    cd amrex-26.01 && \
+    case $real_precision in \
+        real32) precision=SINGLE;; \
+        real64) precision=DOUBLE;; \
+        *) exit 1;; \
+    esac && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DAMReX_FORTRAN=OFF \
+        -DAMReX_FORTRAN_INTERFACES=OFF \
+        -DAMReX_OMP=ON \
+        -DAMReX_PARTICLES=ON \
+        -DAMReX_PRECISION="$precision" \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Find libraries in /usr/local/lib64
+RUN echo /usr/local/lib64 >/etc/ld.so.conf.d/usr-local-lib64.conf && \
+    ldconfig

--- a/docker/carpetx-native-cuda.dockerfile
+++ b/docker/carpetx-native-cuda.dockerfile
@@ -1,0 +1,427 @@
+# How to build this Docker image:
+
+#     docker build --file carpetx-native-cuda.dockerfile --tag einsteintoolkit/carpetx:native-cuda-real64 .
+#     docker push einsteintoolkit/carpetx:native-cuda-real64
+
+#     docker build --build-arg real_precision=real32 --file carpetx-native-cuda.dockerfile --tag einsteintoolkit/carpetx:native-cuda-real32 .
+#     docker push einsteintoolkit/carpetx:native-cuda-real32
+
+# FROM nvidia/cuda:12.9.1-devel-ubuntu24.04
+# FROM nvidia/cuda:13.0.0-devel-ubuntu24.04
+# FROM nvidia/cuda:12.6.3-devel-ubuntu24.04
+# FROM nvidia/cuda:13.1.1-devel-ubuntu24.04
+# FROM nvidia/cuda:13.1.2-devel-ubuntu24.04
+# FROM nvidia/cuda:13.3.0-devel-ubuntu24.04
+FROM nvidia/cuda:13.3.1-devel-ubuntu24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANGUAGE=en_US.en \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
+
+RUN mkdir /cactus
+WORKDIR /cactus
+
+# Install system packages
+# - Boost on Ubuntu requires OpenMPI
+#        elfutils
+#        python2
+RUN apt-get update && \
+    apt-get --yes --no-install-recommends install \
+        ca-certificates \
+        clang-format \
+        cmake \
+        cvs \
+        diffutils \
+        g++ \
+        gcc \
+        gdb \
+        gfortran \
+        git \
+        hdf5-filter-plugin \
+        hdf5-filter-plugin-blosc-serial \
+        hdf5-filter-plugin-zfp-serial \
+        hdf5-plugin-lzf \
+        hdf5-tools \
+        hwloc-nox \
+        language-pack-en \
+        less \
+        libblosc-dev \
+        libblosc2-dev \
+        libboost-all-dev \
+        libbz2-dev \
+        libfftw3-dev \
+        libgit2-dev \
+        libgsl-dev \
+        libhdf5-dev \
+        libhwloc-dev \
+        liblz4-dev \
+        libopenblas-dev \
+        libopenmpi-dev \
+        libpetsc-real-dev \
+        libprotobuf-dev \
+        libreadline-dev \
+        libtool \
+        libudev-dev \
+        libyaml-cpp-dev \
+        libzfp-dev \
+        libzstd-dev \
+        locales \
+        m4 \
+        meson \
+        ninja-build \
+        nlohmann-json3-dev \
+        numactl \
+        perl \
+        pkgconf \
+        protobuf-compiler \
+        python3 \
+        python3-numpy \
+        python3-pip \
+        python3-requests \
+        rsync \
+        subversion \
+        unzip \
+        vim \
+        wget \
+        zlib1g-dev \
+        && \
+    rm -rf /var/lib/apt/lists/*
+
+# # Install HPCToolkit
+# # Install this first because it is expensive to build
+# RUN mkdir src && \
+#     (cd src && \
+#     wget https://github.com/spack/spack/archive/refs/tags/v1.2.2.tar.gz && \
+#     tar xzf v1.2.2.tar.gz && \
+#     export SPACK_ROOT="$(pwd)/spack-1.2.2" && \
+#     mkdir -p "${HOME}/.spack" && \
+#     echo 'config: {install_tree: {root: /spack}}' >"${HOME}/.spack/config.yaml" && \
+#     . ${SPACK_ROOT}/share/spack/setup-env.sh && \
+#     wget https://github.com/spack/spack-packages/archive/refs/tags/v2026.06.0.tar.gz && \
+#     tar xzf v2026.06.0.tar.gz && \
+#     spack repo add --scope site spack-packages-2026.06.0/repos/spack_repo/builtin && \
+#     spack external find \
+#         autoconf \
+#         automake \
+#         cmake \
+#         cuda \
+#         diffutils \
+#         elfutils \
+#         gmake \
+#         libtool \
+#         m4 \
+#         meson \
+#         ninja \
+#         numactl \
+#         perl \
+#         pkgconf \
+#         python \
+#     && \
+#     spack install --fail-fast hpctoolkit +cuda ~viewer && \
+#     spack view --dependencies no hardlink /hpctoolkit hpctoolkit && \
+#     true) && \
+#     rm -rf src "${HOME}/.spack"
+
+# # Install blosc2
+# # blosc2 is a compression library, comparable to zlib
+# RUN mkdir src && \
+#     (cd src && \
+#     wget https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.18.0.tar.gz && \
+#     tar xzf v2.18.0.tar.gz && \
+#     cd c-blosc2-2.18.0 && \
+#     cmake -B build -G Ninja \
+#         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+#         -DCMAKE_INSTALL_PREFIX=/usr/local \
+#         -DBUILD_BENCHMARKS=OFF \
+#         -DBUILD_EXAMPLES=OFF \
+#         -DBUILD_FUZZERS=OFF \
+#         -DBUILD_STATIC=OFF \
+#         -DBUILD_TESTS=OFF \
+#         -DPREFER_EXTERNAL_LZ4=ON  \
+#         -DPREFER_EXTERNAL_ZLIB=ON \
+#         -DPREFER_EXTERNAL_ZSTD=ON \
+#         && \
+#     cmake --build build && \
+#     cmake --install build && \
+#     true) && \
+#     rm -rf src
+
+# Install MGARD
+# MGARD is a lossy compression library
+# Note: -DMGARD_ENABLE_CUDA=ON requires nvcomp with a restrictive licence
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/CODARcode/MGARD/archive/refs/tags/1.6.0.tar.gz && \
+    tar xzf 1.6.0.tar.gz && \
+    cd MGARD-1.6.0 && \
+    cmake -B build -G Ninja \
+        -DBUILD_TESTING=OFF \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        -DMGARD_ENABLE_OPENMP=ON \
+        -DMGARD_ENABLE_SERIAL=ON \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install SZ3
+# SZ3 is a lossy compression library
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/szcompressor/SZ3/releases/download/v3.3.2/SZ3-v3.3.2.zip && \
+    unzip SZ3-v3.3.2.zip && \
+    cd SZ3-master && \
+    cmake -B build -G Ninja \
+        -DBUILD_H5Z_FILTER=ON \
+        -DBUILD_MDZ=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install ADIOS2
+# ADIOS2 is a parallel I/O library, comparable to HDF5
+# - depends on blosc2
+# - depends on MGARD
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.12.1.tar.gz && \
+    tar xzf v2.12.1.tar.gz && \
+    cd ADIOS2-2.12.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_TESTING=OFF \
+        -DADIOS2_BUILD_EXAMPLES=OFF \
+        -DADIOS2_Blosc2_PREFER_SHARED=ON \
+        -DADIOS2_USE_BZip2=ON \
+        -DADIOS2_USE_Blosc2=ON \
+        -DADIOS2_USE_Fortran=OFF \
+        -DADIOS2_USE_HDF5=ON \
+        -DADIOS2_USE_MGARD=ON \
+        -DADIOS2_USE_SZ3=ON \
+        -DADIOS2_USE_ZFP=ON && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install ASDF
+# ASDF is an I/O library like HDF5
+# - depends on yaml-cpp
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/asdf-cxx/archive/refs/tags/version/7.3.2.tar.gz && \
+    tar xzf 7.3.2.tar.gz && \
+    cd asdf-cxx-version-7.3.2 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install NSIMD
+# NSIMD allows writing explicitly SIMD-vectorized code
+# Note: This assumes that the system has x86_64 CPUs
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/agenium-scale/nsimd/archive/refs/tags/v3.0.1.tar.gz && \
+    tar xzf v3.0.1.tar.gz && \
+    cd nsimd-3.0.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -Dsimd=AVX2 \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# COPY patches/openPMD-api.patch /cactus/patches/
+
+# Install openPMD-api
+# openPMD-api defines a standard for laying out AMR data in a file
+# - depends on ADIOS2
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/openPMD/openPMD-api/archive/refs/tags/0.17.1.tar.gz && \
+    tar xzf 0.17.1.tar.gz && \
+    cd openPMD-api-0.17.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_EXAMPLES=OFF \
+        -DBUILD_TESTING=OFF \
+        -DopenPMD_BUILD_SHARED_LIBS=ON \
+        -DopenPMD_USE_MPI=ON \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install RePrimAnd
+# RePrimAnd is a physics package for nuclear equations of state
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/wokast/RePrimAnd/archive/refs/tags/v1.7.tar.gz && \
+    tar xzf v1.7.tar.gz && \
+    cd RePrimAnd-1.7 && \
+    meson setup build --buildtype=release --prefix=/usr/local -Dcpp_std=c++14 && \
+    ninja -C build && \
+    ninja -C build install && \
+    true) && \
+    rm -rf src
+
+# Install Silo
+# Silo defines a standard for laying out AMR data in a file
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/LLNL/Silo/releases/download/4.12.1/Silo-4.12.1.tar.xz && \
+    tar xJf Silo-4.12.1.tar.xz && \
+    cd Silo-4.12.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DSILO_BUILD_FOR_BSD_LICENSE=ON \
+        -DSILO_ENABLE_BROWSER=OFF \
+        -DSILO_ENABLE_FORTRAN=OFF \
+        -DSILO_ENABLE_HDF5=ON \
+        -DSILO_ENABLE_JSON=OFF \
+        -DSILO_ENABLE_PYTHON_MODULE=OFF \
+        -DSILO_ENABLE_SHARED=ON \
+        -DSILO_ENABLE_SILEX=OFF \
+        -DSILO_ENABLE_SILOCK=ON \
+        -DSILO_ENABLE_TESTS=OFF \
+        -DSILO_HDF5_SZIP_DIR=/usr/local \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install Conduit
+# Conduit defines a standard for laying out AMR data in a file.
+# - depends on Silo
+# TODO:
+# - enable CUDA? HIP?
+# -DADIOS_DIR=/usr/local   # conduit doesn't find ADIOS because there is no FindADIOS.cmake
+# -DZFP_DIR=/usr           # conduit doesn't find zfp because the library directory is wrong
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/LLNL/conduit/releases/download/v0.9.7/conduit-v0.9.7-src-with-blt.tar.gz && \
+    tar xzf conduit-v0.9.7-src-with-blt.tar.gz && \
+    cd conduit-v0.9.7 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCONDUIT_ENABLE_TESTS=OFF \
+        -DENABLE_COVERAGE=OFF \
+        -DENABLE_DOCS=OFF \
+        -DENABLE_EXAMPLES=OFF \
+        -DENABLE_FORTRAN=OFF \
+        -DENABLE_MPI=ON \
+        -DENABLE_OPENMP=ON \
+        -DENABLE_PYTHON=ON \
+        -DENABLE_RELAY_WEBSERVER=OFF \
+        -DENABLE_TESTS=OFF \
+        -DENABLE_UTILS=ON \
+        -DHDF5_DIR=/usr \
+        -DSILO_DIR=/usr/local \
+        -DZLIB_DIR=/usr \
+        src \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install SimulationIO
+# SimulationIO is an I/O library like HDF5
+# - depends on asdf-cxx
+# - depends on yaml-cpp
+# Currently disabling ASDF because there is a confusion with C++11/17 standards
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/SimulationIO/archive/refs/tags/version/9.0.3.tar.gz && \
+    tar xzf 9.0.3.tar.gz && \
+    cd SimulationIO-version-9.0.3 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DENABLE_ASDF_CXX=OFF \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install ssht
+# ssht provides spin-weighted spherical harmonics
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/astro-informatics/ssht/archive/v1.5.2.tar.gz && \
+    tar xzf v1.5.2.tar.gz && \
+    cd ssht-1.5.2 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_TESTING=OFF \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+ARG real_precision=real64
+
+# Install AMReX
+# AMReX provides adaptive mesh refinement
+# - Enable Fortran for `docker/Dockerfile`
+# - Install this last because it changes most often
+# Should we keep the AMReX source tree around for debugging?
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/AMReX-Codes/amrex/archive/26.01.tar.gz && \
+    tar xzf 26.01.tar.gz && \
+    cd amrex-26.01 && \
+    case $real_precision in \
+        real32) precision=SINGLE;; \
+        real64) precision=DOUBLE;; \
+        *) exit 1;; \
+    esac && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DAMReX_CUDA_ARCH=8.0 \
+        -DAMReX_FORTRAN=OFF \
+        -DAMReX_FORTRAN_INTERFACES=OFF \
+        -DAMReX_GPU_BACKEND=CUDA \
+        -DAMReX_OMP=ON \
+        -DAMReX_PARTICLES=ON \
+        -DAMReX_PRECISION="$precision" \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Find libraries in /usr/local/lib64
+RUN echo /usr/local/lib64 >/etc/ld.so.conf.d/usr-local-lib64.conf && \
+    ldconfig

--- a/docker/carpetx-native-oneapi.dockerfile
+++ b/docker/carpetx-native-oneapi.dockerfile
@@ -1,0 +1,416 @@
+# How to build this Docker image:
+
+#     docker build --file carpetx-native-oneapi.dockerfile --tag einsteintoolkit/carpetx:native-oneapi-real64 .
+#     docker push einsteintoolkit/carpetx:native-oneapi-real64
+
+#     docker build --build-arg real_precision=real32 --file carpetx-native-oneapi.dockerfile --tag einsteintoolkit/carpetx:native-oneapi-real32 .
+#     docker push einsteintoolkit/carpetx:native-oneapi-real32
+
+# FROM intel/oneapi-basekit:2025.2.0-0-devel-ubuntu24.04
+FROM intel/oneapi-basekit:2025.2.2-0-devel-ubuntu24.04
+# [AMReX linker step is broken]
+# FROM intel/oneapi-basekit:2025.3.0-0-devel-ubuntu24.04
+# FROM intel/oneapi-basekit:2025.3.1-0-devel-ubuntu24.04
+# FROM intel/oneapi-basekit:2025.3.2-0-devel-ubuntu24.04
+# FROM intel/oneapi-toolkit:2026.0.0-devel-ubuntu24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANGUAGE=en_US.en \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
+
+RUN mkdir /cactus
+WORKDIR /cactus
+
+# Install system packages
+# - Boost on Ubuntu requires OpenMPI
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 28DA432DAAC8BAEA && \
+    apt-get update --allow-insecure-repositories && \
+    apt-get --yes --no-install-recommends install \
+        ca-certificates \
+        clang-format \
+        cmake \
+        cvs \
+        diffutils \
+        g++ \
+        gcc \
+        gdb \
+        gfortran \
+        git \
+        hdf5-filter-plugin \
+        hdf5-filter-plugin-blosc-serial \
+        hdf5-filter-plugin-zfp-serial \
+        hdf5-plugin-lzf \
+        hdf5-tools \
+        hwloc-nox \
+        language-pack-en \
+        less \
+        libblosc-dev \
+        libblosc2-dev \
+        libboost-all-dev \
+        libbz2-dev \
+        libfftw3-dev \
+        libgit2-dev \
+        libgsl-dev \
+        libhdf5-dev \
+        libhwloc-dev \
+        liblz4-dev \
+        libopenblas-dev \
+        libopenmpi-dev \
+        libpetsc-real-dev \
+        libprotobuf-dev \
+        libreadline-dev \
+        libtool \
+        libudev-dev \
+        libyaml-cpp-dev \
+        libzfp-dev \
+        libzstd-dev \
+        locales \
+        m4 \
+        meson \
+        ninja-build \
+        nlohmann-json3-dev \
+        numactl \
+        perl \
+        pkgconf \
+        protobuf-compiler \
+        python3 \
+        python3-numpy \
+        python3-pip \
+        python3-requests \
+        rsync \
+        subversion \
+        unzip \
+        vim \
+        wget \
+        zlib1g-dev \
+        && \
+    rm -rf /var/lib/apt/lists/*
+
+# Remove troublesome libraries
+RUN find /opt/intel -name 'impi.pc' -delete && \
+    find /opt/intel -name 'libhwloc.a' -delete && \
+    find /opt/intel -name 'libhwloc.so' -delete && \
+    find /opt/intel -name 'libmpi*a' -delete && \
+    find /opt/intel -name 'libmpi*so' -delete && \
+    find /opt/intel -name 'mpi.h' -delete && \
+    find /opt/intel -name 'mpicc' -delete && \
+    find /opt/intel -name 'mpicxx' -delete && \
+    find /opt/intel -name 'mpiexec' -delete && \
+    find /opt/intel -name 'mpirun' -delete
+
+# # Install blosc2
+# # blosc2 is a compression library, comparable to zlib
+# RUN mkdir src && \
+#     (cd src && \
+#     wget https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.18.0.tar.gz && \
+#     tar xzf v2.18.0.tar.gz && \
+#     cd c-blosc2-2.18.0 && \
+#     cmake -B build -G Ninja \
+#         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+#         -DCMAKE_INSTALL_PREFIX=/usr/local \
+#         -DBUILD_BENCHMARKS=OFF \
+#         -DBUILD_EXAMPLES=OFF \
+#         -DBUILD_FUZZERS=OFF \
+#         -DBUILD_STATIC=OFF \
+#         -DBUILD_TESTS=OFF \
+#         -DPREFER_EXTERNAL_LZ4=ON  \
+#         -DPREFER_EXTERNAL_ZLIB=ON \
+#         -DPREFER_EXTERNAL_ZSTD=ON \
+#         && \
+#     cmake --build build && \
+#     cmake --install build && \
+#     true) && \
+#     rm -rf src
+
+# Install MGARD
+# MGARD is a lossy compression library
+# Note: -DMGARD_ENABLE_SYCL=ON does not work
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/CODARcode/MGARD/archive/refs/tags/1.6.0.tar.gz && \
+    tar xzf 1.6.0.tar.gz && \
+    cd MGARD-1.6.0 && \
+    cmake -B build -G Ninja \
+        -DBUILD_TESTING=OFF \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        -DMGARD_ENABLE_OPENMP=ON \
+        -DMGARD_ENABLE_SERIAL=ON \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install SZ3
+# SZ3 is a lossy compression library
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/szcompressor/SZ3/releases/download/v3.3.2/SZ3-v3.3.2.zip && \
+    unzip SZ3-v3.3.2.zip && \
+    cd SZ3-master && \
+    cmake -B build -G Ninja \
+        -DBUILD_H5Z_FILTER=ON \
+        -DBUILD_MDZ=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install ADIOS2
+# ADIOS2 is a parallel I/O library, comparable to HDF5
+# - depends on blosc2
+# - depends on MGARD
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.12.1.tar.gz && \
+    tar xzf v2.12.1.tar.gz && \
+    cd ADIOS2-2.12.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_TESTING=OFF \
+        -DADIOS2_BUILD_EXAMPLES=OFF \
+        -DADIOS2_Blosc2_PREFER_SHARED=ON \
+        -DADIOS2_USE_BZip2=ON \
+        -DADIOS2_USE_Blosc2=ON \
+        -DADIOS2_USE_Fortran=OFF \
+        -DADIOS2_USE_HDF5=ON \
+        -DADIOS2_USE_MGARD=ON \
+        -DADIOS2_USE_SZ3=ON \
+        -DADIOS2_USE_ZFP=ON && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install ASDF
+# ASDF is an I/O library like HDF5
+# - depends on yaml-cpp
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/asdf-cxx/archive/refs/tags/version/7.3.2.tar.gz && \
+    tar xzf 7.3.2.tar.gz && \
+    cd asdf-cxx-version-7.3.2 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install NSIMD
+# NSIMD allows writing explicitly SIMD-vectorized code
+# Note: This assumes that the system has x86_64 CPUs
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/agenium-scale/nsimd/archive/refs/tags/v3.0.1.tar.gz && \
+    tar xzf v3.0.1.tar.gz && \
+    cd nsimd-3.0.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -Dsimd=AVX2 \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# COPY patches/openPMD-api.patch /cactus/patches/
+
+# Install openPMD-api
+# openPMD-api defines a standard for laying out AMR data in a file
+# - depends on ADIOS2
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/openPMD/openPMD-api/archive/refs/tags/0.17.1.tar.gz && \
+    tar xzf 0.17.1.tar.gz && \
+    cd openPMD-api-0.17.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_EXAMPLES=OFF \
+        -DBUILD_TESTING=OFF \
+        -DopenPMD_BUILD_SHARED_LIBS=ON \
+        -DopenPMD_USE_MPI=ON \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install RePrimAnd
+# RePrimAnd is a physics package for nuclear equations of state
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/wokast/RePrimAnd/archive/refs/tags/v1.7.tar.gz && \
+    tar xzf v1.7.tar.gz && \
+    cd RePrimAnd-1.7 && \
+    meson setup build --buildtype=release --prefix=/usr/local -Dcpp_std=c++14 && \
+    ninja -C build && \
+    ninja -C build install && \
+    true) && \
+    rm -rf src
+
+# Install Silo
+# Silo defines a standard for laying out AMR data in a file
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/LLNL/Silo/releases/download/4.12.1/Silo-4.12.1.tar.xz && \
+    tar xJf Silo-4.12.1.tar.xz && \
+    cd Silo-4.12.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DSILO_BUILD_FOR_BSD_LICENSE=ON \
+        -DSILO_ENABLE_BROWSER=OFF \
+        -DSILO_ENABLE_FORTRAN=OFF \
+        -DSILO_ENABLE_HDF5=ON \
+        -DSILO_ENABLE_JSON=OFF \
+        -DSILO_ENABLE_PYTHON_MODULE=OFF \
+        -DSILO_ENABLE_SHARED=ON \
+        -DSILO_ENABLE_SILEX=OFF \
+        -DSILO_ENABLE_SILOCK=ON \
+        -DSILO_ENABLE_TESTS=OFF \
+        -DSILO_HDF5_SZIP_DIR=/usr/local \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install Conduit
+# Conduit defines a standard for laying out AMR data in a file.
+# - depends on Silo
+# TODO:
+# - enable CUDA? HIP?
+# -DADIOS_DIR=/usr/local   # conduit doesn't find ADIOS because there is no FindADIOS.cmake
+# -DZFP_DIR=/usr           # conduit doesn't find zfp because the library directory is wrong
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/LLNL/conduit/releases/download/v0.9.7/conduit-v0.9.7-src-with-blt.tar.gz && \
+    tar xzf conduit-v0.9.7-src-with-blt.tar.gz && \
+    cd conduit-v0.9.7 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCONDUIT_ENABLE_TESTS=OFF \
+        -DENABLE_COVERAGE=OFF \
+        -DENABLE_DOCS=OFF \
+        -DENABLE_EXAMPLES=OFF \
+        -DENABLE_FORTRAN=OFF \
+        -DENABLE_MPI=ON \
+        -DENABLE_OPENMP=ON \
+        -DENABLE_PYTHON=ON \
+        -DENABLE_RELAY_WEBSERVER=OFF \
+        -DENABLE_TESTS=OFF \
+        -DENABLE_UTILS=ON \
+        -DHDF5_DIR=/usr \
+        -DSILO_DIR=/usr/local \
+        -DZLIB_DIR=/usr \
+        src \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install SimulationIO
+# SimulationIO is an I/O library like HDF5
+# - depends on asdf-cxx
+# - depends on yaml-cpp
+# Currently disabling ASDF because there is a confusion with C++11/17 standards
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/SimulationIO/archive/refs/tags/version/9.0.3.tar.gz && \
+    tar xzf 9.0.3.tar.gz && \
+    cd SimulationIO-version-9.0.3 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DENABLE_ASDF_CXX=OFF \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install ssht
+# ssht provides spin-weighted spherical harmonics
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/astro-informatics/ssht/archive/v1.5.2.tar.gz && \
+    tar xzf v1.5.2.tar.gz && \
+    cd ssht-1.5.2 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_TESTING=OFF \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+ARG real_precision=real64
+
+# Install AMReX
+# AMReX provides adaptive mesh refinement
+# - Enable Fortran for `docker/Dockerfile`
+# - Install this last because it changes most often
+# Should we keep the AMReX source tree around for debugging?
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/AMReX-Codes/amrex/archive/26.01.tar.gz && \
+    tar xzf 26.01.tar.gz && \
+    rm -rf /opt/intel/oneapi/mpi && \
+    cd amrex-26.01 && \
+    case $real_precision in \
+        real32) precision=SINGLE;; \
+        real64) precision=DOUBLE;; \
+        *) exit 1;; \
+    esac && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_C_COMPILER=icx \
+        -DCMAKE_CXX_COMPILER=icpx \
+        -DCMAKE_PREFIX_PATH='/opt/intel/oneapi' \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DAMReX_FORTRAN=OFF \
+        -DAMReX_FORTRAN_INTERFACES=OFF \
+        -DAMReX_GPU_BACKEND=SYCL \
+        -DAMReX_INTEL_ARCH=intel_gpu_pvc \
+        -DAMReX_OMP=OFF \
+        -DAMReX_PARTICLES=ON \
+        -DAMReX_PRECISION="$precision" \
+        -DMPI_CXX_ADDITIONAL_INCLUDE_DIRS='/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi;/usr/lib/x86_64-linux-gnu/openmpi/include' \
+        -DMPI_CXX_LIB_NAMES='mpi_cxx;mpi;open-rte;open-pal;hwloc' \
+        -DMPI_C_ADDITIONAL_INCLUDE_DIRS='/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi;/usr/lib/x86_64-linux-gnu/openmpi/include' \
+        -DMPI_C_LIB_NAMES='mpi;open-rte;open-pal;hwloc' \
+        -DMPI_hwloc_LIBRARY=/lib/x86_64-linux-gnu/libhwloc.so \
+        -DMPI_mpi_LIBRARY=/usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi.so \
+        -DMPI_mpi_cxx_LIBRARY=/usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi_cxx.so \
+        -DMPI_open-pal_LIBRARY=/lib/x86_64-linux-gnu/libopen-pal.so \
+        -DMPI_open-rte_LIBRARY=/lib/x86_64-linux-gnu/libopen-rte.so \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Find libraries in /usr/local/lib64
+RUN echo /usr/local/lib64 >/etc/ld.so.conf.d/usr-local-lib64.conf && \
+    ldconfig

--- a/docker/carpetx-native-rocm.dockerfile
+++ b/docker/carpetx-native-rocm.dockerfile
@@ -1,0 +1,439 @@
+# How to build this Docker image:
+
+#     docker build --file carpetx-native-rocm.dockerfile --tag einsteintoolkit/carpetx:native-rocm-real64 .
+#     docker push einsteintoolkit/carpetx:native-rocm-real64
+
+#     docker build --build-arg real_precision=real32 --file carpetx-native-rocm.dockerfile --tag einsteintoolkit/carpetx:native-rocm-real32 .
+#     docker push einsteintoolkit/carpetx:native-rocm-real32
+
+# FROM rocm/dev-ubuntu-24.04:6.4.1
+# FROM rocm/dev-ubuntu-24.04:6.4.3
+# FROM rocm/dev-ubuntu-24.04:7.1
+# FROM rocm/dev-ubuntu-24.04:7.1.1
+# FROM rocm/dev-ubuntu-24.04:7.2
+# FROM rocm/dev-ubuntu-24.04:7.2.3
+FROM rocm/dev-ubuntu-24.04:7.2.4
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANGUAGE=en_US.en \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
+
+RUN mkdir /cactus
+WORKDIR /cactus
+
+# Install system packages
+# - Boost on Ubuntu requires OpenMPI
+#        elfutils
+#        python2
+RUN apt-get update && \
+    apt-get --yes --no-install-recommends install \
+        ca-certificates \
+        clang-format \
+        cmake \
+        cvs \
+        diffutils \
+        g++ \
+        gcc \
+        gdb \
+        gfortran \
+        git \
+        hdf5-filter-plugin \
+        hdf5-filter-plugin-blosc-serial \
+        hdf5-filter-plugin-zfp-serial \
+        hdf5-plugin-lzf \
+        hdf5-tools \
+        hiprand-dev \
+        hwloc-nox \
+        language-pack-en \
+        less \
+        libblosc-dev \
+        libblosc2-dev \
+        libboost-all-dev \
+        libbz2-dev \
+        libfftw3-dev \
+        libgit2-dev \
+        libgsl-dev \
+        libhdf5-dev \
+        libhwloc-dev \
+        liblz4-dev \
+        libopenblas-dev \
+        libopenmpi-dev \
+        libpetsc-real-dev \
+        libprotobuf-dev \
+        libreadline-dev \
+        libtool \
+        libudev-dev \
+        libyaml-cpp-dev \
+        libzfp-dev \
+        libzstd-dev \
+        locales \
+        m4 \
+        meson \
+        ninja-build \
+        nlohmann-json3-dev \
+        numactl \
+        perl \
+        pkgconf \
+        protobuf-compiler \
+        python3 \
+        python3-numpy \
+        python3-pip \
+        python3-requests \
+        rocprim-dev \
+        rocrand-dev \
+        rocsparse-dev \
+        rsync \
+        subversion \
+        unzip \
+        vim \
+        wget \
+        zlib1g-dev \
+        && \
+    rm -rf /var/lib/apt/lists/*
+
+# # Install HPCToolkit
+# # Install this first because it is expensive to build
+# # Installing HPCToolkit without rocm since the install fails when this option is enabled.
+# RUN mkdir src && \
+#     (cd src && \
+#     wget https://github.com/spack/spack/archive/refs/tags/v1.2.2.tar.gz && \
+#     tar xzf v1.2.2.tar.gz && \
+#     export SPACK_ROOT="$(pwd)/spack-1.2.2" && \
+#     mkdir -p "${HOME}/.spack" && \
+#     echo 'config: {install_tree: {root: /spack}}' >"${HOME}/.spack/config.yaml" && \
+#     . ${SPACK_ROOT}/share/spack/setup-env.sh && \
+#     wget https://github.com/spack/spack-packages/archive/refs/tags/v2026.06.0.tar.gz && \
+#     tar xzf v2026.06.0.tar.gz && \
+#     spack repo add --scope site spack-packages-2026.06.0/repos/spack_repo/builtin && \
+#     spack external find \
+#         autoconf \
+#         automake \
+#         cmake \
+#         diffutils \
+#         elfutils \
+#         gmake \
+#         libtool \
+#         m4 \
+#         meson \
+#         ninja \
+#         numactl \
+#         perl \
+#         pkgconf \
+#         python \
+#     && \
+#     spack install --fail-fast hpctoolkit ~viewer && \
+#     spack view --dependencies no hardlink /hpctoolkit hpctoolkit && \
+#     true) && \
+#     rm -rf src "${HOME}/.spack"
+
+# # Install blosc2
+# # blosc2 is a compression library, comparable to zlib
+# RUN mkdir src && \
+#     (cd src && \
+#     wget https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.18.0.tar.gz && \
+#     tar xzf v2.18.0.tar.gz && \
+#     cd c-blosc2-2.18.0 && \
+#     cmake -B build -G Ninja \
+#         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+#         -DCMAKE_INSTALL_PREFIX=/usr/local \
+#         -DBUILD_BENCHMARKS=OFF \
+#         -DBUILD_EXAMPLES=OFF \
+#         -DBUILD_FUZZERS=OFF \
+#         -DBUILD_STATIC=OFF \
+#         -DBUILD_TESTS=OFF \
+#         -DPREFER_EXTERNAL_LZ4=ON  \
+#         -DPREFER_EXTERNAL_ZLIB=ON \
+#         -DPREFER_EXTERNAL_ZSTD=ON \
+#         && \
+#     cmake --build build && \
+#     cmake --install build && \
+#     true) && \
+#     rm -rf src
+
+# Install MGARD
+# MGARD is a lossy compression library
+# Note: -DMGARD_ENABLE_HIP=ON doesn't work
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/CODARcode/MGARD/archive/refs/tags/1.6.0.tar.gz && \
+    tar xzf 1.6.0.tar.gz && \
+    cd MGARD-1.6.0 && \
+    cmake -B build -G Ninja \
+        -DBUILD_TESTING=OFF \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        -DMGARD_ENABLE_OPENMP=ON \
+        -DMGARD_ENABLE_SERIAL=ON \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install SZ3
+# SZ3 is a lossy compression library
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/szcompressor/SZ3/releases/download/v3.3.2/SZ3-v3.3.2.zip && \
+    unzip SZ3-v3.3.2.zip && \
+    cd SZ3-master && \
+    cmake -B build -G Ninja \
+        -DBUILD_H5Z_FILTER=ON \
+        -DBUILD_MDZ=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install ADIOS2
+# ADIOS2 is a parallel I/O library, comparable to HDF5
+# - depends on blosc2
+# - depends on MGARD
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.12.1.tar.gz && \
+    tar xzf v2.12.1.tar.gz && \
+    cd ADIOS2-2.12.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_TESTING=OFF \
+        -DADIOS2_BUILD_EXAMPLES=OFF \
+        -DADIOS2_Blosc2_PREFER_SHARED=ON \
+        -DADIOS2_USE_BZip2=ON \
+        -DADIOS2_USE_Blosc2=ON \
+        -DADIOS2_USE_Fortran=OFF \
+        -DADIOS2_USE_HDF5=ON \
+        -DADIOS2_USE_MGARD=ON \
+        -DADIOS2_USE_SZ3=ON \
+        -DADIOS2_USE_ZFP=ON && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install ASDF
+# ASDF is an I/O library like HDF5
+# - depends on yaml-cpp
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/asdf-cxx/archive/refs/tags/version/7.3.2.tar.gz && \
+    tar xzf 7.3.2.tar.gz && \
+    cd asdf-cxx-version-7.3.2 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install NSIMD
+# NSIMD allows writing explicitly SIMD-vectorized code
+# Note: This assumes that the system has x86_64 CPUs
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/agenium-scale/nsimd/archive/refs/tags/v3.0.1.tar.gz && \
+    tar xzf v3.0.1.tar.gz && \
+    cd nsimd-3.0.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -Dsimd=AVX2 \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# COPY patches/openPMD-api.patch /cactus/patches/
+
+# Install openPMD-api
+# openPMD-api defines a standard for laying out AMR data in a file
+# - depends on ADIOS2
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/openPMD/openPMD-api/archive/refs/tags/0.17.1.tar.gz && \
+    tar xzf 0.17.1.tar.gz && \
+    cd openPMD-api-0.17.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_EXAMPLES=OFF \
+        -DBUILD_TESTING=OFF \
+        -DopenPMD_BUILD_SHARED_LIBS=ON \
+        -DopenPMD_USE_MPI=ON \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install RePrimAnd
+# RePrimAnd is a physics package for nuclear equations of state
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/wokast/RePrimAnd/archive/refs/tags/v1.7.tar.gz && \
+    tar xzf v1.7.tar.gz && \
+    cd RePrimAnd-1.7 && \
+    meson setup build --buildtype=release --prefix=/usr/local -Dcpp_std=c++14 && \
+    ninja -C build && \
+    ninja -C build install && \
+    true) && \
+    rm -rf src
+
+# Install Silo
+# Silo defines a standard for laying out AMR data in a file
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/LLNL/Silo/releases/download/4.12.1/Silo-4.12.1.tar.xz && \
+    tar xJf Silo-4.12.1.tar.xz && \
+    cd Silo-4.12.1 && \
+    mkdir build && \
+    cd build && \
+    ../configure \
+        --disable-fortran \
+        --disable-static \
+        --enable-optimization \
+        --enable-shared \
+        --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial/include,/usr/lib/x86_64-linux-gnu/hdf5/serial/lib \
+        --prefix=/usr/local \
+        && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    true) && \
+    rm -rf src
+
+# Install Conduit
+# Conduit defines a standard for laying out AMR data in a file.
+# - depends on Silo
+# TODO:
+# - enable CUDA? HIP?
+# -DADIOS_DIR=/usr/local   # conduit doesn't find ADIOS because there is no FindADIOS.cmake
+# -DZFP_DIR=/usr           # conduit doesn't find zfp because the library directory is wrong
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/LLNL/conduit/releases/download/v0.9.7/conduit-v0.9.7-src-with-blt.tar.gz && \
+    tar xzf conduit-v0.9.7-src-with-blt.tar.gz && \
+    cd conduit-v0.9.7 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCONDUIT_ENABLE_TESTS=OFF \
+        -DENABLE_COVERAGE=OFF \
+        -DENABLE_DOCS=OFF \
+        -DENABLE_EXAMPLES=OFF \
+        -DENABLE_FORTRAN=OFF \
+        -DENABLE_MPI=ON \
+        -DENABLE_OPENMP=ON \
+        -DENABLE_PYTHON=ON \
+        -DENABLE_RELAY_WEBSERVER=OFF \
+        -DENABLE_TESTS=OFF \
+        -DENABLE_UTILS=ON \
+        -DHDF5_DIR=/usr \
+        -DSILO_DIR=/usr/local \
+        -DZLIB_DIR=/usr \
+        src \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install SimulationIO
+# SimulationIO is an I/O library like HDF5
+# - depends on asdf-cxx
+# - depends on yaml-cpp
+# Currently disabling ASDF because there is a confusion with C++11/17 standards
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/SimulationIO/archive/refs/tags/version/9.0.3.tar.gz && \
+    tar xzf 9.0.3.tar.gz && \
+    cd SimulationIO-version-9.0.3 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DENABLE_ASDF_CXX=OFF \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install ssht
+# ssht provides spin-weighted spherical harmonics
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/astro-informatics/ssht/archive/v1.5.2.tar.gz && \
+    tar xzf v1.5.2.tar.gz && \
+    cd ssht-1.5.2 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_TESTING=OFF \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+ARG real_precision=real64
+
+# Install AMReX
+# AMReX provides adaptive mesh refinement
+# - Enable Fortran for `docker/Dockerfile`
+# - Install this last because it changes most often
+# Should we keep the AMReX source tree around for debugging?
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/AMReX-Codes/amrex/archive/26.01.tar.gz && \
+    tar xzf 26.01.tar.gz && \
+    cd amrex-26.01 && \
+    case $real_precision in \
+        real32) precision=SINGLE;; \
+        real64) precision=DOUBLE;; \
+        *) exit 1;; \
+    esac && \
+    env LDFLAGS=-Wl,-rpath,/opt/rocm/lib \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
+        -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
+        -DCMAKE_PREFIX_PATH='/opt/rocm/lib/cmake/AMDDeviceLibs;/opt/rocm/lib/cmake/amd_comgr;/opt/rocm/lib/cmake/hip;/opt/rocm/lib/cmake/hiprand;/opt/rocm/lib/cmake/hsa-runtime64;/opt/rocm/lib/cmake/rocprim;/opt/rocm/lib/cmake/rocrand;/opt/rocm/lib/cmake/rocsparse' \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DAMReX_AMD_ARCH=gfx90a \
+        -DAMReX_FORTRAN=OFF \
+        -DAMReX_FORTRAN_INTERFACES=OFF \
+        -DAMReX_GPU_BACKEND=HIP \
+        -DAMReX_OMP=OFF \
+        -DAMReX_PARTICLES=ON \
+        -DAMReX_PRECISION="$precision" \
+        -DMPI_CXX_ADDITIONAL_INCLUDE_DIRS='/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi;/usr/lib/x86_64-linux-gnu/openmpi/include' \
+        -DMPI_CXX_LIB_NAMES='mpi_cxx;mpi;open-rte;open-pal;hwloc' \
+        -DMPI_C_ADDITIONAL_INCLUDE_DIRS='/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi;/usr/lib/x86_64-linux-gnu/openmpi/include' \
+        -DMPI_C_LIB_NAMES='mpi;open-rte;open-pal;hwloc' \
+        -DMPI_hwloc_LIBRARY=/lib/x86_64-linux-gnu/libhwloc.so \
+        -DMPI_mpi_LIBRARY=/usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi.so \
+        -DMPI_mpi_cxx_LIBRARY=/usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi_cxx.so \
+        -DMPI_open-pal_LIBRARY=/lib/x86_64-linux-gnu/libopen-pal.so \
+        -DMPI_open-rte_LIBRARY=/lib/x86_64-linux-gnu/libopen-rte.so \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Find libraries in /usr/local/lib64
+RUN echo /usr/local/lib64 >/etc/ld.so.conf.d/usr-local-lib64.conf && \
+    ldconfig

--- a/docker/carpetx-oneapi.dockerfile
+++ b/docker/carpetx-oneapi.dockerfile
@@ -6,10 +6,148 @@
 #     docker build --build-arg real_precision=real32 --file carpetx-oneapi.dockerfile --tag einsteintoolkit/carpetx:oneapi-real32 .
 #     docker push einsteintoolkit/carpetx:oneapi-real32
 
+# This is `carpetx-native-oneapi.dockerfile` with every MPI-using library moved
+# onto the **MPI ABI** (MPI-5.0 §20.2) instead of a directly-linked MPI. Two
+# packages provide that ABI over the distribution's MPI:
+#
+#   mpi_abi_wrapper  the C bindings: `mpi.h`, `libmpi_abi`, `mpicc`, `mpicxx`
+#   mpif             the Fortran bindings: `mpif.h`, `mpi.mod`, `mpi_f08.mod`,
+#                    `libmpif`, `mpifort` -- needed because §20.4 leaves
+#                    `MPI_Fint` and the Fortran modules out of the ABI entirely
+#
+# Both install into `/usr/local`, so `/usr/local/bin/{mpicc,mpicxx,mpifort}` is
+# the toolchain every stanza below is pointed at, and neither `libmpi.so.40`
+# (Open MPI) nor `libmpi.so.12` (Intel MPI) may appear in the `ldd` output of
+# anything this file installs. Which MPI actually
+# runs a binary is then a *run-time* choice: `libmpi_abi` dlopens the wrapper,
+# and another ABI-providing implementation can be put in front of it without
+# recompiling. `/usr/local/bin/mpiexec` is a **forwarder**, not a launcher:
+# starting a job stays the wrapped MPI's business, so it resolves that MPI's own
+# `mpiexec` -- `$MPI_ABI_WRAPPER_MPIEXEC`, else the path found beside
+# `MPI_C_COMPILER` at configure time -- and passes every argument through. That
+# is the same run-time indirection `libmpi_abi` uses to find `libmpiwrapper`, so
+# the launcher follows the library when a binary is re-pointed.
+#
+# Consequences for the apt list below:
+# - `libhdf5-dev` and `libpetsc-real-dev` are **gone**. Both are built here
+#   instead, over the ABI. PETSc drags in a whole parallel stack when installed
+#   from apt -- parallel HDF5, hypre, MUMPS, ScaLAPACK, PtScotch, SuperLU-DIST,
+#   CombBLAS, FFTW3-MPI -- every one of which links `libmpi.so.40`; dropping it
+#   removes all of them at once, and the PETSc built here has none of them.
+# - `libaec-dev` is **added**: it provides the szip encoder that Debian's HDF5
+#   was built with, which the HDF5 built here would otherwise lose.
+# - `libcurl4-openssl-dev` and `libjpeg-dev` are **added** because they were
+#   only ever present as transitive dependencies of `libpetsc-real-dev`, and
+#   dropping it took them with it. The Cactus option list points LIBCURL_DIR
+#   and LIBJPEG_DIR at /usr, so their absence stops the CST outright:
+#   "LIBJPEG not found at /usr". Naming them explicitly is right regardless --
+#   depending on PETSc to supply an image's libjpeg was always an accident.
+# - `python3-dev` is **added** for the same kind of reason. Conduit is built
+#   with `-DENABLE_PYTHON=ON`, so its `find_package(Python3 ... Development
+#   NumPy)` needs `Python.h` and the numpy headers; those arrived only as a
+#   transitive dependency of `libboost-all-dev`, by way of
+#   `libboost-python1.83-dev`. Naming it explicitly is right regardless, and is
+#   required outright in the images below that narrow Boost.
+# - `libopenmpi-dev` is **gone**. The MPI being wrapped here is Intel MPI, out
+#   of the base image, and there is to be exactly one MPI in the image.
+# - `libboost-all-dev` becomes **`libboost-filesystem-dev`**, and this is not
+#   cosmetic: `libboost-all-dev` depends on `libboost-mpi-dev`, which depends on
+#   `libopenmpi-dev`, so leaving it in would reinstall Ubuntu's Open MPI through
+#   the back door and defeat the line above. `libboost-filesystem-dev` reaches
+#   no MPI package at all (checked with `apt-cache depends --recurse`).
+#   **Not plain `libboost-dev`**, which is the obvious narrowing and does not
+#   work: RePrimAnd's `meson.build` asks for `dependency('boost')`, and Meson's
+#   Boost detection wants to see boost *libraries* even when the dependency is
+#   header-only -- with headers alone it reports "Run-time dependency Boost
+#   found: NO (tried system)" and RePrimAnd stops. Measured on Ubuntu 26.04:
+#   `libboost-dev` installs 0 boost libraries and fails; `libboost-filesystem-dev`
+#   installs 6 and gives "Boost found: YES 1.90.0 (/usr)".
+#   `filesystem` is the right component to keep rather than an arbitrary one:
+#   `desert-arm64v8.cfg` sets `BOOST_LIBS="boost_filesystem"`, so Cactus does
+#   link it. Nothing else does -- CarpetX's own Boost use is header-only
+#   (`boost::math` in `repos/CarpetX/Algo/src/roots.hxx`) and RePrimAnd's
+#   `dependency('boost')` names no modules -- so for those it only has to be
+#   present to be found.
+#
+# The matching Cactus option list needs `MPI_DIR = /usr/local`,
+# `HDF5_DIR = /usr/local` (with `hdf5_hl_fortran`/`hdf5_fortran`, the CMake
+# spelling, rather than Debian's `hdf5hl_fortran`), and `PETSC_DIR = /usr/local`.
+#
+# oneAPI-specific notes:
+# - **the wrapped MPI is Intel MPI**, at `$I_MPI_ROOT` =
+#   `/opt/intel/oneapi/mpi/2021.18`, which the base image ships. This reverses
+#   `carpetx-native-oneapi.dockerfile`'s policy: that file deletes Intel MPI outright
+#   (a `find /opt/intel -name 'libmpi*so' -delete` stanza, and a second
+#   `rm -rf /opt/intel/oneapi/mpi` inside the AMReX stanza) in order to use
+#   Ubuntu's Open MPI instead. Under the ABI there is no reason to throw the
+#   vendor MPI away: it is wrapped like any other, and a run-time swap can still
+#   put a different implementation in front of it. Both deletion stanzas are
+#   therefore gone -- except for the `libhwloc.a`/`libhwloc.so` half of the
+#   first, which is about Intel's hwloc colliding with the system one and has
+#   nothing to do with MPI.
+# - mpi_abi_wrapper is configured with `mpiicx`, Intel MPI's *Intel-compiler*
+#   wrapper, rather than its GNU-compiler `mpicc`, so that the wrapper is built
+#   by the same `icx` that compiles everything else in this image.
+# - **the base image advertises Intel MPI's headers to every compiler
+#   invocation**, through `C_INCLUDE_PATH` and `CPLUS_INCLUDE_PATH`. That
+#   shadows the ABI's own `mpi.h` everywhere, and no compiler flag can undo it,
+#   because /usr/local/include is a built-in system directory and `-I` on such a
+#   directory is ignored. The wrapped MPI's include directory is therefore moved
+#   aside once mpi_abi_wrapper has been built; see the stanza that does it.
+# - the base image moves from `intel/oneapi-basekit` to
+#   `intel/oneapi-toolkit`. basekit is dead-ended at 2025.3.2 with no Ubuntu 26
+#   tag; oneapi-toolkit is its successor and bundles Intel MPI, MKL and the
+#   compilers together. **Watch the AMReX link step**: `carpetx-native-oneapi.dockerfile`
+#   is deliberately pinned back to basekit 2025.2.2 because every later basekit
+#   broke it. Whether that is fixed in the 2026.1.0 toolkit is unknown; if it
+#   recurs, fall back to basekit 2025.2.2 and keep everything else here.
+# - the apt list is `carpetx-cpu.dockerfile`'s (minus `libopenmpi-dev`,
+#   with Boost narrowed), not `carpetx-native-oneapi.dockerfile`'s. That file drops a
+#   dozen packages -- `make`, `patch`, `tar`, `xz-utils`, `bzip2`, ... -- because
+#   it builds neither HPCToolkit nor PETSc from source. The PETSc stanza below
+#   does, and `--download-*` needs those tools.
+# - AMReX's nine hard-wired `-DMPI_*` variables are **gone**. They named Open
+#   MPI's `libmpi`, `libmpi_cxx`, `libopen-rte` and `libopen-pal` by absolute
+#   path, which is both the wrong MPI now and exactly the kind of direct link
+#   this file forbids. If `icpx` turns out not to accept what
+#   `mpi_abi_wrapper`'s `mpicc -showme:link` reports, the ABI spelling is far
+#   simpler, the ABI having no `open-rte`/`open-pal`/`mpi_cxx` split:
+#   `-DMPI_C_LIB_NAMES=mpi_abi`,
+#   `-DMPI_mpi_abi_LIBRARY=/usr/local/lib/libmpi_abi.so` and
+#   `-DMPI_C_ADDITIONAL_INCLUDE_DIRS=/usr/local/include`.
+
+# The basekit images are `carpetx-native-oneapi.dockerfile`'s history; that file is
+# pinned to 2025.2.2 because the AMReX linker step is broken on every later
+# basekit. basekit itself is now dead-ended -- 2025.3.2 is its last release and
+# it has no Ubuntu 26 tag -- so oneapi-toolkit is the only way forward.
 # FROM intel/oneapi-basekit:2025.2.0-0-devel-ubuntu24.04
-FROM intel/oneapi-basekit:2025.2.2-0-devel-ubuntu24.04
-# [AMReX linker step is broken]
+# FROM intel/oneapi-basekit:2025.2.2-0-devel-ubuntu24.04
 # FROM intel/oneapi-basekit:2025.3.0-0-devel-ubuntu24.04
+# FROM intel/oneapi-basekit:2025.3.1-0-devel-ubuntu24.04
+# FROM intel/oneapi-basekit:2025.3.2-0-devel-ubuntu24.04
+# FROM intel/oneapi-toolkit:2026.0.0-devel-ubuntu24.04
+# FROM intel/oneapi-toolkit:2026.0.1-devel-ubuntu24.04
+FROM intel/oneapi-toolkit:2026.1.0-devel-ubuntu26.04
+
+# The base image puts Intel MPI's `bin` second on PATH, six entries ahead of
+# /usr/local/bin, so a bare `mpiexec`, `mpirun`, `mpicc` or `mpicxx` means the
+# *wrapped* MPI's rather than the ABI prefix's. Today the two launchers are the
+# same binary -- `/usr/local/bin/mpiexec` is a forwarder, and the launcher it
+# forwards to is the one found beside `MPI_C_COMPILER` at configure time, i.e.
+# Intel's -- so this is not a correctness bug now. It matters for two other
+# reasons:
+# - the run-time swap this whole file exists to enable. Point
+#   `MPI_ABI_WRAPPER_LIB` at another implementation and the forwarder follows it
+#   through `MPI_ABI_WRAPPER_MPIEXEC`, while a bare Intel `mpiexec` does not.
+#   Launcher and library must match, and a mismatch does not fail loudly -- it
+#   silently starts N one-rank jobs. Cactus's own runscript (`desert.run`) calls
+#   `mpiexec` unqualified, so this is the ordering it will get.
+# - `mpicc`/`mpicxx`. Intel MPI's wrappers stop working further down anyway,
+#   once its `include` directory is moved aside, so a bare `mpicc` resolving to
+#   them would fail confusingly rather than compile against the ABI.
+# The CUDA variant needs the same line for the same reason; the ROCm and CPU
+# variants do not, having /usr/local/bin ahead of their MPI already.
+ENV PATH=/usr/local/bin:${PATH}
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LANGUAGE=en_US.en \
@@ -21,14 +159,20 @@ WORKDIR /cactus
 
 # Install system packages
 # - Boost on Ubuntu requires OpenMPI
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 28DA432DAAC8BAEA && \
-    apt-get update --allow-insecure-repositories && \
+#        elfutils
+#        python2
+RUN apt-get update && \
     apt-get --yes --no-install-recommends install \
+        bison \
+        bzip2 \
         ca-certificates \
         clang-format \
         cmake \
+        curl \
         cvs \
         diffutils \
+        elfutils \
+        flex \
         g++ \
         gcc \
         gdb \
@@ -42,19 +186,22 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 28DA432DAAC8BAEA &&
         hwloc-nox \
         language-pack-en \
         less \
+        libaec-dev \
         libblosc-dev \
         libblosc2-dev \
-        libboost-all-dev \
+        libboost-filesystem-dev \
         libbz2-dev \
+        libcurl4-openssl-dev \
         libfftw3-dev \
         libgit2-dev \
         libgsl-dev \
-        libhdf5-dev \
         libhwloc-dev \
+        libiberty-dev \
+        libjpeg-dev \
         liblz4-dev \
+        liblzma-dev \
         libopenblas-dev \
-        libopenmpi-dev \
-        libpetsc-real-dev \
+        libpapi-dev \
         libprotobuf-dev \
         libreadline-dev \
         libtool \
@@ -64,69 +211,350 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 28DA432DAAC8BAEA &&
         libzstd-dev \
         locales \
         m4 \
+        make \
         meson \
         ninja-build \
         nlohmann-json3-dev \
         numactl \
+        papi-tools \
+        patch \
         perl \
         pkgconf \
         protobuf-compiler \
         python3 \
+        python3-dev \
         python3-numpy \
         python3-pip \
         python3-requests \
+        python3-venv \
         rsync \
         subversion \
+        tar \
+        unzip \
         vim \
         wget \
+        xz-utils \
         zlib1g-dev \
+        zstd \
         && \
     rm -rf /var/lib/apt/lists/*
 
-# Remove troublesome libraries
-RUN find /opt/intel -name 'impi.pc' -delete && \
-    find /opt/intel -name 'libhwloc.a' -delete && \
-    find /opt/intel -name 'libhwloc.so' -delete && \
-    find /opt/intel -name 'libmpi*a' -delete && \
-    find /opt/intel -name 'libmpi*so' -delete && \
-    find /opt/intel -name 'mpi.h' -delete && \
-    find /opt/intel -name 'mpicc' -delete && \
-    find /opt/intel -name 'mpicxx' -delete && \
-    find /opt/intel -name 'mpiexec' -delete && \
-    find /opt/intel -name 'mpirun' -delete
-
-# # Install blosc2
-# # blosc2 is a compression library, comparable to zlib
+# # Install HPCToolkit
+# # Install this first because it is expensive to build
+# # HPCToolkit is not built here, matching `carpetx-native-oneapi.dockerfile`.
 # RUN mkdir src && \
 #     (cd src && \
-#     wget https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.18.0.tar.gz && \
-#     tar xzf v2.18.0.tar.gz && \
-#     cd c-blosc2-2.18.0 && \
-#     cmake -B build -G Ninja \
-#         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-#         -DCMAKE_INSTALL_PREFIX=/usr/local \
-#         -DBUILD_BENCHMARKS=OFF \
-#         -DBUILD_EXAMPLES=OFF \
-#         -DBUILD_FUZZERS=OFF \
-#         -DBUILD_STATIC=OFF \
-#         -DBUILD_TESTS=OFF \
-#         -DPREFER_EXTERNAL_LZ4=ON  \
-#         -DPREFER_EXTERNAL_ZLIB=ON \
-#         -DPREFER_EXTERNAL_ZSTD=ON \
-#         && \
-#     cmake --build build && \
-#     cmake --install build && \
+#     wget https://github.com/spack/spack/archive/refs/tags/v1.2.2.tar.gz && \
+#     tar xzf v1.2.2.tar.gz && \
+#     export SPACK_ROOT="$(pwd)/spack-1.2.2" && \
+#     mkdir -p "${HOME}/.spack" && \
+#     echo 'config: {install_tree: {root: /spack}}' >"${HOME}/.spack/config.yaml" && \
+#     . ${SPACK_ROOT}/share/spack/setup-env.sh && \
+#     wget https://github.com/spack/spack-packages/archive/refs/tags/v2026.06.0.tar.gz && \
+#     tar xzf v2026.06.0.tar.gz && \
+#     spack repo add --scope site spack-packages-2026.06.0/repos/spack_repo/builtin && \
+#     spack external find \
+#         autoconf \
+#         automake \
+#         cmake \
+#         curl \
+#         diffutils \
+#         elfutils \
+#         gmake \
+#         libtool \
+#         m4 \
+#         meson \
+#         ninja \
+#         numactl \
+#         perl \
+#         pkgconf \
+#         python \
+#     && \
+#     spack install --fail-fast hpctoolkit ~viewer && \
+#     spack view --dependencies no hardlink /hpctoolkit hpctoolkit && \
 #     true) && \
-#     rm -rf src
+#     rm -rf src "${HOME}/.spack"
+
+# Remove troublesome libraries
+# Only the hwloc half of `carpetx-native-oneapi.dockerfile`'s stanza survives: Intel's
+# static and shared hwloc collide with the system one. Every `libmpi*`, `mpi.h`,
+# `mpicc`, `mpicxx`, `mpiexec` and `mpirun` deletion is gone -- that MPI is the
+# one being wrapped below.
+RUN find /opt/intel -name 'libhwloc.a' -delete && \
+    find /opt/intel -name 'libhwloc.so' -delete
+
+# Put the ABI's libraries ahead of Intel MPI's on the linker's search path
+# `/usr/local/lib` is not in ld's default list on Debian, while the base image
+# puts Intel MPI's `lib` on LIBRARY_PATH, so a bare `-lmpi` would find Intel
+# MPI's `libmpi.so`. Nothing here asks for `-lmpi` -- the ABI is `-lmpi_abi` --
+# but the ordering costs nothing and removes the possibility.
+# The include side of the same problem is *not* solvable this way; see the
+# stanza after mpi_abi_wrapper below.
+ENV LIBRARY_PATH=/usr/local/lib:${LIBRARY_PATH}
+
+# Install mpi_abi_wrapper
+# mpi_abi_wrapper wraps an MPI library and provides the MPI ABI
+# The MPI being wrapped is Intel MPI from the base image, named explicitly:
+# left to itself find_package(MPI) would search PATH, and `mpiicx` is Intel
+# MPI's Intel-compiler wrapper, which is what the rest of this image compiles
+# with. MPI_HOME points at the same prefix so that any nested find_package(MPI)
+# inside the wrapper's own build agrees.
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/mpi_abi_wrapper/archive/refs/tags/v1.2.0.tar.gz && \
+    tar xzf v1.2.0.tar.gz && \
+    cd mpi_abi_wrapper-1.2.0 && \
+    cmake -B build -G Ninja \
+        -DBUILD_TESTING=OFF \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        -DMPI_C_COMPILER="${I_MPI_ROOT}/bin/mpiicx" \
+        -DMPI_HOME="${I_MPI_ROOT}" \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Hide the wrapped MPI's headers from everything below
+# On `carpetx-cpu.dockerfile` nothing has to be done here: no other
+# `mpi.h` on that image sits in a directory the compiler searches unasked. This
+# image is different -- the base exports Intel MPI's include directory in
+# `C_INCLUDE_PATH` and `CPLUS_INCLUDE_PATH` -- and that **cannot be out-ranked
+# from the command line**. GCC searches `-I` and CPATH first, then `-isystem`
+# and C_INCLUDE_PATH/CPLUS_INCLUDE_PATH, then its built-in directories; but
+# /usr/local/include *is* a built-in directory, and "if a standard system
+# include directory is also specified with -I, the -I option is ignored" -- it
+# stays at the end of the chain. Measured, all three ways: with Intel MPI's
+# directory on C_INCLUDE_PATH, plain compilation, `-I/usr/local/include` and
+# `CPATH=/usr/local/include` all pick Intel MPI's header. Only `-isystem` or
+# removing the directory changes the answer, and `-isystem` would have to be
+# threaded through every stanza's flags.
+#
+# The symptom if this is skipped: mpif compiles against Intel MPI's `mpi.h` and
+# fails on `MPI_ABI_VERSION undeclared` and on
+# `sizeof(MPI_Status) == 8 * sizeof(MPI_Fint)` -- Intel MPI is MPICH-derived,
+# with MPI_STATUS_SIZE 5, where the ABI mandates 8. HDF5, ADIOS2, openPMD, Silo
+# and Conduit would all have hit it next.
+#
+# So the headers are moved aside, which makes the invariant this file rests on
+# -- nothing below compiles against the MPI being wrapped -- a property of the
+# filesystem rather than of a search path. It is version-independent, unlike
+# editing `2021.18` out of the two variables. **Only the headers move**:
+# `libmpi.so` stays where it is, because `libmpiwrapper` linked it just above
+# and dlopens it at run time. `mpif.h` and the `mpi*.mod` files go along with
+# them, which is intended -- mpif supplies its own, and a Fortran thorn finding
+# Intel MPI's would be the same bug one language over.
+#
+# Placed after mpi_abi_wrapper, the one stanza that legitimately needs these
+# headers, and before everything that must not see them.
+RUN mv "${I_MPI_ROOT}/include" "${I_MPI_ROOT}/include.wrapped-by-mpi-abi"
+
+# Install mpif
+# mpif provides the Fortran bindings for the MPI ABI
+# - depends on mpi_abi_wrapper
+# The ABI is specified for C only: MPI-5.0 §20.4 leaves `MPI_Fint` and the
+# Fortran modules out of it deliberately, so `mpi.h` and `libmpi_abi` give a
+# Fortran caller nothing. mpif supplies `mpif.h`, `use mpi` and `use mpi_f08`
+# on top of them, and is what makes HDF5's Fortran interface, PETSc's Fortran
+# stubs and Cactus's own Fortran thorns possible over the ABI.
+# MPI_C_COMPILER is named explicitly rather than left to find_package(MPI):
+# CMake's FindMPI searches PATH, finds the wrapped MPI's own `mpicc` -- Intel
+# MPI's, in this image -- and mpif then stops with "MPI_C_LIBRARIES ... names no
+# libmpi_abi". MPI_HOME is what mpifort records as its default MPI prefix
+# (`mpifort -showme:mpiprefix`).
+# CMAKE_Fortran_COMPILER is pinned, which matters only in this image: the oneAPI
+# base puts `ifx` on PATH alongside apt's gfortran, and CMake is otherwise free
+# to pick either. `ifx` is named so that this image has one Fortran toolchain
+# throughout, matching the `icx`/`icpx` the rest of it uses. HDF5 below carries
+# the same pin and PETSc inherits it through mpifort, so `libmpif`, HDF5's
+# Fortran interface and PETSc's Fortran stubs all agree.
+# **The Cactus option list must follow**: Fortran `.mod` files are
+# compiler-specific, so `desert-oneapi.cfg`'s `F90 = gfortran` has to become
+# `F90 = ifx`, or `use mpi` in a thorn gets a module file it cannot read.
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/mpif/archive/refs/tags/v1.0.1.tar.gz && \
+    tar xzf v1.0.1.tar.gz && \
+    cd mpif-1.0.1 && \
+    cmake -B build -G Ninja \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_Fortran_COMPILER=ifx \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_HOME=/usr/local \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# From here on, every find_package(MPI) must resolve to the ABI rather than to
+# the system Open MPI on PATH. The stanzas below say so explicitly with
+# -DMPI_C_COMPILER, but that does not reach a find_package(MPI) issued from
+# *inside* another package's config file -- and HDF5's `hdf5-config.cmake` does
+# exactly that, to rebuild the MPI::MPI_C target its exported targets depend
+# on. A consumer that merely links HDF5 therefore acquires an -lmpi against the
+# system MPI, silently: measured on SZ3's H5Z filter and on Silo, both of which
+# came out with a direct NEEDED on libmpi.so.40. MPI_HOME is a documented
+# FindMPI hint (`MPI_HINT_DIRS`, FindMPI.cmake) read from the environment, so
+# it reaches those nested calls where -D cannot.
+ENV MPI_HOME=/usr/local
+
+# Install HDF5
+# HDF5 is the I/O library nearly everything below reads and writes through
+# - depends on mpi_abi_wrapper (parallel I/O) and mpif (the Fortran interface)
+# Built here rather than taken from apt because Debian's parallel flavour
+# (`libhdf5-openmpi-dev`) links libmpi.so.40, and its serial flavour has no
+# MPI-IO at all. Cactus wants one HDF5 with all three language interfaces:
+# - HDF5_ALLOW_UNSUPPORTED is required because HDF5 refuses to combine the C++
+#   interface with parallel I/O. Debian's `libhdf5-openmpi-cpp` is built the
+#   same way; the C++ interface simply has no parallel entry points of its own.
+# - HDF5 2.x renamed two of these options from their 1.14 spellings, and both
+#   renames fail quietly rather than loudly: `ALLOW_UNSUPPORTED` became
+#   `HDF5_ALLOW_UNSUPPORTED` (that one does at least stop the configure), and
+#   `HDF5_ENABLE_Z_LIB_SUPPORT` became `HDF5_ENABLE_ZLIB_SUPPORT` -- the old
+#   name is merely reported as an unused variable, and the build then finishes
+#   with no zlib and hence no `deflate` filter at all.
+# - the CMake build spells the Fortran libraries `hdf5_fortran` /
+#   `hdf5_hl_fortran`, where Debian spells the latter `hdf5hl_fortran`. The
+#   Cactus option list has to follow this spelling.
+# - the `hdf5-filter-plugin*` and `hdf5-plugin-lzf` apt packages install their
+#   dynamically-loaded filters under /usr/lib/*/hdf5/{serial,openmpi}/plugins,
+#   built against Debian's `libhdf5_serial`. This build looks in
+#   /usr/local/hdf5/lib/plugin instead, so it does not load them -- which is
+#   the right outcome, since loading them would pull a second HDF5 with a
+#   different soname into the process. Those packages remain useful to apt's
+#   own /usr/bin/h5dump; a file needing one of those filters has to be read
+#   with that, not with /usr/local/bin/h5dump.
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/HDFGroup/hdf5/releases/download/2.2.0/hdf5-2.2.0.tar.gz && \
+    tar xzf hdf5-2.2.0.tar.gz && \
+    cd hdf5-2.2.0 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_Fortran_COMPILER=ifx \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_STATIC_LIBS=OFF \
+        -DBUILD_TESTING=OFF \
+        -DHDF5_ALLOW_UNSUPPORTED=ON \
+        -DHDF5_BUILD_CPP_LIB=ON \
+        -DHDF5_BUILD_EXAMPLES=OFF \
+        -DHDF5_BUILD_FORTRAN=ON \
+        -DHDF5_BUILD_HL_LIB=ON \
+        -DHDF5_BUILD_TOOLS=ON \
+        -DHDF5_ENABLE_PARALLEL=ON \
+        -DHDF5_ENABLE_SZIP_ENCODING=ON \
+        -DHDF5_ENABLE_SZIP_SUPPORT=ON \
+        -DHDF5_ENABLE_ZLIB_SUPPORT=ON \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
+        -DMPI_Fortran_COMPILER=/usr/local/bin/mpifort \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install PETSc
+# PETSc provides the linear and nonlinear solvers CarpetX/PDESolvers uses
+# - depends on mpi_abi_wrapper, mpif, HDF5, and a BLAS/LAPACK
+#
+# The external packages below are the set an HPC site would normally enable,
+# and the reason they are here is CarpetX/PDESolvers: it assembles the whole
+# refinement hierarchy into one flat `MatCreateAIJ` and then chooses no
+# preconditioner in the source at all, so whatever PETSc defaults to (ILU
+# serially, block-Jacobi/ILU in parallel) is what ends up solving an elliptic
+# problem that wants multigrid. Every package here is reachable from
+# `PDESolvers::petsc_options` alone, with no code change:
+#
+#   hypre         BoomerAMG, the standard algebraic multigrid for exactly this
+#                 (`-pc_type hypre -pc_hypre_type boomeramg`). This is the one
+#                 that matters; the rest are supporting cast.
+#   MUMPS         parallel sparse direct (`-pc_type lu
+#                 -pc_factor_mat_solver_type mumps`) -- the fallback when AMG
+#                 stalls, and the usual coarse-grid solver
+#   SuperLU_DIST  the other parallel direct solver, same role
+#   SuperLU       serial direct
+#   SuiteSparse   UMFPACK / CHOLMOD / KLU, serial direct
+#   ScaLAPACK     required by MUMPS
+#   METIS         graph partitioning
+#   PT-Scotch     parallel partitioning and ordering, for MUMPS and SuperLU_DIST
+#
+# - **PT-Scotch rather than ParMETIS**, the other obvious choice for that last
+#   slot: ParMETIS is licensed for non-commercial research use only, so it must
+#   not go into an image that gets pushed to a registry. PT-Scotch is CeCILL-C,
+#   and its `libptscotchparmetisv3` answers the ParMETIS v3 API that MUMPS and
+#   SuperLU_DIST actually ask for. Debian's PETSc makes the same substitution
+#   for the same reason.
+# - **--download-* rather than a stanza each.** PETSc builds these with the
+#   compilers it was given, so they come out over the ABI automatically, and
+#   their versions stay matched to the PETSc release, which is the combination
+#   PETSc tests. Wiring eight packages up by hand and then persuading PETSc to
+#   accept them is the part that goes wrong.
+# - PT-Scotch generates its parsers at build time, which is why `flex` and
+#   `bison` are in the apt list above. Without them configure dies deep in the
+#   download stage with "PTScotch needs flex installed".
+# - --with-hdf5-dir draws a warning -- "Using version 2.2.0 of package HDF5,
+#   PETSc is tested with 1.14". Configure accepts it; nothing in Cactus uses
+#   PetscViewerHDF5, so this is availability rather than something relied on.
+#   Drop --with-hdf5-dir if it ever turns into a hard error.
+# - PETSc's configure compiles and runs small MPI programs. Intel MPI does not
+#   refuse to run as root the way Open MPI does, so the OMPI_ALLOW_RUN_AS_ROOT
+#   pair `carpetx-cpu.dockerfile` needs here is not required; it is left
+#   in place anyway, harmless, in case the wrapped MPI is ever changed back.
+# - --with-mpiexec names the ABI prefix's own `mpiexec`, which forwards to the
+#   wrapped MPI's launcher rather than being one. Naming the forwarder rather
+#   than /usr/bin/mpiexec keeps the recorded launcher correct if this image is
+#   later re-pointed at another MPI; PETSc would otherwise bake in whatever it
+#   found on PATH.
+# - the stock build installs `libpetsc.so` and `include/petsc.h` under one
+#   prefix, which is exactly the layout `ExternalLibraries-PETSc/src/detect.sh`
+#   looks for -- unlike Debian's `libpetsc_real.so` under /usr/lib/petsc.
+RUN mkdir src && \
+    (cd src && \
+    export OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 && \
+    wget https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.25.5.tar.gz && \
+    tar xzf petsc-3.25.5.tar.gz && \
+    cd petsc-3.25.5 && \
+    ./configure \
+        --prefix=/usr/local \
+        --download-hypre \
+        --download-metis \
+        --download-mumps \
+        --download-ptscotch \
+        --download-scalapack \
+        --download-suitesparse \
+        --download-superlu \
+        --download-superlu_dist \
+        --with-blaslapack-lib=-lopenblas \
+        --with-cc=/usr/local/bin/mpicc \
+        --with-cxx=/usr/local/bin/mpicxx \
+        --with-debugging=0 \
+        --with-fc=/usr/local/bin/mpifort \
+        --with-hdf5-dir=/usr/local \
+        --with-mpiexec=/usr/local/bin/mpiexec \
+        --with-shared-libraries=1 \
+        --with-x=0 \
+        COPTFLAGS=-O2 CXXOPTFLAGS=-O2 FOPTFLAGS=-O2 \
+        && \
+    make && \
+    make install && \
+    true) && \
+    rm -rf src
 
 # Install MGARD
 # MGARD is a lossy compression library
 # Note: -DMGARD_ENABLE_SYCL=ON does not work
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/CODARcode/MGARD/archive/refs/tags/1.5.2.tar.gz && \
-    tar xzf 1.5.2.tar.gz && \
-    cd MGARD-1.5.2 && \
+    wget https://github.com/CODARcode/MGARD/archive/refs/tags/1.6.0.tar.gz && \
+    tar xzf 1.6.0.tar.gz && \
+    cd MGARD-1.6.0 && \
     cmake -B build -G Ninja \
         -DBUILD_TESTING=OFF \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -140,15 +568,58 @@ RUN mkdir src && \
     true) && \
     rm -rf src
 
+# Install SZ3
+# SZ3 is a lossy compression library
+# - BUILD_H5Z_FILTER links HDF5, which drags MPI in behind it; hence the
+#   compilers, even though SZ3 itself knows nothing about MPI
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/szcompressor/SZ3/releases/download/v3.3.2/SZ3-v3.3.2.zip && \
+    unzip SZ3-v3.3.2.zip && \
+    cd SZ3-master && \
+    cmake -B build -G Ninja \
+        -DBUILD_H5Z_FILTER=ON \
+        -DBUILD_MDZ=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
 # Install ADIOS2
 # ADIOS2 is a parallel I/O library, comparable to HDF5
 # - depends on blosc2
 # - depends on MGARD
+# - depends on mpi_abi_wrapper: ADIOS2 is built against the MPI ABI, not against
+#   the system MPI directly. ADIOS2 inserts its own `cmake/` at the front of
+#   CMAKE_MODULE_PATH and its `cmake/FindMPI.cmake` defers to CMake's bundled
+#   module, so pointing CMAKE_MODULE_PATH at mpi_abi_wrapper's FindMPI shim
+#   would be shadowed. Instead we name the wrappers, which CMake's own FindMPI
+#   interrogates with `-showme:compile` / `-showme:link` -- flags that
+#   mpi_abi_wrapper's `bin/mpicc` answers the way a real mpicc would.
+# - ADIOS2_USE_MPI=ON rather than the AUTO default, so that a failure to find
+#   the MPI ABI is an error here instead of a silently serial ADIOS2.
+#
+#     wget https://github.com/GTkorvo/dill/commit/94b4c437182318a0d446fb6f82511fac0e4f2516.patch && \
+#     (cd thirdparty/dill/dill && patch -p1 <../94b4c437182318a0d446fb6f82511fac0e4f2516.patch) && \
+#
+#     wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.12.0.tar.gz && \
+#     tar xzf v2.12.0.tar.gz && \
+#     cd ADIOS2-2.12.0 && \
+#
+#    wget https://github.com/ornladios/ADIOS2/archive/45035d24b4505b241037e2a1b35a4bbf1af782a8.tar.gz && \
+#    tar xzf 45035d24b4505b241037e2a1b35a4bbf1af782a8.tar.gz && \
+#    cd ADIOS2-45035d24b4505b241037e2a1b35a4bbf1af782a8 && \
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.10.2.tar.gz && \
-    tar xzf v2.10.2.tar.gz && \
-    cd ADIOS2-2.10.2 && \
+    wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.12.1.tar.gz && \
+    tar xzf v2.12.1.tar.gz && \
+    cd ADIOS2-2.12.1 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -161,7 +632,11 @@ RUN mkdir src && \
         -DADIOS2_USE_Fortran=OFF \
         -DADIOS2_USE_HDF5=ON \
         -DADIOS2_USE_MGARD=ON \
+        -DADIOS2_USE_MPI=ON \
+        -DADIOS2_USE_SZ3=ON \
         -DADIOS2_USE_ZFP=ON \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
     cmake --build build && \
     cmake --install build && \
@@ -173,9 +648,9 @@ RUN mkdir src && \
 # - depends on yaml-cpp
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/eschnett/asdf-cxx/archive/refs/tags/version/7.3.2.tar.gz && \
-    tar xzf 7.3.2.tar.gz && \
-    cd asdf-cxx-version-7.3.2 && \
+    wget https://github.com/eschnett/asdf-cxx/archive/refs/tags/version/8.0.0.tar.gz && \
+    tar xzf 8.0.0.tar.gz && \
+    cd asdf-cxx-version-8.0.0 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -197,6 +672,7 @@ RUN mkdir src && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
         -Dsimd=AVX2 \
         && \
     cmake --build build && \
@@ -209,11 +685,20 @@ RUN mkdir src && \
 # Install openPMD-api
 # openPMD-api defines a standard for laying out AMR data in a file
 # - depends on ADIOS2
+# - depends on mpi_abi_wrapper, and this is not optional: openPMD calls
+#   find_package(MPI) itself, and left alone it finds the system Open MPI and
+#   then fails to link ADIOS2 -- "undefined reference to
+#   adios2::ADIOS::ADIOS(ompi_communicator_t*)", because ADIOS2's MPI_Comm is
+#   the ABI's. The subtler half is HDF5: it is *also* mandatory that
+#   find_package(HDF5) resolve to the ABI-built HDF5 in /usr/local, since
+#   openPMD hands an MPI_Comm to H5Pset_fapl_mpio. Mixing there does not fail
+#   to link -- C linkage hides the type mismatch -- it silently passes an ABI
+#   handle to a library expecting an ompi_communicator_t*.
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/openPMD/openPMD-api/archive/refs/tags/0.16.1.tar.gz && \
-    tar xzf 0.16.1.tar.gz && \
-    cd openPMD-api-0.16.1 && \
+    wget https://github.com/openPMD/openPMD-api/archive/refs/tags/0.17.1.tar.gz && \
+    tar xzf 0.17.1.tar.gz && \
+    cd openPMD-api-0.17.1 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -221,6 +706,8 @@ RUN mkdir src && \
         -DBUILD_TESTING=OFF \
         -DopenPMD_BUILD_SHARED_LIBS=ON \
         -DopenPMD_USE_MPI=ON \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
     cmake --build build && \
     cmake --install build && \
@@ -234,7 +721,7 @@ RUN mkdir src && \
     wget https://github.com/wokast/RePrimAnd/archive/refs/tags/v1.7.tar.gz && \
     tar xzf v1.7.tar.gz && \
     cd RePrimAnd-1.7 && \
-    meson build --buildtype=release --prefix=/usr/local && \
+    meson setup build --buildtype=release --prefix=/usr/local -Dcpp_std=c++14 && \
     ninja -C build && \
     ninja -C build install && \
     true) && \
@@ -242,38 +729,51 @@ RUN mkdir src && \
 
 # Install Silo
 # Silo defines a standard for laying out AMR data in a file
+# - Silo has no MPI of its own, but it links HDF5 and so inherits HDF5's MPI;
+#   the compilers are named for the same reason as in the SZ3 stanza
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/LLNL/Silo/releases/download/4.11.1/silo-4.11.1.tar.xz && \
-    tar xJf silo-4.11.1.tar.xz && \
-    cd silo-4.11.1 && \
-    mkdir build && \
-    cd build && \
-    ../configure \
-        --disable-fortran \
-        --disable-static \
-        --enable-optimization \
-        --enable-shared \
-        --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial/include,/usr/lib/x86_64-linux-gnu/hdf5/serial/lib \
-        --prefix=/usr/local \
+    wget https://github.com/LLNL/Silo/releases/download/4.12.1/Silo-4.12.1.tar.xz && \
+    tar xJf Silo-4.12.1.tar.xz && \
+    cd Silo-4.12.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DSILO_BUILD_FOR_BSD_LICENSE=ON \
+        -DSILO_ENABLE_BROWSER=OFF \
+        -DSILO_ENABLE_FORTRAN=OFF \
+        -DSILO_ENABLE_HDF5=ON \
+        -DSILO_ENABLE_JSON=OFF \
+        -DSILO_ENABLE_PYTHON_MODULE=OFF \
+        -DSILO_ENABLE_SHARED=ON \
+        -DSILO_ENABLE_SILEX=OFF \
+        -DSILO_ENABLE_SILOCK=ON \
+        -DSILO_ENABLE_TESTS=OFF \
+        -DSILO_HDF5_SZIP_DIR=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
-    make -j$(nproc) && \
-    make -j$(nproc) install && \
+    cmake --build build && \
+    cmake --install build && \
     true) && \
     rm -rf src
 
 # Install Conduit
 # Conduit defines a standard for laying out AMR data in a file.
 # - depends on Silo
+# - depends on mpi_abi_wrapper: `libconduit_relay_mpi*` and
+#   `libconduit_blueprint_mpi` take an MPI_Comm across their public interface.
+#   HDF5_DIR moves from /usr to /usr/local for the same reason -- Conduit's
+#   relay writes HDF5, and the two must agree on what an MPI_Comm is.
 # TODO:
 # - enable CUDA? HIP?
 # -DADIOS_DIR=/usr/local   # conduit doesn't find ADIOS because there is no FindADIOS.cmake
 # -DZFP_DIR=/usr           # conduit doesn't find zfp because the library directory is wrong
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/LLNL/conduit/releases/download/v0.9.5/conduit-v0.9.5-src-with-blt.tar.gz && \
-    tar xzf conduit-v0.9.5-src-with-blt.tar.gz && \
-    cd conduit-v0.9.5 && \
+    wget https://github.com/LLNL/conduit/releases/download/v0.9.8/conduit-v0.9.8-src-with-blt.tar.gz && \
+    tar xzf conduit-v0.9.8-src-with-blt.tar.gz && \
+    cd conduit-v0.9.8 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -289,7 +789,9 @@ RUN mkdir src && \
         -DENABLE_RELAY_WEBSERVER=OFF \
         -DENABLE_TESTS=OFF \
         -DENABLE_UTILS=ON \
-        -DHDF5_DIR=/usr \
+        -DHDF5_DIR=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         -DSILO_DIR=/usr/local \
         -DZLIB_DIR=/usr \
         src \
@@ -312,7 +814,8 @@ RUN mkdir src && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
-        -DENABLE_ASDF_CXX=OFF \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        -DENABLE_ASDF_CXX=ON \
         && \
     cmake --build build && \
     cmake --install build && \
@@ -336,19 +839,80 @@ RUN mkdir src && \
     true) && \
     rm -rf src
 
+# # Install Fuka
+# RUN mkdir src
+# WORKDIR src
+# RUN git clone --branch ET_2025_05 https://bitbucket.org/fukaws/fuka
+# WORKDIR fuka
+# # Ensure this macro is defined at build time to enable multi-threaded importers
+# RUN sed -i -E 's%// #define DEFAULT_KAD_MEM%#define DEFAULT_KAD_MEM%' include/memory.hpp
+# WORKDIR build_release
+# RUN env HOME_KADATH=/cactus/src/fuka \
+#     cmake -B build -G Ninja \
+#         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+#         -DCMAKE_INSTALL_PREFIX=/usr/local \
+#         -DGRHAYL_EOS=OFF \
+#         -DPAR_VERSION=ON
+# RUN cmake --build build
+# WORKDIR ..
+# RUN cp lib/libkadath.a /usr/local/lib
+# RUN ls -l /cactus/src/fuka/include
+# RUN false
+# WORKDIR ../..
+# RUN rm -rf src
+# RUN echo
+# RUN ls -l /usr/local/include
+# RUN ls -l /usr/local/lib
+# RUN false
+
 ARG real_precision=real64
 
 # Install AMReX
 # AMReX provides adaptive mesh refinement
+# - depends on mpi_abi_wrapper: AMReX is where CarpetX's own communication
+#   happens, so its MPI_Comm has to be the same one Cactus calls MPI_Init on.
+#   AMReX_MPI defaults to ON and is left that way; only the compilers change.
+#   The nine `-DMPI_*` variables `carpetx-native-oneapi.dockerfile` sets here, and its
+#   `rm -rf /opt/intel/oneapi/mpi`, are both gone: see the oneAPI notes in the
+#   header.
+# - `/usr/local` is appended to CMAKE_PREFIX_PATH. That variable is set here as
+#   an explicit `/opt/intel/oneapi`-only list, which would otherwise hide the
+#   ABI's own CMake package from any nested find_package.
+# - **AMReX_SYCL_SPLIT_KERNEL=OFF is what makes this link finish.** The option
+#   defaults to ON and adds `-fsycl-device-code-split=per_kernel`
+#   (`Tools/CMake/AMReXSYCL.cmake`), which asks `sycl-post-link` for one device
+#   image per kernel -- and AMReX generates a very large number of them through
+#   templates. Observed on the 2026.1.0 toolkit: after `[121/122]`, i.e. at the
+#   final link of `libamrex_3d.so`, `sycl-post-link` sat at 100% CPU with
+#   12.7 GB resident and climbing, with no end in sight.
+#
+#   This is the "AMReX linker step is broken" note that pins
+#   `carpetx-native-oneapi.dockerfile` to basekit 2025.2.2. That file's `FROM`
+#   history marks 2025.3.0, 2025.3.1, 2025.3.2 and toolkit 2026.0.0 as broken;
+#   2026.1.0 makes five releases, so the regression is not one to wait out.
+#   Turning the split off is the one lever that acts directly on the tool that
+#   is blowing up, rather than around it.
+#
+#   The cost is at run time, not build time: without the per-kernel split there
+#   is one larger device image, so the first run JITs more than it strictly
+#   needs. If a future toolkit fixes `sycl-post-link`, this line is the thing to
+#   remove; if instead this proves insufficient, the fallback is
+#   basekit 2025.2.2 -- it ships Intel MPI 2021.16 and exports the same
+#   `C_INCLUDE_PATH`, so every other stanza in this file works there unchanged.
+#
+#   Unrelated but worth knowing while reading the link line: AMReX enables
+#   `-flink-huge-device-code` when `CMAKE_BUILD_TYPE MATCHES "Debug"`, and
+#   CMake's `MATCHES` is a regex, so `RelWithDebInfo` matches it by substring.
+#   That large-device-code workaround is therefore already in effect here, by
+#   accident rather than by choice.
 # - Enable Fortran for `docker/Dockerfile`
 # - Install this last because it changes most often
 # Should we keep the AMReX source tree around for debugging?
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/AMReX-Codes/amrex/archive/25.11.tar.gz && \
-    tar xzf 25.11.tar.gz && \
-    rm -rf /opt/intel/oneapi/mpi && \
-    cd amrex-25.11 && \
+    wget https://github.com/AMReX-Codes/amrex/archive/26.01.tar.gz && \
+    tar xzf 26.01.tar.gz && \
+    cd amrex-26.01 && \
     case $real_precision in \
         real32) precision=SINGLE;; \
         real64) precision=DOUBLE;; \
@@ -358,7 +922,7 @@ RUN mkdir src && \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_C_COMPILER=icx \
         -DCMAKE_CXX_COMPILER=icpx \
-        -DCMAKE_PREFIX_PATH='/opt/intel/oneapi' \
+        -DCMAKE_PREFIX_PATH='/opt/intel/oneapi;/usr/local' \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
         -DBUILD_SHARED_LIBS=ON \
         -DAMReX_FORTRAN=OFF \
@@ -368,15 +932,9 @@ RUN mkdir src && \
         -DAMReX_OMP=OFF \
         -DAMReX_PARTICLES=ON \
         -DAMReX_PRECISION="$precision" \
-        -DMPI_CXX_ADDITIONAL_INCLUDE_DIRS='/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi;/usr/lib/x86_64-linux-gnu/openmpi/include' \
-        -DMPI_CXX_LIB_NAMES='mpi_cxx;mpi;open-rte;open-pal;hwloc' \
-        -DMPI_C_ADDITIONAL_INCLUDE_DIRS='/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi;/usr/lib/x86_64-linux-gnu/openmpi/include' \
-        -DMPI_C_LIB_NAMES='mpi;open-rte;open-pal;hwloc' \
-        -DMPI_hwloc_LIBRARY=/lib/x86_64-linux-gnu/libhwloc.so \
-        -DMPI_mpi_LIBRARY=/usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi.so \
-        -DMPI_mpi_cxx_LIBRARY=/usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi_cxx.so \
-        -DMPI_open-pal_LIBRARY=/lib/x86_64-linux-gnu/libopen-pal.so \
-        -DMPI_open-rte_LIBRARY=/lib/x86_64-linux-gnu/libopen-rte.so \
+        -DAMReX_SYCL_SPLIT_KERNEL=OFF \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
     cmake --build build && \
     cmake --install build && \

--- a/docker/carpetx-rocm.dockerfile
+++ b/docker/carpetx-rocm.dockerfile
@@ -6,9 +6,131 @@
 #     docker build --build-arg real_precision=real32 --file carpetx-rocm.dockerfile --tag einsteintoolkit/carpetx:rocm-real32 .
 #     docker push einsteintoolkit/carpetx:rocm-real32
 
+# This is `carpetx-native-rocm.dockerfile` with every MPI-using library moved
+# onto the **MPI ABI** (MPI-5.0 §20.2) instead of the system Open MPI. Two
+# packages provide that ABI over the distribution's MPI:
+#
+#   mpi_abi_wrapper  the C bindings: `mpi.h`, `libmpi_abi`, `mpicc`, `mpicxx`
+#   mpif             the Fortran bindings: `mpif.h`, `mpi.mod`, `mpi_f08.mod`,
+#                    `libmpif`, `mpifort` -- needed because §20.4 leaves
+#                    `MPI_Fint` and the Fortran modules out of the ABI entirely
+#
+# Both install into `/usr/local`, so `/usr/local/bin/{mpicc,mpicxx,mpifort}` is
+# the toolchain every stanza below is pointed at, and `libmpi.so.40` must not
+# appear in the `ldd` output of anything this file installs. Which MPI actually
+# runs a binary is then a *run-time* choice: `libmpi_abi` dlopens the wrapper,
+# and another ABI-providing implementation can be put in front of it without
+# recompiling. `/usr/local/bin/mpiexec` is a **forwarder**, not a launcher:
+# starting a job stays the wrapped MPI's business, so it resolves that MPI's own
+# `mpiexec` -- `$MPI_ABI_WRAPPER_MPIEXEC`, else the path found beside
+# `MPI_C_COMPILER` at configure time -- and passes every argument through. That
+# is the same run-time indirection `libmpi_abi` uses to find `libmpiwrapper`, so
+# the launcher follows the library when a binary is re-pointed.
+#
+# Consequences for the apt list below:
+# - `libhdf5-dev` and `libpetsc-real-dev` are **gone**. Both are built here
+#   instead, over the ABI. PETSc drags in a whole parallel stack when installed
+#   from apt -- parallel HDF5, hypre, MUMPS, ScaLAPACK, PtScotch, SuperLU-DIST,
+#   CombBLAS, FFTW3-MPI -- every one of which links `libmpi.so.40`; dropping it
+#   removes all of them at once, and the PETSc built here has none of them.
+# - `libaec-dev` is **added**: it provides the szip encoder that Debian's HDF5
+#   was built with, which the HDF5 built here would otherwise lose.
+# - `libcurl4-openssl-dev` and `libjpeg-dev` are **added** because they were
+#   only ever present as transitive dependencies of `libpetsc-real-dev`, and
+#   dropping it took them with it. The Cactus option list points LIBCURL_DIR
+#   and LIBJPEG_DIR at /usr, so their absence stops the CST outright:
+#   "LIBJPEG not found at /usr". Naming them explicitly is right regardless --
+#   depending on PETSc to supply an image's libjpeg was always an accident.
+# - `python3-dev` is **added** for the same kind of reason. Conduit is built
+#   with `-DENABLE_PYTHON=ON`, so its `find_package(Python3 ... Development
+#   NumPy)` needs `Python.h` and the numpy headers; those arrived only as a
+#   transitive dependency of `libboost-all-dev`, by way of
+#   `libboost-python1.83-dev`. Naming it explicitly is right regardless, and is
+#   required outright in the images below that narrow Boost.
+# - `libopenmpi-dev` stays. It is the MPI being *wrapped*; nothing else in this
+#   image compiles against it.
+# - `libboost-all-dev` becomes **`libboost-filesystem-dev`**. The wide package
+#   drags in Boost.MPI, which links `libmpi.so.40` directly -- the one thing
+#   every other line here exists to avoid. Nothing links Boost.MPI today, so it
+#   was previously left alone with a note saying it must not start being used;
+#   the narrow package retires that caveat instead of restating it, and matches
+#   the accelerator variants, where the wide package is not merely untidy but
+#   reinstalls a second MPI outright.
+#   **Not plain `libboost-dev`**, which is the obvious narrowing and does not
+#   work: RePrimAnd's `meson.build` asks for `dependency('boost')`, and Meson's
+#   Boost detection wants to see boost *libraries* even when the dependency is
+#   header-only -- with headers alone it reports "Run-time dependency Boost
+#   found: NO (tried system)" and RePrimAnd stops. Measured on Ubuntu 26.04:
+#   `libboost-dev` installs 0 boost libraries and fails; `libboost-filesystem-dev`
+#   installs 6 and gives "Boost found: YES 1.90.0 (/usr)".
+#   `filesystem` is the right component to keep rather than an arbitrary one:
+#   `desert-arm64v8.cfg` sets `BOOST_LIBS="boost_filesystem"`, so Cactus does
+#   link it. Nothing else does -- CarpetX's own Boost use is header-only
+#   (`boost::math` in `repos/CarpetX/Algo/src/roots.hxx`) and RePrimAnd's
+#   `dependency('boost')` names no modules -- so for those it only has to be
+#   present to be found.
+#
+# The matching Cactus option list needs `MPI_DIR = /usr/local`,
+# `HDF5_DIR = /usr/local` (with `hdf5_hl_fortran`/`hdf5_fortran`, the CMake
+# spelling, rather than Debian's `hdf5hl_fortran`), and `PETSC_DIR = /usr/local`.
+#
+# ROCm-specific notes:
+# - **ROCm 10 renamed every Debian package and moved the install prefix.** The
+#   `hiprand-dev`, `rocprim-dev`, `rocrand-dev` and `rocsparse-dev` that
+#   `carpetx-native-rocm.dockerfile` installs do not exist in the `ubuntu2604`
+#   repository; the four map onto three (verified against the repository's own
+#   `Packages` index):
+#
+#     hiprand-dev + rocrand-dev  ->  amdrocm-rand-dev
+#     rocprim-dev                ->  amdrocm-ccl-dev   (rocprim, hipcub, rocthrust)
+#     rocsparse-dev              ->  amdrocm-sparse-dev
+#
+#   All three are header-only, a few MB each, and pull no per-GPU subpackages.
+# - **the prefix moved from `/opt/rocm` to `/opt/rocm/core-10.0`**, and no
+#   package ships a compatibility symlink for it. So `/opt/rocm/llvm/bin/clang++`
+#   is gone -- ROCm's LLVM now lives at `core-10.0/lib/llvm/bin` -- and the
+#   `/opt/rocm/lib/cmake/<pkg>` directories `carpetx-native-rocm.dockerfile` lists in
+#   CMAKE_PREFIX_PATH are gone with it. Both are handled below by naming the
+#   *prefix* rather than paths inside it, which survives the next such move.
+#   The Cactus option list needs the same treatment: `desert-rocm.cfg`'s
+#   `CC`/`CXX` still point at `/opt/rocm/llvm/bin/clang`.
+# - **ROCm ships no MPI of its own**, so the MPI being wrapped here is the same
+#   Ubuntu Open MPI as in `carpetx-cpu.dockerfile`, and `libopenmpi-dev`
+#   stays in the apt list for that reason. This file is therefore the closest of
+#   the three accelerator variants to the CPU one.
+# - the apt list is `carpetx-cpu.dockerfile`'s, plus ROCm's four `-dev`
+#   packages -- **not** `carpetx-native-rocm.dockerfile`'s. That file drops a dozen
+#   packages (`make`, `patch`, `tar`, `xz-utils`, `bzip2`, ...) because it builds
+#   neither HPCToolkit nor PETSc from source. The PETSc stanza below does, and
+#   `--download-*` needs those tools, so the fuller list is kept.
+# - Silo is built with **CMake**, as in every other file here, where
+#   `carpetx-native-rocm.dockerfile` uses autotools and points `--with-hdf5` at
+#   `/usr/lib/x86_64-linux-gnu/hdf5/serial`. Those paths do not exist once
+#   `libhdf5-dev` is gone, so that form could not survive the port regardless.
+# - AMReX's nine hard-wired `-DMPI_*` variables are **gone**. They named Open
+#   MPI's `libmpi`, `libmpi_cxx`, `libopen-rte` and `libopen-pal` by absolute
+#   path -- exactly the `libmpi.so.40` this file must not link -- so they had to
+#   be removed rather than supplemented. `-DMPI_C_COMPILER`/`-DMPI_CXX_COMPILER`
+#   replace them. If ROCm's `clang++` turns out not to accept what
+#   `mpi_abi_wrapper`'s `mpicc -showme:link` reports, the ABI spelling of those
+#   variables is far simpler than what they replaced, because the ABI has no
+#   `open-rte`/`open-pal`/`mpi_cxx` split: `-DMPI_C_LIB_NAMES=mpi_abi`,
+#   `-DMPI_mpi_abi_LIBRARY=/usr/local/lib/libmpi_abi.so` and
+#   `-DMPI_C_ADDITIONAL_INCLUDE_DIRS=/usr/local/include`.
+
+# The 24.04 images are `carpetx-native-rocm.dockerfile`'s history. Note that the 26.04
+# repository publishes only `-full` tags -- there is no slim `dev` tag as there
+# was for 7.2.4 -- so moving to Ubuntu 26.04 takes the base from 1.2 GB to
+# 8.3 GB. `10.0.0-full` and `latest` are the same digest.
 # FROM rocm/dev-ubuntu-24.04:6.4.1
 # FROM rocm/dev-ubuntu-24.04:6.4.3
-FROM rocm/dev-ubuntu-24.04:7.1
+# FROM rocm/dev-ubuntu-24.04:7.1
+# FROM rocm/dev-ubuntu-24.04:7.1.1
+# FROM rocm/dev-ubuntu-24.04:7.2
+# FROM rocm/dev-ubuntu-24.04:7.2.3
+# FROM rocm/dev-ubuntu-24.04:7.2.4
+# FROM rocm/dev-ubuntu-26.04:7.14.1-full
+FROM rocm/dev-ubuntu-26.04:10.0.0-full
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LANGUAGE=en_US.en \
@@ -24,11 +146,19 @@ WORKDIR /cactus
 #        python2
 RUN apt-get update && \
     apt-get --yes --no-install-recommends install \
+        bison \
+        bzip2 \
+        amdrocm-ccl-dev \
+        amdrocm-rand-dev \
+        amdrocm-sparse-dev \
         ca-certificates \
         clang-format \
         cmake \
+        curl \
         cvs \
         diffutils \
+        elfutils \
+        flex \
         g++ \
         gcc \
         gdb \
@@ -39,23 +169,26 @@ RUN apt-get update && \
         hdf5-filter-plugin-zfp-serial \
         hdf5-plugin-lzf \
         hdf5-tools \
-        hiprand-dev \
         hwloc-nox \
         language-pack-en \
         less \
+        libaec-dev \
         libblosc-dev \
         libblosc2-dev \
-        libboost-all-dev \
+        libboost-filesystem-dev \
         libbz2-dev \
+        libcurl4-openssl-dev \
         libfftw3-dev \
         libgit2-dev \
         libgsl-dev \
-        libhdf5-dev \
         libhwloc-dev \
+        libiberty-dev \
+        libjpeg-dev \
         liblz4-dev \
+        liblzma-dev \
         libopenblas-dev \
         libopenmpi-dev \
-        libpetsc-real-dev \
+        libpapi-dev \
         libprotobuf-dev \
         libreadline-dev \
         libtool \
@@ -65,25 +198,31 @@ RUN apt-get update && \
         libzstd-dev \
         locales \
         m4 \
+        make \
         meson \
         ninja-build \
         nlohmann-json3-dev \
         numactl \
+        papi-tools \
+        patch \
         perl \
         pkgconf \
         protobuf-compiler \
         python3 \
+        python3-dev \
         python3-numpy \
         python3-pip \
         python3-requests \
-        rocprim-dev \
-        rocrand-dev \
-        rocsparse-dev \
+        python3-venv \
         rsync \
         subversion \
+        tar \
+        unzip \
         vim \
         wget \
+        xz-utils \
         zlib1g-dev \
+        zstd \
         && \
     rm -rf /var/lib/apt/lists/*
 
@@ -92,20 +231,24 @@ RUN apt-get update && \
 # # Installing HPCToolkit without rocm since the install fails when this option is enabled.
 # RUN mkdir src && \
 #     (cd src && \
-#     wget https://github.com/spack/spack/archive/refs/tags/v1.0.2.tar.gz && \
-#     tar xzf v1.0.2.tar.gz && \
-#     export SPACK_ROOT="$(pwd)/spack-1.0.2" && \
+#     wget https://github.com/spack/spack/archive/refs/tags/v1.2.2.tar.gz && \
+#     tar xzf v1.2.2.tar.gz && \
+#     export SPACK_ROOT="$(pwd)/spack-1.2.2" && \
 #     mkdir -p "${HOME}/.spack" && \
 #     echo 'config: {install_tree: {root: /spack}}' >"${HOME}/.spack/config.yaml" && \
 #     . ${SPACK_ROOT}/share/spack/setup-env.sh && \
+#     wget https://github.com/spack/spack-packages/archive/refs/tags/v2026.06.0.tar.gz && \
+#     tar xzf v2026.06.0.tar.gz && \
+#     spack repo add --scope site spack-packages-2026.06.0/repos/spack_repo/builtin && \
 #     spack external find \
 #         autoconf \
 #         automake \
 #         cmake \
+#         curl \
 #         diffutils \
 #         elfutils \
 #         gmake \
-#         plibtool \
+#         libtool \
 #         m4 \
 #         meson \
 #         ninja \
@@ -119,38 +262,216 @@ RUN apt-get update && \
 #     true) && \
 #     rm -rf src "${HOME}/.spack"
 
-# # Install blosc2
-# # blosc2 is a compression library, comparable to zlib
-# RUN mkdir src && \
-#     (cd src && \
-#     wget https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.18.0.tar.gz && \
-#     tar xzf v2.18.0.tar.gz && \
-#     cd c-blosc2-2.18.0 && \
-#     cmake -B build -G Ninja \
-#         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-#         -DCMAKE_INSTALL_PREFIX=/usr/local \
-#         -DBUILD_BENCHMARKS=OFF \
-#         -DBUILD_EXAMPLES=OFF \
-#         -DBUILD_FUZZERS=OFF \
-#         -DBUILD_STATIC=OFF \
-#         -DBUILD_TESTS=OFF \
-#         -DPREFER_EXTERNAL_LZ4=ON  \
-#         -DPREFER_EXTERNAL_ZLIB=ON \
-#         -DPREFER_EXTERNAL_ZSTD=ON \
-#         && \
-#     cmake --build build && \
-#     cmake --install build && \
-#     true) && \
-#     rm -rf src
+# Install mpi_abi_wrapper
+# mpi_abi_wrapper wraps an MPI library and provides the MPI ABI
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/mpi_abi_wrapper/archive/refs/tags/v1.2.0.tar.gz && \
+    tar xzf v1.2.0.tar.gz && \
+    cd mpi_abi_wrapper-1.2.0 && \
+    cmake -B build -G Ninja \
+        -DBUILD_TESTING=OFF \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install mpif
+# mpif provides the Fortran bindings for the MPI ABI
+# - depends on mpi_abi_wrapper
+# The ABI is specified for C only: MPI-5.0 §20.4 leaves `MPI_Fint` and the
+# Fortran modules out of it deliberately, so `mpi.h` and `libmpi_abi` give a
+# Fortran caller nothing. mpif supplies `mpif.h`, `use mpi` and `use mpi_f08`
+# on top of them, and is what makes HDF5's Fortran interface, PETSc's Fortran
+# stubs and Cactus's own Fortran thorns possible over the ABI.
+# MPI_C_COMPILER is named explicitly rather than left to find_package(MPI):
+# CMake's FindMPI searches PATH, finds the system Open MPI's `mpicc` at
+# /usr/bin/mpicc, and mpif then stops with "MPI_C_LIBRARIES ... names no
+# libmpi_abi". MPI_HOME is what mpifort records as its default MPI prefix
+# (`mpifort -showme:mpiprefix`).
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/eschnett/mpif/archive/refs/tags/v1.0.1.tar.gz && \
+    tar xzf v1.0.1.tar.gz && \
+    cd mpif-1.0.1 && \
+    cmake -B build -G Ninja \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_HOME=/usr/local \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# From here on, every find_package(MPI) must resolve to the ABI rather than to
+# the system Open MPI on PATH. The stanzas below say so explicitly with
+# -DMPI_C_COMPILER, but that does not reach a find_package(MPI) issued from
+# *inside* another package's config file -- and HDF5's `hdf5-config.cmake` does
+# exactly that, to rebuild the MPI::MPI_C target its exported targets depend
+# on. A consumer that merely links HDF5 therefore acquires an -lmpi against the
+# system MPI, silently: measured on SZ3's H5Z filter and on Silo, both of which
+# came out with a direct NEEDED on libmpi.so.40. MPI_HOME is a documented
+# FindMPI hint (`MPI_HINT_DIRS`, FindMPI.cmake) read from the environment, so
+# it reaches those nested calls where -D cannot.
+ENV MPI_HOME=/usr/local
+
+# Install HDF5
+# HDF5 is the I/O library nearly everything below reads and writes through
+# - depends on mpi_abi_wrapper (parallel I/O) and mpif (the Fortran interface)
+# Built here rather than taken from apt because Debian's parallel flavour
+# (`libhdf5-openmpi-dev`) links libmpi.so.40, and its serial flavour has no
+# MPI-IO at all. Cactus wants one HDF5 with all three language interfaces:
+# - HDF5_ALLOW_UNSUPPORTED is required because HDF5 refuses to combine the C++
+#   interface with parallel I/O. Debian's `libhdf5-openmpi-cpp` is built the
+#   same way; the C++ interface simply has no parallel entry points of its own.
+# - HDF5 2.x renamed two of these options from their 1.14 spellings, and both
+#   renames fail quietly rather than loudly: `ALLOW_UNSUPPORTED` became
+#   `HDF5_ALLOW_UNSUPPORTED` (that one does at least stop the configure), and
+#   `HDF5_ENABLE_Z_LIB_SUPPORT` became `HDF5_ENABLE_ZLIB_SUPPORT` -- the old
+#   name is merely reported as an unused variable, and the build then finishes
+#   with no zlib and hence no `deflate` filter at all.
+# - the CMake build spells the Fortran libraries `hdf5_fortran` /
+#   `hdf5_hl_fortran`, where Debian spells the latter `hdf5hl_fortran`. The
+#   Cactus option list has to follow this spelling.
+# - the `hdf5-filter-plugin*` and `hdf5-plugin-lzf` apt packages install their
+#   dynamically-loaded filters under /usr/lib/*/hdf5/{serial,openmpi}/plugins,
+#   built against Debian's `libhdf5_serial`. This build looks in
+#   /usr/local/hdf5/lib/plugin instead, so it does not load them -- which is
+#   the right outcome, since loading them would pull a second HDF5 with a
+#   different soname into the process. Those packages remain useful to apt's
+#   own /usr/bin/h5dump; a file needing one of those filters has to be read
+#   with that, not with /usr/local/bin/h5dump.
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/HDFGroup/hdf5/releases/download/2.2.0/hdf5-2.2.0.tar.gz && \
+    tar xzf hdf5-2.2.0.tar.gz && \
+    cd hdf5-2.2.0 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_STATIC_LIBS=OFF \
+        -DBUILD_TESTING=OFF \
+        -DHDF5_ALLOW_UNSUPPORTED=ON \
+        -DHDF5_BUILD_CPP_LIB=ON \
+        -DHDF5_BUILD_EXAMPLES=OFF \
+        -DHDF5_BUILD_FORTRAN=ON \
+        -DHDF5_BUILD_HL_LIB=ON \
+        -DHDF5_BUILD_TOOLS=ON \
+        -DHDF5_ENABLE_PARALLEL=ON \
+        -DHDF5_ENABLE_SZIP_ENCODING=ON \
+        -DHDF5_ENABLE_SZIP_SUPPORT=ON \
+        -DHDF5_ENABLE_ZLIB_SUPPORT=ON \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
+        -DMPI_Fortran_COMPILER=/usr/local/bin/mpifort \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
+# Install PETSc
+# PETSc provides the linear and nonlinear solvers CarpetX/PDESolvers uses
+# - depends on mpi_abi_wrapper, mpif, HDF5, and a BLAS/LAPACK
+#
+# The external packages below are the set an HPC site would normally enable,
+# and the reason they are here is CarpetX/PDESolvers: it assembles the whole
+# refinement hierarchy into one flat `MatCreateAIJ` and then chooses no
+# preconditioner in the source at all, so whatever PETSc defaults to (ILU
+# serially, block-Jacobi/ILU in parallel) is what ends up solving an elliptic
+# problem that wants multigrid. Every package here is reachable from
+# `PDESolvers::petsc_options` alone, with no code change:
+#
+#   hypre         BoomerAMG, the standard algebraic multigrid for exactly this
+#                 (`-pc_type hypre -pc_hypre_type boomeramg`). This is the one
+#                 that matters; the rest are supporting cast.
+#   MUMPS         parallel sparse direct (`-pc_type lu
+#                 -pc_factor_mat_solver_type mumps`) -- the fallback when AMG
+#                 stalls, and the usual coarse-grid solver
+#   SuperLU_DIST  the other parallel direct solver, same role
+#   SuperLU       serial direct
+#   SuiteSparse   UMFPACK / CHOLMOD / KLU, serial direct
+#   ScaLAPACK     required by MUMPS
+#   METIS         graph partitioning
+#   PT-Scotch     parallel partitioning and ordering, for MUMPS and SuperLU_DIST
+#
+# - **PT-Scotch rather than ParMETIS**, the other obvious choice for that last
+#   slot: ParMETIS is licensed for non-commercial research use only, so it must
+#   not go into an image that gets pushed to a registry. PT-Scotch is CeCILL-C,
+#   and its `libptscotchparmetisv3` answers the ParMETIS v3 API that MUMPS and
+#   SuperLU_DIST actually ask for. Debian's PETSc makes the same substitution
+#   for the same reason.
+# - **--download-* rather than a stanza each.** PETSc builds these with the
+#   compilers it was given, so they come out over the ABI automatically, and
+#   their versions stay matched to the PETSc release, which is the combination
+#   PETSc tests. Wiring eight packages up by hand and then persuading PETSc to
+#   accept them is the part that goes wrong.
+# - PT-Scotch generates its parsers at build time, which is why `flex` and
+#   `bison` are in the apt list above. Without them configure dies deep in the
+#   download stage with "PTScotch needs flex installed".
+# - --with-hdf5-dir draws a warning -- "Using version 2.2.0 of package HDF5,
+#   PETSc is tested with 1.14". Configure accepts it; nothing in Cactus uses
+#   PetscViewerHDF5, so this is availability rather than something relied on.
+#   Drop --with-hdf5-dir if it ever turns into a hard error.
+# - PETSc's configure compiles and runs small MPI programs; Open MPI refuses to
+#   initialise as root without OMPI_ALLOW_RUN_AS_ROOT, and this container is
+#   root. The variables are scoped to this RUN rather than set image-wide.
+# - --with-mpiexec names the ABI prefix's own `mpiexec`, which forwards to the
+#   wrapped MPI's launcher rather than being one. Naming the forwarder rather
+#   than /usr/bin/mpiexec keeps the recorded launcher correct if this image is
+#   later re-pointed at another MPI; PETSc would otherwise bake in whatever it
+#   found on PATH.
+# - the stock build installs `libpetsc.so` and `include/petsc.h` under one
+#   prefix, which is exactly the layout `ExternalLibraries-PETSc/src/detect.sh`
+#   looks for -- unlike Debian's `libpetsc_real.so` under /usr/lib/petsc.
+RUN mkdir src && \
+    (cd src && \
+    export OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 && \
+    wget https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.25.5.tar.gz && \
+    tar xzf petsc-3.25.5.tar.gz && \
+    cd petsc-3.25.5 && \
+    ./configure \
+        --prefix=/usr/local \
+        --download-hypre \
+        --download-metis \
+        --download-mumps \
+        --download-ptscotch \
+        --download-scalapack \
+        --download-suitesparse \
+        --download-superlu \
+        --download-superlu_dist \
+        --with-blaslapack-lib=-lopenblas \
+        --with-cc=/usr/local/bin/mpicc \
+        --with-cxx=/usr/local/bin/mpicxx \
+        --with-debugging=0 \
+        --with-fc=/usr/local/bin/mpifort \
+        --with-hdf5-dir=/usr/local \
+        --with-mpiexec=/usr/local/bin/mpiexec \
+        --with-shared-libraries=1 \
+        --with-x=0 \
+        COPTFLAGS=-O2 CXXOPTFLAGS=-O2 FOPTFLAGS=-O2 \
+        && \
+    make && \
+    make install && \
+    true) && \
+    rm -rf src
 
 # Install MGARD
 # MGARD is a lossy compression library
 # Note: -DMGARD_ENABLE_HIP=ON doesn't work
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/CODARcode/MGARD/archive/refs/tags/1.5.2.tar.gz && \
-    tar xzf 1.5.2.tar.gz && \
-    cd MGARD-1.5.2 && \
+    wget https://github.com/CODARcode/MGARD/archive/refs/tags/1.6.0.tar.gz && \
+    tar xzf 1.6.0.tar.gz && \
+    cd MGARD-1.6.0 && \
     cmake -B build -G Ninja \
         -DBUILD_TESTING=OFF \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -164,15 +485,58 @@ RUN mkdir src && \
     true) && \
     rm -rf src
 
+# Install SZ3
+# SZ3 is a lossy compression library
+# - BUILD_H5Z_FILTER links HDF5, which drags MPI in behind it; hence the
+#   compilers, even though SZ3 itself knows nothing about MPI
+RUN mkdir src && \
+    (cd src && \
+    wget https://github.com/szcompressor/SZ3/releases/download/v3.3.2/SZ3-v3.3.2.zip && \
+    unzip SZ3-v3.3.2.zip && \
+    cd SZ3-master && \
+    cmake -B build -G Ninja \
+        -DBUILD_H5Z_FILTER=ON \
+        -DBUILD_MDZ=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_PREFIX_PATH=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
+        && \
+    cmake --build build && \
+    cmake --install build && \
+    true) && \
+    rm -rf src
+
 # Install ADIOS2
 # ADIOS2 is a parallel I/O library, comparable to HDF5
 # - depends on blosc2
 # - depends on MGARD
+# - depends on mpi_abi_wrapper: ADIOS2 is built against the MPI ABI, not against
+#   the system MPI directly. ADIOS2 inserts its own `cmake/` at the front of
+#   CMAKE_MODULE_PATH and its `cmake/FindMPI.cmake` defers to CMake's bundled
+#   module, so pointing CMAKE_MODULE_PATH at mpi_abi_wrapper's FindMPI shim
+#   would be shadowed. Instead we name the wrappers, which CMake's own FindMPI
+#   interrogates with `-showme:compile` / `-showme:link` -- flags that
+#   mpi_abi_wrapper's `bin/mpicc` answers the way a real mpicc would.
+# - ADIOS2_USE_MPI=ON rather than the AUTO default, so that a failure to find
+#   the MPI ABI is an error here instead of a silently serial ADIOS2.
+#
+#     wget https://github.com/GTkorvo/dill/commit/94b4c437182318a0d446fb6f82511fac0e4f2516.patch && \
+#     (cd thirdparty/dill/dill && patch -p1 <../94b4c437182318a0d446fb6f82511fac0e4f2516.patch) && \
+#
+#     wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.12.0.tar.gz && \
+#     tar xzf v2.12.0.tar.gz && \
+#     cd ADIOS2-2.12.0 && \
+#
+#    wget https://github.com/ornladios/ADIOS2/archive/45035d24b4505b241037e2a1b35a4bbf1af782a8.tar.gz && \
+#    tar xzf 45035d24b4505b241037e2a1b35a4bbf1af782a8.tar.gz && \
+#    cd ADIOS2-45035d24b4505b241037e2a1b35a4bbf1af782a8 && \
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.10.2.tar.gz && \
-    tar xzf v2.10.2.tar.gz && \
-    cd ADIOS2-2.10.2 && \
+    wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.12.1.tar.gz && \
+    tar xzf v2.12.1.tar.gz && \
+    cd ADIOS2-2.12.1 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -185,7 +549,11 @@ RUN mkdir src && \
         -DADIOS2_USE_Fortran=OFF \
         -DADIOS2_USE_HDF5=ON \
         -DADIOS2_USE_MGARD=ON \
+        -DADIOS2_USE_MPI=ON \
+        -DADIOS2_USE_SZ3=ON \
         -DADIOS2_USE_ZFP=ON \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
     cmake --build build && \
     cmake --install build && \
@@ -197,9 +565,9 @@ RUN mkdir src && \
 # - depends on yaml-cpp
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/eschnett/asdf-cxx/archive/refs/tags/version/7.3.2.tar.gz && \
-    tar xzf 7.3.2.tar.gz && \
-    cd asdf-cxx-version-7.3.2 && \
+    wget https://github.com/eschnett/asdf-cxx/archive/refs/tags/version/8.0.0.tar.gz && \
+    tar xzf 8.0.0.tar.gz && \
+    cd asdf-cxx-version-8.0.0 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -221,6 +589,7 @@ RUN mkdir src && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
         -Dsimd=AVX2 \
         && \
     cmake --build build && \
@@ -233,11 +602,20 @@ RUN mkdir src && \
 # Install openPMD-api
 # openPMD-api defines a standard for laying out AMR data in a file
 # - depends on ADIOS2
+# - depends on mpi_abi_wrapper, and this is not optional: openPMD calls
+#   find_package(MPI) itself, and left alone it finds the system Open MPI and
+#   then fails to link ADIOS2 -- "undefined reference to
+#   adios2::ADIOS::ADIOS(ompi_communicator_t*)", because ADIOS2's MPI_Comm is
+#   the ABI's. The subtler half is HDF5: it is *also* mandatory that
+#   find_package(HDF5) resolve to the ABI-built HDF5 in /usr/local, since
+#   openPMD hands an MPI_Comm to H5Pset_fapl_mpio. Mixing there does not fail
+#   to link -- C linkage hides the type mismatch -- it silently passes an ABI
+#   handle to a library expecting an ompi_communicator_t*.
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/openPMD/openPMD-api/archive/refs/tags/0.16.1.tar.gz && \
-    tar xzf 0.16.1.tar.gz && \
-    cd openPMD-api-0.16.1 && \
+    wget https://github.com/openPMD/openPMD-api/archive/refs/tags/0.17.1.tar.gz && \
+    tar xzf 0.17.1.tar.gz && \
+    cd openPMD-api-0.17.1 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -245,6 +623,8 @@ RUN mkdir src && \
         -DBUILD_TESTING=OFF \
         -DopenPMD_BUILD_SHARED_LIBS=ON \
         -DopenPMD_USE_MPI=ON \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
     cmake --build build && \
     cmake --install build && \
@@ -258,7 +638,7 @@ RUN mkdir src && \
     wget https://github.com/wokast/RePrimAnd/archive/refs/tags/v1.7.tar.gz && \
     tar xzf v1.7.tar.gz && \
     cd RePrimAnd-1.7 && \
-    meson build --buildtype=release --prefix=/usr/local && \
+    meson setup build --buildtype=release --prefix=/usr/local -Dcpp_std=c++14 && \
     ninja -C build && \
     ninja -C build install && \
     true) && \
@@ -266,38 +646,51 @@ RUN mkdir src && \
 
 # Install Silo
 # Silo defines a standard for laying out AMR data in a file
+# - Silo has no MPI of its own, but it links HDF5 and so inherits HDF5's MPI;
+#   the compilers are named for the same reason as in the SZ3 stanza
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/LLNL/Silo/releases/download/4.11.1/silo-4.11.1.tar.xz && \
-    tar xJf silo-4.11.1.tar.xz && \
-    cd silo-4.11.1 && \
-    mkdir build && \
-    cd build && \
-    ../configure \
-        --disable-fortran \
-        --disable-static \
-        --enable-optimization \
-        --enable-shared \
-        --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial/include,/usr/lib/x86_64-linux-gnu/hdf5/serial/lib \
-        --prefix=/usr/local \
+    wget https://github.com/LLNL/Silo/releases/download/4.12.1/Silo-4.12.1.tar.xz && \
+    tar xJf Silo-4.12.1.tar.xz && \
+    cd Silo-4.12.1 && \
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DSILO_BUILD_FOR_BSD_LICENSE=ON \
+        -DSILO_ENABLE_BROWSER=OFF \
+        -DSILO_ENABLE_FORTRAN=OFF \
+        -DSILO_ENABLE_HDF5=ON \
+        -DSILO_ENABLE_JSON=OFF \
+        -DSILO_ENABLE_PYTHON_MODULE=OFF \
+        -DSILO_ENABLE_SHARED=ON \
+        -DSILO_ENABLE_SILEX=OFF \
+        -DSILO_ENABLE_SILOCK=ON \
+        -DSILO_ENABLE_TESTS=OFF \
+        -DSILO_HDF5_SZIP_DIR=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
-    make -j$(nproc) && \
-    make -j$(nproc) install && \
+    cmake --build build && \
+    cmake --install build && \
     true) && \
     rm -rf src
 
 # Install Conduit
 # Conduit defines a standard for laying out AMR data in a file.
 # - depends on Silo
+# - depends on mpi_abi_wrapper: `libconduit_relay_mpi*` and
+#   `libconduit_blueprint_mpi` take an MPI_Comm across their public interface.
+#   HDF5_DIR moves from /usr to /usr/local for the same reason -- Conduit's
+#   relay writes HDF5, and the two must agree on what an MPI_Comm is.
 # TODO:
 # - enable CUDA? HIP?
 # -DADIOS_DIR=/usr/local   # conduit doesn't find ADIOS because there is no FindADIOS.cmake
 # -DZFP_DIR=/usr           # conduit doesn't find zfp because the library directory is wrong
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/LLNL/conduit/releases/download/v0.9.5/conduit-v0.9.5-src-with-blt.tar.gz && \
-    tar xzf conduit-v0.9.5-src-with-blt.tar.gz && \
-    cd conduit-v0.9.5 && \
+    wget https://github.com/LLNL/conduit/releases/download/v0.9.8/conduit-v0.9.8-src-with-blt.tar.gz && \
+    tar xzf conduit-v0.9.8-src-with-blt.tar.gz && \
+    cd conduit-v0.9.8 && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -313,7 +706,9 @@ RUN mkdir src && \
         -DENABLE_RELAY_WEBSERVER=OFF \
         -DENABLE_TESTS=OFF \
         -DENABLE_UTILS=ON \
-        -DHDF5_DIR=/usr \
+        -DHDF5_DIR=/usr/local \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         -DSILO_DIR=/usr/local \
         -DZLIB_DIR=/usr \
         src \
@@ -336,7 +731,8 @@ RUN mkdir src && \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
-        -DENABLE_ASDF_CXX=OFF \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        -DENABLE_ASDF_CXX=ON \
         && \
     cmake --build build && \
     cmake --install build && \
@@ -360,29 +756,73 @@ RUN mkdir src && \
     true) && \
     rm -rf src
 
+# # Install Fuka
+# RUN mkdir src
+# WORKDIR src
+# RUN git clone --branch ET_2025_05 https://bitbucket.org/fukaws/fuka
+# WORKDIR fuka
+# # Ensure this macro is defined at build time to enable multi-threaded importers
+# RUN sed -i -E 's%// #define DEFAULT_KAD_MEM%#define DEFAULT_KAD_MEM%' include/memory.hpp
+# WORKDIR build_release
+# RUN env HOME_KADATH=/cactus/src/fuka \
+#     cmake -B build -G Ninja \
+#         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+#         -DCMAKE_INSTALL_PREFIX=/usr/local \
+#         -DGRHAYL_EOS=OFF \
+#         -DPAR_VERSION=ON
+# RUN cmake --build build
+# WORKDIR ..
+# RUN cp lib/libkadath.a /usr/local/lib
+# RUN ls -l /cactus/src/fuka/include
+# RUN false
+# WORKDIR ../..
+# RUN rm -rf src
+# RUN echo
+# RUN ls -l /usr/local/include
+# RUN ls -l /usr/local/lib
+# RUN false
+
 ARG real_precision=real64
 
 # Install AMReX
 # AMReX provides adaptive mesh refinement
+# - depends on mpi_abi_wrapper: AMReX is where CarpetX's own communication
+#   happens, so its MPI_Comm has to be the same one Cactus calls MPI_Init on.
+#   AMReX_MPI defaults to ON and is left that way; only the compilers change.
+#   The nine `-DMPI_*` variables `carpetx-native-rocm.dockerfile` sets here are gone:
+#   see the ROCm notes in the header.
+# - CMAKE_PREFIX_PATH names *prefixes*, where `carpetx-native-rocm.dockerfile` names
+#   eight individual `/opt/rocm/lib/cmake/<pkg>` directories. CMake looks for
+#   `<prefix>/lib/cmake/<name>` itself, so one prefix finds all of them, and the
+#   list does not have to be rewritten every time ROCm moves a package -- which
+#   it just did, in ROCm 10. Both `${ROCM_PATH}` and `${ROCM_PATH}/core-10.0`
+#   are listed because only the second exists on disk in ROCm 10 while the first
+#   is what the image advertises; CMake ignores a prefix that is not there.
+#   `/usr/local` is on the list so the ABI's own CMake package stays visible to
+#   any nested find_package.
+# - the compilers are named without a path. `amdclang++` and `amdclang` sit in
+#   `${ROCM_PATH}/bin`, which the base image puts on PATH, so this does not
+#   depend on where ROCm actually unpacked its LLVM -- in ROCm 10 that is
+#   `core-10.0/lib/llvm/bin`, not the `/opt/rocm/llvm/bin` the older file used.
 # - Enable Fortran for `docker/Dockerfile`
 # - Install this last because it changes most often
 # Should we keep the AMReX source tree around for debugging?
 RUN mkdir src && \
     (cd src && \
-    wget https://github.com/AMReX-Codes/amrex/archive/25.11.tar.gz && \
-    tar xzf 25.11.tar.gz && \
-    cd amrex-25.11 && \
+    wget https://github.com/AMReX-Codes/amrex/archive/26.01.tar.gz && \
+    tar xzf 26.01.tar.gz && \
+    cd amrex-26.01 && \
     case $real_precision in \
         real32) precision=SINGLE;; \
         real64) precision=DOUBLE;; \
         *) exit 1;; \
     esac && \
-    env LDFLAGS=-Wl,-rpath,/opt/rocm/lib \
+    env LDFLAGS="-Wl,-rpath,${ROCM_PATH}/lib -Wl,-rpath,${ROCM_PATH}/core-10.0/lib" \
     cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
-        -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
-        -DCMAKE_PREFIX_PATH='/opt/rocm/lib/cmake/AMDDeviceLibs;/opt/rocm/lib/cmake/amd_comgr;/opt/rocm/lib/cmake/hip;/opt/rocm/lib/cmake/hiprand;/opt/rocm/lib/cmake/hsa-runtime64;/opt/rocm/lib/cmake/rocprim;/opt/rocm/lib/cmake/rocrand;/opt/rocm/lib/cmake/rocsparse' \
+        -DCMAKE_CXX_COMPILER=amdclang++ \
+        -DCMAKE_C_COMPILER=amdclang \
+        -DCMAKE_PREFIX_PATH="${ROCM_PATH};${ROCM_PATH}/core-10.0;/usr/local" \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
         -DBUILD_SHARED_LIBS=ON \
         -DAMReX_AMD_ARCH=gfx90a \
@@ -392,15 +832,8 @@ RUN mkdir src && \
         -DAMReX_OMP=OFF \
         -DAMReX_PARTICLES=ON \
         -DAMReX_PRECISION="$precision" \
-        -DMPI_CXX_ADDITIONAL_INCLUDE_DIRS='/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi;/usr/lib/x86_64-linux-gnu/openmpi/include' \
-        -DMPI_CXX_LIB_NAMES='mpi_cxx;mpi;open-rte;open-pal;hwloc' \
-        -DMPI_C_ADDITIONAL_INCLUDE_DIRS='/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi;/usr/lib/x86_64-linux-gnu/openmpi/include' \
-        -DMPI_C_LIB_NAMES='mpi;open-rte;open-pal;hwloc' \
-        -DMPI_hwloc_LIBRARY=/lib/x86_64-linux-gnu/libhwloc.so \
-        -DMPI_mpi_LIBRARY=/usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi.so \
-        -DMPI_mpi_cxx_LIBRARY=/usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi_cxx.so \
-        -DMPI_open-pal_LIBRARY=/lib/x86_64-linux-gnu/libopen-pal.so \
-        -DMPI_open-rte_LIBRARY=/lib/x86_64-linux-gnu/libopen-rte.so \
+        -DMPI_C_COMPILER=/usr/local/bin/mpicc \
+        -DMPI_CXX_COMPILER=/usr/local/bin/mpicxx \
         && \
     cmake --build build && \
     cmake --install build && \

--- a/scripts/actions-cpu-real32.cfg
+++ b/scripts/actions-cpu-real32.cfg
@@ -88,6 +88,13 @@ AMREX_DIR = /usr/local
 # ASDF_CXX_DIR = /usr/local
 BLAS_DIR = /usr
 BOOST_DIR = /usr
+# BOOST_LIBS must be set: ExternalLibraries/Boost defaults to
+# "boost_filesystem boost_system" when it is empty (Boost/configure.sh:166),
+# and the image installs libboost-filesystem-dev only, so the link fails with
+# "cannot find -lboost_system". Boost.System has been header-only since Boost
+# 1.69, so naming just filesystem is correct rather than a workaround --
+# `desert-arm64v8.cfg` has always done this.
+BOOST_LIBS = boost_filesystem
 CONDUIT_DIR = /usr/local
 FFTW3_DIR = /usr
 GSL_DIR = /usr

--- a/scripts/actions-cpu-real32.cfg
+++ b/scripts/actions-cpu-real32.cfg
@@ -3,9 +3,33 @@
 # The "weird" options here should probably be made the default in the
 # ET instead of being set here.
 
+# The container this option list targets provides MPI, HDF5 and PETSc through
+# the **MPI ABI** in /usr/local, not through distribution packages: the image
+# builds mpi_abi_wrapper (the C bindings) and mpif (the Fortran ones) over the
+# MPI it wraps, then builds HDF5 and PETSc against those. See the header of the
+# matching `docker/carpetx-*.dockerfile` for the image side, and
+# `simfactory/mdb/optionlists/desert*.cfg` for the same four blocks in the
+# interactive option lists.
+#
+# - MPI_INC_DIRS / MPI_LIB_DIRS / MPI_LIBS are set explicitly so that
+#   ExternalLibraries/MPI takes its *manual* path (detect.pl:84). The automatic
+#   path asks the wrapper for `-compile_info`, which answers with the compile
+#   flags alone -- no `-L`, no `-l` -- so MPI would be configured with an empty
+#   MPI_LIBS and nothing would be linked.
+# - HDF5 is the CMake build, which spells the Fortran libraries `hdf5_fortran` /
+#   `hdf5_hl_fortran` where Debian spelled the latter `hdf5hl_fortran`, and adds
+#   the `*_f90cstub` pair Debian did not have.
+# - PETSc is `libpetsc.so` under one prefix, so PETSC_LIBS is left unset:
+#   detect.sh settles on `petsc m` and the external packages (hypre, MUMPS,
+#   SuperLU_DIST, ...) arrive through libpetsc.so's own DT_NEEDED entries.
+#   `PETSC_LIBS = petsc_real` was Debian's split-package spelling and is gone.
+# - F90FLAGS gains -I/usr/local/include: gfortran does not search it for `.mod`
+#   files the way the preprocessor searches it for headers, and detect.pl strips
+#   the directory out of MPI_INC_DIRS/HDF5_INC_DIRS for being standard.
+
 # Whenever this version string changes, the application is configured
 # and rebuilt from scratch
-VERSION = actions-cpu-real32-2023-02-04
+VERSION = actions-cpu-real32-2026-09-07
 
 CPP = cpp
 CC = gcc
@@ -20,7 +44,7 @@ F90 = gfortran
 CFLAGS = -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS -fPIE -fcf-protection=full -fstack-clash-protection -fstack-protector-strong -ftrivial-auto-var-init=pattern -g -march=x86-64-v3 -pie -pipe -std=gnu11
 CXXFLAGS = -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS -fPIE -fcf-protection=full -fstack-clash-protection -fstack-protector-strong -g -march=x86-64-v3 -pie -pipe -std=gnu++17
 FPPFLAGS = -traditional
-F90FLAGS = -fPIE -fcf-protection=full -fcray-pointer -ffixed-line-length-none -finit-character=65 -finit-integer=42424242 -finit-real=nan -fstack-clash-protection -fstack-protector-strong -g -march=x86-64-v3 -pie -pipe
+F90FLAGS = -fPIE -fcf-protection=full -fcray-pointer -ffixed-line-length-none -finit-character=65 -finit-integer=42424242 -finit-real=nan -fstack-clash-protection -fstack-protector-strong -g -march=x86-64-v3 -pie -pipe -I/usr/local/include
 LDFLAGS = -L/usr/lib/x86_64-linux-gnu -Wl,-rpath,/usr/local/lib -Wl,-z,relro,-z,now
 
 C_LINE_DIRECTIVES = yes
@@ -59,7 +83,7 @@ FPP_WARN_FLAGS = -Wall
 F90_WARN_FLAGS = -Wall -Wshadow -Wsurprising
 
 ADIOS2_DIR = /usr/local
-ADIOS2_LIBS = adios2_cxx11_mpi adios2_cxx11 mgard protobuf
+ADIOS2_LIBS = adios2_cxx_mpi adios2_cxx mgard protobuf
 AMREX_DIR = /usr/local
 # ASDF_CXX_DIR = /usr/local
 BLAS_DIR = /usr
@@ -67,26 +91,28 @@ BOOST_DIR = /usr
 CONDUIT_DIR = /usr/local
 FFTW3_DIR = /usr
 GSL_DIR = /usr
-HDF5_DIR = /usr/lib/x86_64-linux-gnu/hdf5/serial
+HDF5_DIR = /usr/local
 HDF5_ENABLE_CXX = yes
 HDF5_ENABLE_FORTRAN = yes
-HDF5_INC_DIRS = /usr/lib/x86_64-linux-gnu/hdf5/serial/include
-HDF5_LIB_DIRS = /usr/lib/x86_64-linux-gnu/hdf5/serial/lib
-HDF5_LIBS = hdf5_hl_cpp hdf5_cpp hdf5hl_fortran hdf5_fortran hdf5_hl hdf5
+HDF5_INC_DIRS = /usr/local/include
+HDF5_LIB_DIRS = /usr/local/lib
+HDF5_LIBS = hdf5_hl_cpp hdf5_cpp hdf5_hl_fortran hdf5_fortran hdf5_hl_f90cstub hdf5_f90cstub hdf5_hl hdf5
 HWLOC_DIR = /usr
 # JEMALLOC_DIR = /usr/local
 LAPACK_DIR = /usr
 # LIBJPEG_DIR = /usr
 # LORENE_DIR = /usr/local
-MPI_DIR = /usr
+MPI_DIR = /usr/local
+MPI_INC_DIRS = /usr/local/include
+MPI_LIB_DIRS = /usr/local/lib
+MPI_LIBS = mpif mpi_abi
 NSIMD_DIR = /usr/local
 NSIMD_SIMD = AVX2
 OPENBLAS_DIR = /usr
 OPENPMD_API_DIR = /usr/local
 # OPENSSL_DIR = /usr
 # PAPI_DIR = /usr/local
-PETSC_DIR = /usr/lib/petsc
-PETSC_LIBS = petsc_real
+PETSC_DIR = /usr/local
 PETSC_ARCH_LIBS = m
 PTHREADS_DIR = NO_BUILD
 # REPRIMAND_DIR = /usr/local

--- a/scripts/actions-cpu-real64.cfg
+++ b/scripts/actions-cpu-real64.cfg
@@ -3,9 +3,33 @@
 # The "weird" options here should probably be made the default in the
 # ET instead of being set here.
 
+# The container this option list targets provides MPI, HDF5 and PETSc through
+# the **MPI ABI** in /usr/local, not through distribution packages: the image
+# builds mpi_abi_wrapper (the C bindings) and mpif (the Fortran ones) over the
+# MPI it wraps, then builds HDF5 and PETSc against those. See the header of the
+# matching `docker/carpetx-*.dockerfile` for the image side, and
+# `simfactory/mdb/optionlists/desert*.cfg` for the same four blocks in the
+# interactive option lists.
+#
+# - MPI_INC_DIRS / MPI_LIB_DIRS / MPI_LIBS are set explicitly so that
+#   ExternalLibraries/MPI takes its *manual* path (detect.pl:84). The automatic
+#   path asks the wrapper for `-compile_info`, which answers with the compile
+#   flags alone -- no `-L`, no `-l` -- so MPI would be configured with an empty
+#   MPI_LIBS and nothing would be linked.
+# - HDF5 is the CMake build, which spells the Fortran libraries `hdf5_fortran` /
+#   `hdf5_hl_fortran` where Debian spelled the latter `hdf5hl_fortran`, and adds
+#   the `*_f90cstub` pair Debian did not have.
+# - PETSc is `libpetsc.so` under one prefix, so PETSC_LIBS is left unset:
+#   detect.sh settles on `petsc m` and the external packages (hypre, MUMPS,
+#   SuperLU_DIST, ...) arrive through libpetsc.so's own DT_NEEDED entries.
+#   `PETSC_LIBS = petsc_real` was Debian's split-package spelling and is gone.
+# - F90FLAGS gains -I/usr/local/include: gfortran does not search it for `.mod`
+#   files the way the preprocessor searches it for headers, and detect.pl strips
+#   the directory out of MPI_INC_DIRS/HDF5_INC_DIRS for being standard.
+
 # Whenever this version string changes, the application is configured
 # and rebuilt from scratch
-VERSION = actions-real-cpu64-2023-02-04
+VERSION = actions-real-cpu64-2026-09-07
 
 CPP = cpp
 CC = gcc
@@ -20,7 +44,7 @@ F90 = gfortran
 CFLAGS = -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS -fPIE -fcf-protection=full -fstack-clash-protection -fstack-protector-strong -ftrivial-auto-var-init=pattern -g -march=x86-64-v3 -pie -pipe -std=gnu11
 CXXFLAGS = -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS -fPIE -fcf-protection=full -fstack-clash-protection -fstack-protector-strong -g -march=x86-64-v3 -pie -pipe -std=gnu++17
 FPPFLAGS = -traditional
-F90FLAGS = -fPIE -fcf-protection=full -fcray-pointer -ffixed-line-length-none -finit-character=65 -finit-integer=42424242 -finit-real=nan -fstack-clash-protection -fstack-protector-strong -g -march=x86-64-v3 -pie -pipe
+F90FLAGS = -fPIE -fcf-protection=full -fcray-pointer -ffixed-line-length-none -finit-character=65 -finit-integer=42424242 -finit-real=nan -fstack-clash-protection -fstack-protector-strong -g -march=x86-64-v3 -pie -pipe -I/usr/local/include
 LDFLAGS = -L/usr/lib/x86_64-linux-gnu -Wl,-rpath,/usr/local/lib -Wl,-z,relro,-z,now
 
 C_LINE_DIRECTIVES = yes
@@ -59,7 +83,7 @@ FPP_WARN_FLAGS = -Wall
 F90_WARN_FLAGS = -Wall -Wshadow -Wsurprising
 
 ADIOS2_DIR = /usr/local
-ADIOS2_LIBS = adios2_cxx11_mpi adios2_cxx11 mgard protobuf
+ADIOS2_LIBS = adios2_cxx_mpi adios2_cxx mgard protobuf
 AMREX_DIR = /usr/local
 # ASDF_CXX_DIR = /usr/local
 BLAS_DIR = /usr
@@ -67,26 +91,28 @@ BOOST_DIR = /usr
 CONDUIT_DIR = /usr/local
 FFTW3_DIR = /usr
 GSL_DIR = /usr
-HDF5_DIR = /usr/lib/x86_64-linux-gnu/hdf5/serial
+HDF5_DIR = /usr/local
 HDF5_ENABLE_CXX = yes
 HDF5_ENABLE_FORTRAN = yes
-HDF5_INC_DIRS = /usr/lib/x86_64-linux-gnu/hdf5/serial/include
-HDF5_LIB_DIRS = /usr/lib/x86_64-linux-gnu/hdf5/serial/lib
-HDF5_LIBS = hdf5_hl_cpp hdf5_cpp hdf5hl_fortran hdf5_fortran hdf5_hl hdf5
+HDF5_INC_DIRS = /usr/local/include
+HDF5_LIB_DIRS = /usr/local/lib
+HDF5_LIBS = hdf5_hl_cpp hdf5_cpp hdf5_hl_fortran hdf5_fortran hdf5_hl_f90cstub hdf5_f90cstub hdf5_hl hdf5
 HWLOC_DIR = /usr
 # JEMALLOC_DIR = /usr/local
 LAPACK_DIR = /usr
 # LIBJPEG_DIR = /usr
 # LORENE_DIR = /usr/local
-MPI_DIR = /usr
+MPI_DIR = /usr/local
+MPI_INC_DIRS = /usr/local/include
+MPI_LIB_DIRS = /usr/local/lib
+MPI_LIBS = mpif mpi_abi
 NSIMD_DIR = /usr/local
 NSIMD_SIMD = AVX2
 OPENBLAS_DIR = /usr
 OPENPMD_API_DIR = /usr/local
 # OPENSSL_DIR = /usr
 # PAPI_DIR = /usr/local
-PETSC_DIR = /usr/lib/petsc
-PETSC_LIBS = petsc_real
+PETSC_DIR = /usr/local
 PETSC_ARCH_LIBS = m
 PTHREADS_DIR = NO_BUILD
 # REPRIMAND_DIR = /usr/local

--- a/scripts/actions-cpu-real64.cfg
+++ b/scripts/actions-cpu-real64.cfg
@@ -88,6 +88,13 @@ AMREX_DIR = /usr/local
 # ASDF_CXX_DIR = /usr/local
 BLAS_DIR = /usr
 BOOST_DIR = /usr
+# BOOST_LIBS must be set: ExternalLibraries/Boost defaults to
+# "boost_filesystem boost_system" when it is empty (Boost/configure.sh:166),
+# and the image installs libboost-filesystem-dev only, so the link fails with
+# "cannot find -lboost_system". Boost.System has been header-only since Boost
+# 1.69, so naming just filesystem is correct rather than a workaround --
+# `desert-arm64v8.cfg` has always done this.
+BOOST_LIBS = boost_filesystem
 CONDUIT_DIR = /usr/local
 FFTW3_DIR = /usr
 GSL_DIR = /usr

--- a/scripts/actions-cuda-real32.cfg
+++ b/scripts/actions-cuda-real32.cfg
@@ -51,7 +51,14 @@ CFLAGS = -pipe -g -std=gnu11
 CXXFLAGS = -pipe -g0 -std=c++17 --compiler-options -std=gnu++17 --expt-relaxed-constexpr --extended-lambda --gpu-architecture sm_90 --forward-unknown-to-host-compiler --Werror ext-lambda-captures-this --relocatable-device-code=true --objdir-as-tempdir
 FPPFLAGS = -traditional
 F90FLAGS = -pipe -g -fcray-pointer -ffixed-line-length-none -I/usr/local/include
-LIBS = nvToolsExt gfortran
+# `nvToolsExt` is not named here. NVTX v3 is header-only: `timer.hxx` includes
+# <nvtx3/nvToolsExt.h> under __CUDACC__ and calls nvtxRangeStartA/nvtxRangeEnd,
+# which are static inline and dlopen a profiler's injection library at run time
+# if one is attached -- there is nothing to link against. The old `libnvToolsExt`
+# was retired with NVTX v2 and the NVHPC base image no longer ships it, so
+# naming it ended the link with
+#   /usr/bin/ld: cannot find -lnvToolsExt: No such file or directory
+LIBS = gfortran
 
 C_LINE_DIRECTIVES = yes
 F_LINE_DIRECTIVES = yes

--- a/scripts/actions-cuda-real32.cfg
+++ b/scripts/actions-cuda-real32.cfg
@@ -3,9 +3,33 @@
 # The "weird" options here should probably be made the default in the
 # ET instead of being set here.
 
+# The container this option list targets provides MPI, HDF5 and PETSc through
+# the **MPI ABI** in /usr/local, not through distribution packages: the image
+# builds mpi_abi_wrapper (the C bindings) and mpif (the Fortran ones) over the
+# MPI it wraps, then builds HDF5 and PETSc against those. See the header of the
+# matching `docker/carpetx-*.dockerfile` for the image side, and
+# `simfactory/mdb/optionlists/desert*.cfg` for the same four blocks in the
+# interactive option lists.
+#
+# - MPI_INC_DIRS / MPI_LIB_DIRS / MPI_LIBS are set explicitly so that
+#   ExternalLibraries/MPI takes its *manual* path (detect.pl:84). The automatic
+#   path asks the wrapper for `-compile_info`, which answers with the compile
+#   flags alone -- no `-L`, no `-l` -- so MPI would be configured with an empty
+#   MPI_LIBS and nothing would be linked.
+# - HDF5 is the CMake build, which spells the Fortran libraries `hdf5_fortran` /
+#   `hdf5_hl_fortran` where Debian spelled the latter `hdf5hl_fortran`, and adds
+#   the `*_f90cstub` pair Debian did not have.
+# - PETSc is `libpetsc.so` under one prefix, so PETSC_LIBS is left unset:
+#   detect.sh settles on `petsc m` and the external packages (hypre, MUMPS,
+#   SuperLU_DIST, ...) arrive through libpetsc.so's own DT_NEEDED entries.
+#   `PETSC_LIBS = petsc_real` was Debian's split-package spelling and is gone.
+# - F90FLAGS gains -I/usr/local/include: gfortran does not search it for `.mod`
+#   files the way the preprocessor searches it for headers, and detect.pl strips
+#   the directory out of MPI_INC_DIRS/HDF5_INC_DIRS for being standard.
+
 # Whenever this version string changes, the application is configured
 # and rebuilt from scratch
-VERSION = actions-cuda-real32-2023-02-04
+VERSION = actions-cuda-real32-2026-09-07
 
 CPP = cpp
 CC = gcc
@@ -26,7 +50,7 @@ CFLAGS = -pipe -g -std=gnu11
 #     float  %1 = call i32 @__isnanf(double %tmp), !dbg !1483
 CXXFLAGS = -pipe -g0 -std=c++17 --compiler-options -std=gnu++17 --expt-relaxed-constexpr --extended-lambda --gpu-architecture sm_90 --forward-unknown-to-host-compiler --Werror ext-lambda-captures-this --relocatable-device-code=true --objdir-as-tempdir
 FPPFLAGS = -traditional
-F90FLAGS = -pipe -g -fcray-pointer -ffixed-line-length-none
+F90FLAGS = -pipe -g -fcray-pointer -ffixed-line-length-none -I/usr/local/include
 LIBS = nvToolsExt gfortran
 
 C_LINE_DIRECTIVES = yes
@@ -72,7 +96,7 @@ F90_WARN_FLAGS = -Wall -Wshadow -Wsurprising
 VECTORISE = no
 
 ADIOS2_DIR = /usr/local
-ADIOS2_LIBS = adios2_cxx11_mpi adios2_cxx11 mgard protobuf
+ADIOS2_LIBS = adios2_cxx_mpi adios2_cxx mgard protobuf
 AMREX_DIR = /usr/local
 # ASDF_CXX_DIR = /usr/local
 BLAS_DIR = /usr
@@ -80,26 +104,28 @@ BOOST_DIR = /usr
 CONDUIT_DIR = /usr/local
 FFTW3_DIR = /usr
 GSL_DIR = /usr
-HDF5_DIR = /usr/lib/x86_64-linux-gnu/hdf5/serial
+HDF5_DIR = /usr/local
 HDF5_ENABLE_CXX = yes
 HDF5_ENABLE_FORTRAN = yes
-HDF5_INC_DIRS = /usr/lib/x86_64-linux-gnu/hdf5/serial/include
-HDF5_LIB_DIRS = /usr/lib/x86_64-linux-gnu/hdf5/serial/lib
-HDF5_LIBS = hdf5_hl_cpp hdf5_cpp hdf5hl_fortran hdf5_fortran hdf5_hl hdf5
+HDF5_INC_DIRS = /usr/local/include
+HDF5_LIB_DIRS = /usr/local/lib
+HDF5_LIBS = hdf5_hl_cpp hdf5_cpp hdf5_hl_fortran hdf5_fortran hdf5_hl_f90cstub hdf5_f90cstub hdf5_hl hdf5
 HWLOC_DIR = /usr
 # JEMALLOC_DIR = /usr/local
 LAPACK_DIR = /usr
 # LIBJPEG_DIR = /usr
 # LORENE_DIR = /usr/local
-MPI_DIR = /usr
+MPI_DIR = /usr/local
+MPI_INC_DIRS = /usr/local/include
+MPI_LIB_DIRS = /usr/local/lib
+MPI_LIBS = mpif mpi_abi
 NSIMD_DIR = /usr/local
 NSIMD_SIMD = AVX2
 OPENBLAS_DIR = /usr
 OPENPMD_API_DIR = /usr/local
 # OPENSSL_DIR = /usr
 # PAPI_DIR = /usr/local
-PETSC_DIR = /usr/lib/petsc
-PETSC_LIBS = petsc_real
+PETSC_DIR = /usr/local
 PETSC_ARCH_LIBS = m
 PTHREADS_DIR = NO_BUILD
 # REPRIMAND_DIR = /usr/local

--- a/scripts/actions-cuda-real32.cfg
+++ b/scripts/actions-cuda-real32.cfg
@@ -101,6 +101,13 @@ AMREX_DIR = /usr/local
 # ASDF_CXX_DIR = /usr/local
 BLAS_DIR = /usr
 BOOST_DIR = /usr
+# BOOST_LIBS must be set: ExternalLibraries/Boost defaults to
+# "boost_filesystem boost_system" when it is empty (Boost/configure.sh:166),
+# and the image installs libboost-filesystem-dev only, so the link fails with
+# "cannot find -lboost_system". Boost.System has been header-only since Boost
+# 1.69, so naming just filesystem is correct rather than a workaround --
+# `desert-arm64v8.cfg` has always done this.
+BOOST_LIBS = boost_filesystem
 CONDUIT_DIR = /usr/local
 FFTW3_DIR = /usr
 GSL_DIR = /usr

--- a/scripts/actions-cuda-real64.cfg
+++ b/scripts/actions-cuda-real64.cfg
@@ -51,7 +51,14 @@ CFLAGS = -pipe -g -std=gnu11
 CXXFLAGS = -pipe -g0 -std=c++17 --compiler-options -std=gnu++17 --expt-relaxed-constexpr --extended-lambda --gpu-architecture sm_90 --forward-unknown-to-host-compiler --Werror ext-lambda-captures-this --relocatable-device-code=true --objdir-as-tempdir
 FPPFLAGS = -traditional
 F90FLAGS = -pipe -g -fcray-pointer -ffixed-line-length-none -I/usr/local/include
-LIBS = nvToolsExt gfortran
+# `nvToolsExt` is not named here. NVTX v3 is header-only: `timer.hxx` includes
+# <nvtx3/nvToolsExt.h> under __CUDACC__ and calls nvtxRangeStartA/nvtxRangeEnd,
+# which are static inline and dlopen a profiler's injection library at run time
+# if one is attached -- there is nothing to link against. The old `libnvToolsExt`
+# was retired with NVTX v2 and the NVHPC base image no longer ships it, so
+# naming it ended the link with
+#   /usr/bin/ld: cannot find -lnvToolsExt: No such file or directory
+LIBS = gfortran
 
 C_LINE_DIRECTIVES = yes
 F_LINE_DIRECTIVES = yes

--- a/scripts/actions-cuda-real64.cfg
+++ b/scripts/actions-cuda-real64.cfg
@@ -101,6 +101,13 @@ AMREX_DIR = /usr/local
 # ASDF_CXX_DIR = /usr/local
 BLAS_DIR = /usr
 BOOST_DIR = /usr
+# BOOST_LIBS must be set: ExternalLibraries/Boost defaults to
+# "boost_filesystem boost_system" when it is empty (Boost/configure.sh:166),
+# and the image installs libboost-filesystem-dev only, so the link fails with
+# "cannot find -lboost_system". Boost.System has been header-only since Boost
+# 1.69, so naming just filesystem is correct rather than a workaround --
+# `desert-arm64v8.cfg` has always done this.
+BOOST_LIBS = boost_filesystem
 CONDUIT_DIR = /usr/local
 FFTW3_DIR = /usr
 GSL_DIR = /usr

--- a/scripts/actions-cuda-real64.cfg
+++ b/scripts/actions-cuda-real64.cfg
@@ -3,9 +3,33 @@
 # The "weird" options here should probably be made the default in the
 # ET instead of being set here.
 
+# The container this option list targets provides MPI, HDF5 and PETSc through
+# the **MPI ABI** in /usr/local, not through distribution packages: the image
+# builds mpi_abi_wrapper (the C bindings) and mpif (the Fortran ones) over the
+# MPI it wraps, then builds HDF5 and PETSc against those. See the header of the
+# matching `docker/carpetx-*.dockerfile` for the image side, and
+# `simfactory/mdb/optionlists/desert*.cfg` for the same four blocks in the
+# interactive option lists.
+#
+# - MPI_INC_DIRS / MPI_LIB_DIRS / MPI_LIBS are set explicitly so that
+#   ExternalLibraries/MPI takes its *manual* path (detect.pl:84). The automatic
+#   path asks the wrapper for `-compile_info`, which answers with the compile
+#   flags alone -- no `-L`, no `-l` -- so MPI would be configured with an empty
+#   MPI_LIBS and nothing would be linked.
+# - HDF5 is the CMake build, which spells the Fortran libraries `hdf5_fortran` /
+#   `hdf5_hl_fortran` where Debian spelled the latter `hdf5hl_fortran`, and adds
+#   the `*_f90cstub` pair Debian did not have.
+# - PETSc is `libpetsc.so` under one prefix, so PETSC_LIBS is left unset:
+#   detect.sh settles on `petsc m` and the external packages (hypre, MUMPS,
+#   SuperLU_DIST, ...) arrive through libpetsc.so's own DT_NEEDED entries.
+#   `PETSC_LIBS = petsc_real` was Debian's split-package spelling and is gone.
+# - F90FLAGS gains -I/usr/local/include: gfortran does not search it for `.mod`
+#   files the way the preprocessor searches it for headers, and detect.pl strips
+#   the directory out of MPI_INC_DIRS/HDF5_INC_DIRS for being standard.
+
 # Whenever this version string changes, the application is configured
 # and rebuilt from scratch
-VERSION = actions-cuda-real64-2023-02-04
+VERSION = actions-cuda-real64-2026-09-07
 
 CPP = cpp
 CC = gcc
@@ -26,7 +50,7 @@ CFLAGS = -pipe -g -std=gnu11
 #     float  %1 = call i32 @__isnanf(double %tmp), !dbg !1483
 CXXFLAGS = -pipe -g0 -std=c++17 --compiler-options -std=gnu++17 --expt-relaxed-constexpr --extended-lambda --gpu-architecture sm_90 --forward-unknown-to-host-compiler --Werror ext-lambda-captures-this --relocatable-device-code=true --objdir-as-tempdir
 FPPFLAGS = -traditional
-F90FLAGS = -pipe -g -fcray-pointer -ffixed-line-length-none
+F90FLAGS = -pipe -g -fcray-pointer -ffixed-line-length-none -I/usr/local/include
 LIBS = nvToolsExt gfortran
 
 C_LINE_DIRECTIVES = yes
@@ -72,7 +96,7 @@ F90_WARN_FLAGS = -Wall -Wshadow -Wsurprising
 VECTORISE = no
 
 ADIOS2_DIR = /usr/local
-ADIOS2_LIBS = adios2_cxx11_mpi adios2_cxx11 mgard protobuf
+ADIOS2_LIBS = adios2_cxx_mpi adios2_cxx mgard protobuf
 AMREX_DIR = /usr/local
 # ASDF_CXX_DIR = /usr/local
 BLAS_DIR = /usr
@@ -80,26 +104,28 @@ BOOST_DIR = /usr
 CONDUIT_DIR = /usr/local
 FFTW3_DIR = /usr
 GSL_DIR = /usr
-HDF5_DIR = /usr/lib/x86_64-linux-gnu/hdf5/serial
+HDF5_DIR = /usr/local
 HDF5_ENABLE_CXX = yes
 HDF5_ENABLE_FORTRAN = yes
-HDF5_INC_DIRS = /usr/lib/x86_64-linux-gnu/hdf5/serial/include
-HDF5_LIB_DIRS = /usr/lib/x86_64-linux-gnu/hdf5/serial/lib
-HDF5_LIBS = hdf5_hl_cpp hdf5_cpp hdf5hl_fortran hdf5_fortran hdf5_hl hdf5
+HDF5_INC_DIRS = /usr/local/include
+HDF5_LIB_DIRS = /usr/local/lib
+HDF5_LIBS = hdf5_hl_cpp hdf5_cpp hdf5_hl_fortran hdf5_fortran hdf5_hl_f90cstub hdf5_f90cstub hdf5_hl hdf5
 HWLOC_DIR = /usr
 # JEMALLOC_DIR = /usr/local
 LAPACK_DIR = /usr
 # LIBJPEG_DIR = /usr
 # LORENE_DIR = /usr/local
-MPI_DIR = /usr
+MPI_DIR = /usr/local
+MPI_INC_DIRS = /usr/local/include
+MPI_LIB_DIRS = /usr/local/lib
+MPI_LIBS = mpif mpi_abi
 NSIMD_DIR = /usr/local
 NSIMD_SIMD = AVX2
 OPENBLAS_DIR = /usr
 OPENPMD_API_DIR = /usr/local
 # OPENSSL_DIR = /usr
 # PAPI_DIR = /usr/local
-PETSC_DIR = /usr/lib/petsc
-PETSC_LIBS = petsc_real
+PETSC_DIR = /usr/local
 PETSC_ARCH_LIBS = m
 PTHREADS_DIR = NO_BUILD
 # REPRIMAND_DIR = /usr/local

--- a/scripts/actions-oneapi-real64.cfg
+++ b/scripts/actions-oneapi-real64.cfg
@@ -3,14 +3,44 @@
 # The "weird" options here should probably be made the default in the
 # ET instead of being set here.
 
+# The container this option list targets provides MPI, HDF5 and PETSc through
+# the **MPI ABI** in /usr/local, not through distribution packages: the image
+# builds mpi_abi_wrapper (the C bindings) and mpif (the Fortran ones) over the
+# MPI it wraps, then builds HDF5 and PETSc against those. See the header of the
+# matching `docker/carpetx-*.dockerfile` for the image side, and
+# `simfactory/mdb/optionlists/desert*.cfg` for the same four blocks in the
+# interactive option lists.
+#
+# - MPI_INC_DIRS / MPI_LIB_DIRS / MPI_LIBS are set explicitly so that
+#   ExternalLibraries/MPI takes its *manual* path (detect.pl:84). The automatic
+#   path asks the wrapper for `-compile_info`, which answers with the compile
+#   flags alone -- no `-L`, no `-l` -- so MPI would be configured with an empty
+#   MPI_LIBS and nothing would be linked.
+# - HDF5 is the CMake build, which spells the Fortran libraries `hdf5_fortran` /
+#   `hdf5_hl_fortran` where Debian spelled the latter `hdf5hl_fortran`, and adds
+#   the `*_f90cstub` pair Debian did not have.
+# - PETSc is `libpetsc.so` under one prefix, so PETSC_LIBS is left unset:
+#   detect.sh settles on `petsc m` and the external packages (hypre, MUMPS,
+#   SuperLU_DIST, ...) arrive through libpetsc.so's own DT_NEEDED entries.
+#   `PETSC_LIBS = petsc_real` was Debian's split-package spelling and is gone.
+# - F90FLAGS gains -I/usr/local/include: gfortran does not search it for `.mod`
+#   files the way the preprocessor searches it for headers, and detect.pl strips
+#   the directory out of MPI_INC_DIRS/HDF5_INC_DIRS for being standard.
+
 # Whenever this version string changes, the application is configured
 # and rebuilt from scratch
-VERSION = actions-oneapi-real64-2024-12-23
+VERSION = actions-oneapi-real64-2026-09-07
 
 CPP = cpp
 CC = icx
 CXX = icpx
 FPP = cpp
+# F90 stays gfortran even though this image builds mpif and HDF5's Fortran
+# interface with ifx, because nothing consumes those modules: no .F90/.F in the
+# whole Cactus tree has `use mpi`, `use mpi_f08`, `use hdf5` or includes
+# `mpif.h` (checked). The ifx-built `.mod` files are therefore never read, and
+# the gfortran-specific F90FLAGS below can stay as they are. If a thorn ever
+# does `use hdf5`, this has to become ifx and those flags rewritten with it.
 FC = gfortran
 F90 = gfortran
 LD = icpx -fsycl
@@ -20,7 +50,7 @@ CPPFLAGS = -DSIMD_DISABLE
 CFLAGS = -fp-model=precise -march=x86-64-v3 -pipe -std=gnu11
 CXXFLAGS = -fp-model=precise -fsycl -march=x86-64-v3 -pipe -std=c++17
 FPPFLAGS = -traditional
-F90FLAGS = -fcray-pointer -ffixed-line-length-none -march=x86-64-v3 -pipe
+F90FLAGS = -fcray-pointer -ffixed-line-length-none -march=x86-64-v3 -pipe -I/usr/local/include
 
 LIBDIRS = /usr/local/lib
 LIBS = gfortran
@@ -68,7 +98,7 @@ F90_WARN_FLAGS = -Wall -Wshadow -Wsurprising
 VECTORISE = no
 
 ADIOS2_DIR = /usr/local
-ADIOS2_LIBS = adios2_cxx11_mpi adios2_cxx11 mgard protobuf
+ADIOS2_LIBS = adios2_cxx_mpi adios2_cxx mgard protobuf
 AMREX_DIR = /usr/local
 # ASDF_CXX_DIR = /usr/local
 BLAS_DIR = /usr
@@ -76,26 +106,28 @@ BOOST_DIR = /usr
 CONDUIT_DIR = /usr/local
 FFTW3_DIR = /usr
 GSL_DIR = /usr
-HDF5_DIR = /usr/lib/x86_64-linux-gnu/hdf5/serial
+HDF5_DIR = /usr/local
 HDF5_ENABLE_CXX = yes
 HDF5_ENABLE_FORTRAN = yes
-HDF5_INC_DIRS = /usr/lib/x86_64-linux-gnu/hdf5/serial/include
-HDF5_LIB_DIRS = /usr/lib/x86_64-linux-gnu/hdf5/serial/lib
-HDF5_LIBS = hdf5_hl_cpp hdf5_cpp hdf5hl_fortran hdf5_fortran hdf5_hl hdf5
+HDF5_INC_DIRS = /usr/local/include
+HDF5_LIB_DIRS = /usr/local/lib
+HDF5_LIBS = hdf5_hl_cpp hdf5_cpp hdf5_hl_fortran hdf5_fortran hdf5_hl_f90cstub hdf5_f90cstub hdf5_hl hdf5
 HWLOC_DIR = /usr
 # JEMALLOC_DIR = /usr/local
 LAPACK_DIR = /usr
 # LIBJPEG_DIR = /usr
 # LORENE_DIR = /usr/local
-MPI_DIR = /usr
+MPI_DIR = /usr/local
+MPI_INC_DIRS = /usr/local/include
+MPI_LIB_DIRS = /usr/local/lib
+MPI_LIBS = mpif mpi_abi
 NSIMD_DIR = /usr/local
 NSIMD_SIMD = AVX2
 OPENBLAS_DIR = /usr
 OPENPMD_API_DIR = /usr/local
 # OPENSSL_DIR = /usr
 # PAPI_DIR = /usr/local
-PETSC_DIR = /usr/lib/petsc
-PETSC_LIBS = petsc_real
+PETSC_DIR = /usr/local
 PETSC_ARCH_LIBS = m
 PTHREADS_DIR = NO_BUILD
 # REPRIMAND_DIR = /usr/local

--- a/scripts/actions-oneapi-real64.cfg
+++ b/scripts/actions-oneapi-real64.cfg
@@ -47,8 +47,8 @@ LD = icpx -fsycl
 
 # -g   # Debug information uses too much disk space on CI
 CPPFLAGS = -DSIMD_DISABLE
-CFLAGS = -fp-model=precise -march=x86-64-v3 -pipe -std=gnu11
-CXXFLAGS = -fp-model=precise -fsycl -march=x86-64-v3 -pipe -std=c++17
+CFLAGS = -march=x86-64-v3 -pipe -std=gnu11
+CXXFLAGS = -fsycl -march=x86-64-v3 -pipe -std=c++17
 FPPFLAGS = -traditional
 F90FLAGS = -fcray-pointer -ffixed-line-length-none -march=x86-64-v3 -pipe -I/usr/local/include
 
@@ -75,16 +75,19 @@ F90_DEBUG_FLAGS = -fcheck=bounds,do,mem,pointer,recursion -finit-character=65 -f
 
 OPTIMISE = yes
 # -O3 for SYCL leads to a segfault
-# -ffp-contract=fast is deliberately absent from the C and C++ optimise flags,
-# though it is still on the Fortran ones. CFLAGS/CXXFLAGS set -fp-model=precise,
-# which turns contraction off; -ffp-contract=fast later on the command line
-# overrode it back, so icx emitted
+# The floating-point flags are the same set `actions-cpu-real64.cfg` uses with
+# GCC: fast arithmetic, reassociation permitted, but NaNs and infinities
+# honoured. `-fp-model=precise` used to be on CFLAGS/CXXFLAGS and is gone,
+# because it means the opposite -- it forbids reassociation -- and it was what
+# `-ffp-contract=fast` was overriding, which is why icx printed
 #   warning: overriding '-ffp-model=precise' option with '-ffp-contract=fast'
-# on every single compile -- and the precise model was not actually in effect.
-# Dropping it honours -fp-model=precise and silences the warning. gfortran has
-# no -fp-model, so nothing contradicts it there.
-C_OPTIMISE_FLAGS = -O3 -fexcess-precision=fast -fno-math-errno -fno-rounding-math
-CXX_OPTIMISE_FLAGS = -O2 -fexcess-precision=fast -fno-math-errno -fno-rounding-math
+# on every compile. `-fno-finite-math-only` is added on top of the GNU set: GCC
+# only assumes finite math under -ffast-math, which is not used here, whereas
+# icx's default fp-model is the fast one, so the NaN/Inf guarantee is stated
+# explicitly rather than left to the compiler's default.
+# CXX stays at -O2 rather than -O3, as before, for the SYCL compile.
+C_OPTIMISE_FLAGS = -O3 -fcx-limited-range -fexcess-precision=fast -ffp-contract=fast -fno-math-errno -fno-rounding-math -fno-signaling-nans -fno-finite-math-only
+CXX_OPTIMISE_FLAGS = -O2 -fcx-limited-range -fexcess-precision=fast -ffp-contract=fast -fno-math-errno -fno-rounding-math -fno-signaling-nans -fno-finite-math-only
 F90_OPTIMISE_FLAGS = -O3 -fcx-limited-range -fexcess-precision=fast -ffp-contract=fast -fno-math-errno -fno-rounding-math -fno-signaling-nans
 
 # Clang segfaults with OpenMP enabled

--- a/scripts/actions-oneapi-real64.cfg
+++ b/scripts/actions-oneapi-real64.cfg
@@ -81,13 +81,28 @@ OPTIMISE = yes
 # because it means the opposite -- it forbids reassociation -- and it was what
 # `-ffp-contract=fast` was overriding, which is why icx printed
 #   warning: overriding '-ffp-model=precise' option with '-ffp-contract=fast'
-# on every compile. `-fno-finite-math-only` is added on top of the GNU set: GCC
-# only assumes finite math under -ffast-math, which is not used here, whereas
-# icx's default fp-model is the fast one, so the NaN/Inf guarantee is stated
-# explicitly rather than left to the compiler's default.
+# on every compile.
+#
+# Two deliberate differences from the GCC set, both because icx is not GCC:
+# - `-fno-signaling-nans` is dropped. icx does not implement it and says so --
+#   "optimization flag '-fno-signaling-nans' is not supported" -- once per
+#   compile. Nothing is lost: signalling NaNs are off by default in GCC too,
+#   so the flag was a no-op on both compilers.
+# - `-fno-finite-math-only` is added. GCC only assumes finite math under
+#   -ffast-math, which is not in use, whereas icx defaults to its fast
+#   fp-model, so the NaN/Inf requirement is stated outright rather than left
+#   to whatever that default implies.
+#
+# `-fcx-limited-range` is kept to match GCC and its note suppressed rather than
+# the flag dropped: icx's fast fp-model implies complex range "promoted" and
+# this asks for "basic", so icx reports the override
+# ("-Woverriding-complex-range") on every compile. The override is the point --
+# the GCC set asks for basic complex range -- so the note is noise here.
+# Dropping `-fcx-limited-range` would silence it equally and give more accurate
+# complex division, at the cost of diverging from the GCC option lists.
 # CXX stays at -O2 rather than -O3, as before, for the SYCL compile.
-C_OPTIMISE_FLAGS = -O3 -fcx-limited-range -fexcess-precision=fast -ffp-contract=fast -fno-math-errno -fno-rounding-math -fno-signaling-nans -fno-finite-math-only
-CXX_OPTIMISE_FLAGS = -O2 -fcx-limited-range -fexcess-precision=fast -ffp-contract=fast -fno-math-errno -fno-rounding-math -fno-signaling-nans -fno-finite-math-only
+C_OPTIMISE_FLAGS = -O3 -fcx-limited-range -Wno-overriding-complex-range -fexcess-precision=fast -ffp-contract=fast -fno-math-errno -fno-rounding-math -fno-finite-math-only
+CXX_OPTIMISE_FLAGS = -O2 -fcx-limited-range -Wno-overriding-complex-range -fexcess-precision=fast -ffp-contract=fast -fno-math-errno -fno-rounding-math -fno-finite-math-only
 F90_OPTIMISE_FLAGS = -O3 -fcx-limited-range -fexcess-precision=fast -ffp-contract=fast -fno-math-errno -fno-rounding-math -fno-signaling-nans
 
 # Clang segfaults with OpenMP enabled

--- a/scripts/actions-oneapi-real64.cfg
+++ b/scripts/actions-oneapi-real64.cfg
@@ -75,8 +75,16 @@ F90_DEBUG_FLAGS = -fcheck=bounds,do,mem,pointer,recursion -finit-character=65 -f
 
 OPTIMISE = yes
 # -O3 for SYCL leads to a segfault
-C_OPTIMISE_FLAGS = -O3 -fexcess-precision=fast -ffp-contract=fast -fno-math-errno -fno-rounding-math
-CXX_OPTIMISE_FLAGS = -O2 -fexcess-precision=fast -ffp-contract=fast -fno-math-errno -fno-rounding-math
+# -ffp-contract=fast is deliberately absent from the C and C++ optimise flags,
+# though it is still on the Fortran ones. CFLAGS/CXXFLAGS set -fp-model=precise,
+# which turns contraction off; -ffp-contract=fast later on the command line
+# overrode it back, so icx emitted
+#   warning: overriding '-ffp-model=precise' option with '-ffp-contract=fast'
+# on every single compile -- and the precise model was not actually in effect.
+# Dropping it honours -fp-model=precise and silences the warning. gfortran has
+# no -fp-model, so nothing contradicts it there.
+C_OPTIMISE_FLAGS = -O3 -fexcess-precision=fast -fno-math-errno -fno-rounding-math
+CXX_OPTIMISE_FLAGS = -O2 -fexcess-precision=fast -fno-math-errno -fno-rounding-math
 F90_OPTIMISE_FLAGS = -O3 -fcx-limited-range -fexcess-precision=fast -ffp-contract=fast -fno-math-errno -fno-rounding-math -fno-signaling-nans
 
 # Clang segfaults with OpenMP enabled
@@ -103,6 +111,13 @@ AMREX_DIR = /usr/local
 # ASDF_CXX_DIR = /usr/local
 BLAS_DIR = /usr
 BOOST_DIR = /usr
+# BOOST_LIBS must be set: ExternalLibraries/Boost defaults to
+# "boost_filesystem boost_system" when it is empty (Boost/configure.sh:166),
+# and the image installs libboost-filesystem-dev only, so the link fails with
+# "cannot find -lboost_system". Boost.System has been header-only since Boost
+# 1.69, so naming just filesystem is correct rather than a workaround --
+# `desert-arm64v8.cfg` has always done this.
+BOOST_LIBS = boost_filesystem
 CONDUIT_DIR = /usr/local
 FFTW3_DIR = /usr
 GSL_DIR = /usr

--- a/scripts/actions-rocm-real64.cfg
+++ b/scripts/actions-rocm-real64.cfg
@@ -53,7 +53,26 @@ F90FLAGS = -pipe -g -fcray-pointer -ffixed-line-length-none -I/usr/local/include
 
 SYS_INC_DIRS = /opt/rocm/include /opt/rocm/core-10.0/include
 LIBDIRS = /usr/local/lib /opt/rocm/lib /opt/rocm/core-10.0/lib
-LIBS = amdhip64   dl hwloc ltdl open-pal open-rte udev util   gfortran
+# Only the HIP runtime and the Fortran runtime belong here. Everything else
+# this list used to name was Open MPI's, from when this configuration linked
+# Open MPI directly, and under the MPI ABI nothing may: MPI reaches Cactus
+# through `mpif`/`mpi_abi` (see MPI_LIBS below) and through nothing else.
+#
+#   open-rte   Open MPI's ORTE layer. Gone from Ubuntu 26.04 outright -- Open
+#              MPI 5 replaced ORTE with PRRTE -- so the base image (5.0.10)
+#              ships libopen-pal but no libopen-rte, and the link ended with
+#                ld.lld: error: unable to find library -lopen-rte
+#   open-pal   Open MPI's portability layer. Still present, still wrong to name.
+#   ltdl       what Open MPI 4 dlopened its components with.
+#   udev       pulled in by Open MPI's hwloc.
+#   hwloc      redundant regardless: HWLOC_DIR below puts
+#              ExternalLibraries/hwloc on the case, and it adds -lhwloc itself.
+#   dl, util   merged into libc in glibc 2.34; stubs that resolve and do nothing.
+#
+# `gfortran` stays because LD is amdclang++, which does not add the Fortran
+# runtime by itself. The result matches the cuda and oneapi option lists, which
+# name their GPU runtime and gfortran and nothing more.
+LIBS = amdhip64 gfortran
 
 C_LINE_DIRECTIVES = yes
 F_LINE_DIRECTIVES = yes

--- a/scripts/actions-rocm-real64.cfg
+++ b/scripts/actions-rocm-real64.cfg
@@ -101,6 +101,13 @@ AMREX_DIR = /usr/local
 # ASDF_CXX_DIR = /usr/local
 BLAS_DIR = /usr
 BOOST_DIR = /usr
+# BOOST_LIBS must be set: ExternalLibraries/Boost defaults to
+# "boost_filesystem boost_system" when it is empty (Boost/configure.sh:166),
+# and the image installs libboost-filesystem-dev only, so the link fails with
+# "cannot find -lboost_system". Boost.System has been header-only since Boost
+# 1.69, so naming just filesystem is correct rather than a workaround --
+# `desert-arm64v8.cfg` has always done this.
+BOOST_LIBS = boost_filesystem
 CONDUIT_DIR = /usr/local
 FFTW3_DIR = /usr
 GSL_DIR = /usr

--- a/scripts/actions-rocm-real64.cfg
+++ b/scripts/actions-rocm-real64.cfg
@@ -3,27 +3,56 @@
 # The "weird" options here should probably be made the default in the
 # ET instead of being set here.
 
+# The container this option list targets provides MPI, HDF5 and PETSc through
+# the **MPI ABI** in /usr/local, not through distribution packages: the image
+# builds mpi_abi_wrapper (the C bindings) and mpif (the Fortran ones) over the
+# MPI it wraps, then builds HDF5 and PETSc against those. See the header of the
+# matching `docker/carpetx-*.dockerfile` for the image side, and
+# `simfactory/mdb/optionlists/desert*.cfg` for the same four blocks in the
+# interactive option lists.
+#
+# - MPI_INC_DIRS / MPI_LIB_DIRS / MPI_LIBS are set explicitly so that
+#   ExternalLibraries/MPI takes its *manual* path (detect.pl:84). The automatic
+#   path asks the wrapper for `-compile_info`, which answers with the compile
+#   flags alone -- no `-L`, no `-l` -- so MPI would be configured with an empty
+#   MPI_LIBS and nothing would be linked.
+# - HDF5 is the CMake build, which spells the Fortran libraries `hdf5_fortran` /
+#   `hdf5_hl_fortran` where Debian spelled the latter `hdf5hl_fortran`, and adds
+#   the `*_f90cstub` pair Debian did not have.
+# - PETSc is `libpetsc.so` under one prefix, so PETSC_LIBS is left unset:
+#   detect.sh settles on `petsc m` and the external packages (hypre, MUMPS,
+#   SuperLU_DIST, ...) arrive through libpetsc.so's own DT_NEEDED entries.
+#   `PETSC_LIBS = petsc_real` was Debian's split-package spelling and is gone.
+# - F90FLAGS gains -I/usr/local/include: gfortran does not search it for `.mod`
+#   files the way the preprocessor searches it for headers, and detect.pl strips
+#   the directory out of MPI_INC_DIRS/HDF5_INC_DIRS for being standard.
+
 # Whenever this version string changes, the application is configured
 # and rebuilt from scratch
-VERSION = actions-rocm-real64-2023-04-11
+VERSION = actions-rocm-real64-2026-09-07
 
 CPP = cpp
-CC = /opt/rocm/llvm/bin/clang
-CXX = /opt/rocm/llvm/bin/clang++ -x hip
+# ROCm 10 moved its install prefix to /opt/rocm/core-<version>/ and ships no
+# compatibility symlink, so /opt/rocm/llvm/bin no longer exists -- ROCm's LLVM
+# is now at core-10.0/lib/llvm/bin. `amdclang`/`amdclang++` are named without a
+# path instead: they live in ${ROCM_PATH}/bin, which the base image puts on
+# PATH, so this does not have to be rewritten the next time ROCm moves.
+CC = amdclang
+CXX = amdclang++ -x hip
 FPP = cpp
-#TODO: FC = /opt/rocm/llvm/bin/flang
+#TODO: FC = amdflang
 FC = gfortran
 F90 = gfortran
-LD = /opt/rocm/llvm/bin/clang++
+LD = amdclang++
 
 CPPFLAGS = -DSIMD_DISABLE
 CFLAGS = -pipe -g -std=gnu11
 CXXFLAGS = -pipe -g -std=c++17 --offload-arch=gfx90a
 FPPFLAGS = -traditional
-F90FLAGS = -pipe -g -fcray-pointer -ffixed-line-length-none
+F90FLAGS = -pipe -g -fcray-pointer -ffixed-line-length-none -I/usr/local/include
 
-SYS_INC_DIRS = /opt/rocm/include
-LIBDIRS = /usr/local/lib /opt/rocm/lib
+SYS_INC_DIRS = /opt/rocm/include /opt/rocm/core-10.0/include
+LIBDIRS = /usr/local/lib /opt/rocm/lib /opt/rocm/core-10.0/lib
 LIBS = amdhip64   dl hwloc ltdl open-pal open-rte udev util   gfortran
 
 C_LINE_DIRECTIVES = yes
@@ -67,7 +96,7 @@ F90_WARN_FLAGS = -Wall -Wshadow -Wsurprising
 VECTORISE = no
 
 ADIOS2_DIR = /usr/local
-ADIOS2_LIBS = adios2_cxx11_mpi adios2_cxx11 mgard protobuf
+ADIOS2_LIBS = adios2_cxx_mpi adios2_cxx mgard protobuf
 AMREX_DIR = /usr/local
 # ASDF_CXX_DIR = /usr/local
 BLAS_DIR = /usr
@@ -75,26 +104,28 @@ BOOST_DIR = /usr
 CONDUIT_DIR = /usr/local
 FFTW3_DIR = /usr
 GSL_DIR = /usr
-HDF5_DIR = /usr/lib/x86_64-linux-gnu/hdf5/serial
+HDF5_DIR = /usr/local
 HDF5_ENABLE_CXX = yes
 HDF5_ENABLE_FORTRAN = yes
-HDF5_INC_DIRS = /usr/lib/x86_64-linux-gnu/hdf5/serial/include
-HDF5_LIB_DIRS = /usr/lib/x86_64-linux-gnu/hdf5/serial/lib
-HDF5_LIBS = hdf5_hl_cpp hdf5_cpp hdf5hl_fortran hdf5_fortran hdf5_hl hdf5
+HDF5_INC_DIRS = /usr/local/include
+HDF5_LIB_DIRS = /usr/local/lib
+HDF5_LIBS = hdf5_hl_cpp hdf5_cpp hdf5_hl_fortran hdf5_fortran hdf5_hl_f90cstub hdf5_f90cstub hdf5_hl hdf5
 HWLOC_DIR = /usr
 # JEMALLOC_DIR = /usr/local
 LAPACK_DIR = /usr
 # LIBJPEG_DIR = /usr
 # LORENE_DIR = /usr/local
-MPI_DIR = /usr
+MPI_DIR = /usr/local
+MPI_INC_DIRS = /usr/local/include
+MPI_LIB_DIRS = /usr/local/lib
+MPI_LIBS = mpif mpi_abi
 NSIMD_DIR = /usr/local
 NSIMD_SIMD = AVX2
 OPENBLAS_DIR = /usr
 OPENPMD_API_DIR = /usr/local
 # OPENSSL_DIR = /usr
 # PAPI_DIR = /usr/local
-PETSC_DIR = /usr/lib/petsc
-PETSC_LIBS = petsc_real
+PETSC_DIR = /usr/local
 PETSC_ARCH_LIBS = m
 PTHREADS_DIR = NO_BUILD
 # REPRIMAND_DIR = /usr/local


### PR DESCRIPTION
MPI, HDF5 and PETSc no longer come from distribution packages. Each image now builds mpi_abi_wrapper (the C bindings of the MPI ABI, MPI-5.0 §20.2) and mpif (the Fortran ones) over the MPI it wraps, then builds HDF5 2.2.0 and PETSc 3.25.5 against those, so `libmpi.so.40` appears in nothing an image installs. Which MPI actually runs a binary becomes a run-time choice.

The previous, distribution-package dockerfiles are kept unchanged as `carpetx-native-*.dockerfile`, as backups; the five plain names are now the MPI-ABI images.

Base images move where a newer one exists:

  cpu, arm64v8-cpu  ubuntu:resolute-20260811.1 (26.04)
  cuda              nvcr.io/nvidia/nvhpc:26.5-devel-cuda13.2-ubuntu24.04
  rocm              rocm/dev-ubuntu-26.04:10.0.0-full
  oneapi            intel/oneapi-toolkit:2026.1.0-devel-ubuntu26.04

CUDA and oneAPI wrap a *vendor* MPI rather than Ubuntu's, so `libopenmpi-dev` is gone from both: the HPC SDK's CUDA-aware Open MPI in the first case, Intel MPI in the second. That reverses the old oneAPI policy of deleting Intel MPI outright -- under the ABI there is no reason to throw the vendor MPI away. `libboost-all-dev` becomes `libboost-filesystem-dev` everywhere, because the wide package reaches `libopenmpi-dev` through Boost.MPI and would reinstall a second MPI behind our back; `python3-dev` is named explicitly because it was only ever arriving as a Boost.Python dependency.

Each dockerfile's header carries the reasoning, including the parts that are not obvious: why `ENV MPI_HOME` is needed on top of `-DMPI_C_COMPILER`, why the oneAPI image has to move Intel MPI's `include` directory aside, why ROCm 10's package renames and relocated prefix invalidate the old paths, and why AMReX needs `AMReX_SYCL_SPLIT_KERNEL=OFF` on the current oneAPI toolkit.

The `scripts/actions-*.cfg` option lists follow the images: MPI, HDF5 and PETSc move to /usr/local, `PETSC_LIBS = petsc_real` goes away with Debian's split packaging, HDF5 takes the CMake library spelling, and F90FLAGS gains -I/usr/local/include. ROCm's compilers are named without a path, since ROCm 10 moved /opt/rocm/llvm/bin. ADIOS2 2.12 renamed adios2_cxx11* to adios2_cxx*.

CI temporarily names the `-testing` tags, which is the only way to exercise these images before they are published under the plain ones. That one line is to be reverted before merging.