### PR TITLE
CarpetX: Do not read group_enabled while it is being initialised

### DIFF
--- a/CarpetX/src/io_norm.cxx
+++ b/CarpetX/src/io_norm.cxx
@@ -43,9 +43,9 @@ void OutputNorms(const cGH *restrict cctkGH) {
         }};
     CCTK_TraverseString(out_norm_vars, callback, &enabled, CCTK_GROUP_OR_VAR);
     if (verbose) {
-      CCTK_VINFO("TSV output for groups:");
+      CCTK_VINFO("Norm output for groups:");
       for (int gi = 0; gi < CCTK_NumGroups(); ++gi)
-        if (group_enabled.at(gi))
+        if (enabled.at(gi))
           CCTK_VINFO("  %s", CCTK_FullGroupName(gi));
     }
     return enabled;

--- a/CarpetX/src/io_tsv.cxx
+++ b/CarpetX/src/io_tsv.cxx
@@ -735,7 +735,7 @@ void OutputTSV(const cGH *restrict cctkGH) {
     if (verbose) {
       CCTK_VINFO("TSV output for groups:");
       for (int gi = 0; gi < CCTK_NumGroups(); ++gi)
-        if (group_enabled.at(gi))
+        if (enabled.at(gi))
           CCTK_VINFO("  %s", CCTK_FullGroupName(gi));
     }
     return enabled;


### PR DESCRIPTION
`OutputTSV` and `OutputNorms` both build their `group_enabled` vector from an immediately-invoked lambda, and the verbose branch inside that lambda read `group_enabled` rather than the local `enabled` it is filling. The `[&]` capture makes the name visible inside its own initialiser, so this reads a `std::vector<bool>` whose lifetime has not begun -- undefined behaviour, in practice a garbage size and data pointer, so a spurious std::out_of_range or a segfault rather than merely wrong output.

clang reports it:

  io_tsv.cxx:727:44: warning: variable 'group_enabled' is uninitialized when
  used within its own initialization [-Wuninitialized]

Only the reads inside the two lambdas change; every use after the lambda has returned is correct and is left alone. The mistake is easy to miss because the inner `callback` lambda shadows `enabled` with a reference of its own, so the surrounding code does mention both names legitimately.

It is reachable only under `CarpetX::verbose = yes`, which is why it has gone unnoticed -- but that is exactly the setting recommended for debugging a run.

`OutputNorms` also announced "TSV output for groups:", copied from the TSV writer along with the bug; it now says "Norm output for groups:".